### PR TITLE
Remove path filtering for develop workflow so status checks pass

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -10,13 +10,6 @@ on:
 # Just use this one for now. The downside is it will run redundant workflows for code that didn't change.
     branches:
       - 'develop'
-    paths-ignore:
-      - '.github/**'
-      - 'CHANGELOG/**'
-      - 'build-tools/**'
-      - 'doc/**'
-      - 'tooling/**'
-      - 'tools/**'
   workflow_call:
     inputs:
       image-tag:


### PR DESCRIPTION
Now that we require status checks to pass for merging to develop, we
were running into required checks that were never running due to path
filtering. I think this should fix it.

> Note: If a workflow is skipped due to path filtering, branch
> filtering or a commit message, then checks associated with that
> workflow will remain in a "Pending" state. A pull request that
> requires those checks to be successful will be blocked from merging.
>
> If a job in a workflow is skipped due to a conditional, it will
> report its status as "Success". For more information see Skipping
> workflow runs and Using conditions to control job execution.

-- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
