### PR TITLE
Add jaeger and enable tracing by default in Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -354,12 +354,14 @@ docker_build(
 k8s_resource(
     'onms-keycloak',
     new_name='keycloak',
+    labels='keycloak',
     port_forwards=['26080:8080'],
 )
 
 ### Email ###
 k8s_resource(
     'mail-server',
+    labels='z_dependencies',
     port_forwards=['22080:8025'],
 )
 
@@ -370,18 +372,21 @@ docker_build(
 )
 k8s_resource(
     'grafana',
+    labels='z_dependencies',
     port_forwards=['18080:3000'],
 )
 
 ### Cortex ###
 k8s_resource(
     'cortex',
+    labels='z_dependencies',
     port_forwards=['19000:9000'],
 )
 
 ### Postgres ###
 k8s_resource(
     'postgres',
+    labels='z_dependencies',
     port_forwards=['25054:5432'],
 )
 
@@ -389,17 +394,41 @@ k8s_resource(
 k8s_resource(
     'onms-kafka',
     new_name='kafka',
+    labels='z_dependencies',
     port_forwards=['24092:24092'],
 )
 
 ### Prometheus ###
 k8s_resource(
     'prometheus',
+    labels='z_dependencies',
     port_forwards=['32090:9090'],
 )
 
 ### Others ###
 k8s_resource(
     'ingress-nginx-controller',
-    port_forwards=['0.0.0.0:8123:80', '0.0.0.0:1443:443'],
+    labels=['0_useful'],
+    port_forwards=[
+        port_forward(8123, 80),
+        port_forward(1443, 443),
+    ],
+    links=[
+        link("https://onmshs.local:1443/", name="Web UI"),
+    ],
+)
+
+k8s_resource(
+    'opennms-nginx-errors',
+    labels=['opennms-nginx-errors'],
+)
+
+k8s_resource(
+    'ingress-nginx-admission-create',
+    labels=['z_ingress-nginx-support'],
+)
+
+k8s_resource(
+    'ingress-nginx-admission-patch',
+    labels=['z_ingress-nginx-support'],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -38,6 +38,7 @@
 # Tilt config #
 secret_settings(disable_scrub=True)  ## TODO: update secret values so we can reenable scrub
 load('ext://uibutton', 'cmd_button', 'location')
+load('ext://helm_remote', 'helm_remote') # for simple charts like jaeger
 
 cmd_button(name='reload-certificates',
            argv=['sh', '-c', 'find target/tmp/ -type f -exec rm {} \\;'],
@@ -175,6 +176,14 @@ load_certificate_authority("client-root-ca-certificate", "client-ca", "target/tm
 
 
 # Deployment #
+# https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger
+helm_remote('jaeger', version='0.71.0', repo_url='https://jaegertracing.github.io/helm-charts', values="tilt-jaeger-values.yaml")
+k8s_resource(
+    'jaeger',
+    labels=['0_useful'],
+    port_forwards=port_forward(16686, name="Jaeger UI"),
+)
+
 k8s_yaml(
     helm(
         'charts/opennms',

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -226,6 +226,10 @@
             <version>5.12.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/datachoices/src/main/java/org/opennms/horizon/datachoices/service/DataChoicesService.java
+++ b/datachoices/src/main/java/org/opennms/horizon/datachoices/service/DataChoicesService.java
@@ -28,17 +28,20 @@
 
 package org.opennms.horizon.datachoices.service;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.opennms.horizon.datachoices.dto.ToggleDataChoicesDTO;
 import org.opennms.horizon.datachoices.model.DataChoices;
 import org.opennms.horizon.datachoices.repository.DataChoicesRepository;
 import org.springframework.stereotype.Component;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.transaction.Transactional;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
@@ -76,11 +79,13 @@ public class DataChoicesService {
         }
     }
 
+    @WithSpan
     public void execute() {
         List<String> tenantIds = repository.findAll().stream()
             .map(DataChoices::getTenantId).distinct().collect(Collectors.toList());
 
         log.info("tenantIds.size() = " + tenantIds.size());
+        Span.current().setAttribute("tenant_ids_count", tenantIds.size());
 
 //        todo: perform queries and send HTTP request to usage-stats-handler
     }

--- a/install-local/generate-and-sign-certificate.sh
+++ b/install-local/generate-and-sign-certificate.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
 set -euo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+if [ $# -ge 1 ] && [ "$1" == "-f" ]; then
+    force=1
+    shift
+else
+    force=0
+fi
 
 namespace="$1"
 domain="$2"
@@ -17,10 +25,19 @@ fi
 directory=$(dirname $caKeyFile)
 id=$(uuidgen)
 
+# see if the secret already exists
+if [ -n "$(kubectl -n $namespace get --ignore-not-found=true secret "$secret")" ]; then
+  if [ $force -gt 0 ]; then
+    kubectl -n $namespace delete "secrets/$secret"
+  else
+    echo "Secret '$secret' already exists, not adding. Use '-f' option to force recreation." >&2
+    exit 0
+  fi
+fi
+
 openssl req -newkey rsa:2048 -nodes -keyout "$directory/$id.key" -subj "/CN=$domain/O=Test/C=US" -out "$directory/$id.csr"
 openssl x509 -req -extfile <(printf "subjectAltName=DNS:$domain") -days 14 -in  "$directory/$id.csr" \
   -CA $caCrtFile -CAkey $caKeyFile -CAcreateserial -out "$directory/$id.crt" || (echo "Certificate $id signing failed" && exit 1)
-kubectl -n $namespace delete "secrets/$secret" || true
 kubectl -n $namespace create secret tls $secret --cert "$directory/$id.crt" --key "$directory/$id.key"
 
 rm "$directory/$id.crt" "$directory/$id.key" "$directory/$id.csr"

--- a/install-local/load-or-generate-secret.sh
+++ b/install-local/load-or-generate-secret.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
 set -euo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+if [ $# -ge 1 ] && [ "$1" == "-f" ]; then
+    force=1
+    shift
+else
+    force=0
+fi
 
 namespace="$1"
 domain="$2"
@@ -18,7 +26,16 @@ if [ ! -f $keyFile ]; then
   openssl req -new -x509 -days 14 -key $keyFile -subj "/CN=$domain/O=Test/C=US" -out $crtFile
 fi
 
-kubectl -n "$namespace" delete "secrets/$secret" 2>&1 >/dev/null || true
+# see if the secret already exists
+if [ -n "$(kubectl -n "$namespace" get --ignore-not-found=true secret "$secret")" ]; then
+  if [ $force -gt 0 ]; then
+    kubectl -n "$namespace" delete "secrets/$secret"
+  else
+    echo "Secret '$secret' already exists, not adding. Use '-f' option to force recreation." >&2
+    exit 0
+  fi
+fi
+
 # create secret which is tls, by default tls secrets have no "ca.crt" field which is mandatory in case if we wish to use
 # given secret at ingress for mtls. We append ca.crt in a patch call to keep secret as a tls, but also include ca.crt
 kubectl -n "$namespace" create secret tls "$secret" --key=$keyFile \

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -303,6 +303,11 @@
             <version>5.12.1</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/component/MinionHeartbeatConsumer.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/component/MinionHeartbeatConsumer.java
@@ -42,6 +42,7 @@ import org.opennms.cloud.grpc.minion_gateway.MinionIdentity;
 import org.opennms.horizon.grpc.echo.contract.EchoRequest;
 import org.opennms.horizon.grpc.echo.contract.EchoResponse;
 import org.opennms.horizon.grpc.heartbeat.contract.TenantLocationSpecificHeartbeatMessage;
+import org.opennms.horizon.inventory.exception.LocationNotFoundException;
 import org.opennms.horizon.inventory.service.MonitoringLocationService;
 import org.opennms.horizon.inventory.service.MonitoringSystemService;
 import org.opennms.taskset.contract.MonitorResponse;
@@ -117,6 +118,9 @@ public class MinionHeartbeatConsumer {
             }
 
             Span.current().setStatus(StatusCode.OK);
+        } catch (LocationNotFoundException e) {
+            log.error("Location not found while processing heartbeat message: {}", e.getMessage());
+            Span.current().setStatus(StatusCode.ERROR, "Location not found while processing heartbeat message: " + e.getMessage());
         } catch (Exception e) {
             log.error("Error while processing heartbeat message: ", e);
             Span.current().recordException(e);

--- a/minion-certificate-verifier/main/pom.xml
+++ b/minion-certificate-verifier/main/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/minion-gateway/ipc-grpc-server/pom.xml
+++ b/minion-gateway/ipc-grpc-server/pom.xml
@@ -68,6 +68,10 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/grpc/common/LocationServerInterceptor.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/grpc/common/LocationServerInterceptor.java
@@ -28,7 +28,8 @@
 
 package org.opennms.horizon.shared.grpc.common;
 
-import com.swrve.ratelimitedlogger.RateLimitedLog;
+import org.opennms.horizon.shared.constants.GrpcConstants;
+
 import io.grpc.Context;
 import io.grpc.Contexts;
 import io.grpc.Metadata;
@@ -36,11 +37,8 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
-import java.time.Duration;
-import java.util.function.Supplier;
-import lombok.Getter;
+import io.opentelemetry.api.trace.Span;
 import lombok.extern.slf4j.Slf4j;
-import org.opennms.horizon.shared.constants.GrpcConstants;
 
 /**
  * Location resolver which rely on grpc header.
@@ -72,7 +70,12 @@ public class LocationServerInterceptor implements ServerInterceptor {
     }
 
     public String readContextLocation(Context context) {
-        return GrpcConstants.LOCATION_CONTEXT_KEY.get(context);
+        var location = GrpcConstants.LOCATION_CONTEXT_KEY.get(context);
+        var span = Span.current();
+        if (span.isRecording()) {
+            span.setAttribute("location", location);
+        }
+        return location;
     }
 
 

--- a/minion-gateway/main/pom.xml
+++ b/minion-gateway/main/pom.xml
@@ -156,6 +156,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -994,6 +994,11 @@
                 <artifactId>opentelemetry-api</artifactId>
                 <version>${opentelemetry.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-semconv</artifactId>
+                <version>${opentelemetry.version}-alpha</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -995,6 +995,11 @@
                 <version>${opentelemetry.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.opentelemetry.instrumentation</groupId>
+                <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+                <version>${opentelemetry.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-semconv</artifactId>
                 <version>${opentelemetry.version}-alpha</version>

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -14,6 +14,10 @@ Keycloak:
   HostnameAdminUrl: https://localhost:1443/auth
 
 OpenNMS:
+  global:
+    openTelemetry:
+      otlpTracesEndpoint: "http://jaeger-collector:4317"
+
   API:
     Resources:
       Limits:

--- a/tilt-jaeger-values.yaml
+++ b/tilt-jaeger-values.yaml
@@ -1,0 +1,20 @@
+# Use local, in-memory storage.
+# We set a limit on number of traces to store with a command-line arg later.
+provisionDataStore:
+  cassandra: false
+storage:
+  type: none
+
+# Disable individual services
+agent:
+  enabled: false
+collector:
+  enabled: false
+query:
+  enabled: false
+
+# Use the all-in-one service
+allInOne:
+  enabled: true
+  args:
+    - --memory.max-traces=10000


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

I strongly suggest reviewing commit-by-commit. There are two sonar tests that are failing because a few lines of tracing code were added in sections that already had no coverage. I’m hoping to ignore those failures.

The focus of this PR is to add Jaeger to Tilt to make tracing a first-class debugging tool. It also adds a few more
examples of adding some tracing bits to a few services (to prep for making their logs less noise in the future). It also has a few
small improvements.

Future work after this in upcoming PRs:
1. Disable the nginx-ingress in the opennms helm chart and install it as a separate helm chart like we do in our cloud environments. It will use the same version of nginx that we use in the cloud (or maybe newer). It will also enable tracing in the ingress like we have in the cloud, hence why the current PR comes first.
2. Quiet down some common logging that adds a lot of unnecessary noise to the tilt streaming log output. The current PR introduces some targeted tracing improvements as a prerequisite for quieting down the logging later.
3. Further expansion of tracing support for other kafka messages. Grpc should be fairly well covered—in the minion-gateway, at least.

Before going after the other work in later PRs, we should make sure the Minion can properly work in tilt. It isn’t working for me now, even with a clean develop branch. Because of this, I did not include any of the ingress-nginx work in this PR—I wanted to wait and make sure the minion works before and after my changes.

Main focus:
- Add jaeger and enable tracing by default in Tilt

Examples:
- Add span attributes and set status code in certificate verifier
- inventory: add basic span attributes and status handling for minion heartbeat
- minion-gateway: improve root span details for dispatch traces
- minion-gateway: add location as a span attribute when we have it
- minion-gateway: heartbeat kafka forwarder: add message to span
- datachoices: @WithSpan example: add tenant_ids_count attribute to span

Cleanups:
- Remove dev environment flow URLs
- Don't regenerate certificates/secrets if they already exist unless -f is passed
- inventory: quiet: don't spit out stacktrace for LocationNotFoundException
- tilt: label all of the resources, put most important in 0_useful

The tilt change listed last moves two things up to the top of the resources list and adds named links to the proper URLs for the ingress and jaeger:

<img width="1134" alt="image" src="https://github.com/OpenNMS-Cloud/horizon-stream/assets/4461073/98b7a750-7113-4a06-8421-64ab8eee18e4">

It also makes sure that everything else is labeled, and puts most of the less-interacted-with stuff at the bottom:

<img width="1134" alt="image" src="https://github.com/OpenNMS-Cloud/horizon-stream/assets/4461073/58b3134a-83f6-473a-b9ec-98779ddcfdda">

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
