### PR TITLE
HS-1693: Don`t add prefix twice on RocksDB startup

### DIFF
--- a/minion/minion-grpc/grpc-client/src/main/java/org/opennms/horizon/minion/grpc/queue/RocksDbStore.java
+++ b/minion/minion-grpc/grpc-client/src/main/java/org/opennms/horizon/minion/grpc/queue/RocksDbStore.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -85,7 +86,10 @@ public class RocksDbStore implements SwappingSendQueueFactory.StoreManager {
         final var cfDescs = RocksDB.listColumnFamilies(new Options(), path.toString()).stream()
                                    .map(columnFamilyName -> new ColumnFamilyDescriptor(columnFamilyName, CF_OPTIONS))
                                    .collect(Collectors.toList());
-        cfDescs.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+
+        if (cfDescs.stream().noneMatch(desc -> Arrays.equals(desc.getName(), RocksDB.DEFAULT_COLUMN_FAMILY))) {
+            cfDescs.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+        }
 
         final var cfHandles = Lists.<ColumnFamilyHandle>newArrayListWithCapacity(cfDescs.size());
 


### PR DESCRIPTION
RocksDB init requires to add the default namespace to the list of namespaces to open. But this is only required on first startup, as the second one will already have the namespace in the list of existing ones.

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-1693

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
