### PR TITLE
HS-1685: install-local.sh: use nginx from helm chart instead of built-in

### DIFF
--- a/charts/lokahi/values.yaml
+++ b/charts/lokahi/values.yaml
@@ -390,7 +390,7 @@ TLS:
   CertificateGeneration: false
 
 Ingress:
-  Enabled: true
+  Enabled: false
   DefaultEndpointsEnabled: true
   HttpPort: 80
   HttpsPort: 443

--- a/install-local/install-local.sh
+++ b/install-local/install-local.sh
@@ -254,7 +254,6 @@ if [ $CONTEXT == "local" ]; then
   echo
   install_nginx
   time helm upgrade -i lokahi ./../charts/lokahi -f ./tmp/install-local-opennms-lokahi-values.yaml --namespace $NAMESPACE --wait --timeout "${TIMEOUT}"
-  if [ $? -ne 0 ]; then exit; fi
 
   cluster_ready_check
 
@@ -278,8 +277,6 @@ elif [ "$CONTEXT" == "custom-images" ]; then
 
   install_helm_chart_custom_images
 
-  if [ $? -ne 0 ]; then exit; fi
-
   cluster_ready_check
 
 elif [ "$CONTEXT" == "cicd" ]; then
@@ -295,8 +292,6 @@ elif [ "$CONTEXT" == "cicd" ]; then
   # output values from the release to help with debugging pipelines
   helm get values lokahi --namespace $NAMESPACE
 
-  if [ $? -ne 0 ]; then exit; fi
-
   cluster_ready_check
 
 elif [ $CONTEXT == "existing-k8s" ]; then
@@ -306,7 +301,6 @@ elif [ $CONTEXT == "existing-k8s" ]; then
   echo
   install_nginx
   time helm upgrade -i lokahi ./../charts/lokahi -f ./tmp/install-local-opennms-lokahi-values.yaml --namespace $NAMESPACE --create-namespace --wait --timeout "${TIMEOUT}"
-  if [ $? -ne 0 ]; then exit; fi
 
   cluster_ready_check
 

--- a/install-local/install-local.sh
+++ b/install-local/install-local.sh
@@ -181,8 +181,17 @@ create_namespace () {
 }
 
 install_nginx () {
-  helm repo add -n $NAMESPACE ingress-nginx-repo https://kubernetes.github.io/ingress-nginx
-  helm upgrade -i ingress-nginx ingress-nginx-repo/ingress-nginx --version=4.7.0 --values=../tilt-ingress-nginx-values.yaml --namespace $NAMESPACE --wait --timeout "${TIMEOUT}"
+  # The controller.service.type=ClusterIP is because kind doesn't provide a LoadBalancer by default.
+  # https://github.com/fluxcd/flux2/issues/2476#issuecomment-1051275654
+  # https://github.com/kubernetes-sigs/kind/issues/2889#issuecomment-1321223613
+  helm upgrade --install ingress-nginx ingress-nginx \
+    --repo https://kubernetes.github.io/ingress-nginx \
+    --version 4.7.0 \
+    --namespace $NAMESPACE \
+    --set controller.service.type=ClusterIP \
+    --set controller.hostPort.enabled=true \
+    --values=../tilt-ingress-nginx-values.yaml \
+    --wait --timeout "${TIMEOUT}"
 }
 
 install_helm_chart_custom_images () {

--- a/install-local/install-local.sh
+++ b/install-local/install-local.sh
@@ -180,11 +180,17 @@ create_namespace () {
   kubectl create namespace $NAMESPACE
 }
 
+install_nginx () {
+  helm repo add -n $NAMESPACE ingress-nginx-repo https://kubernetes.github.io/ingress-nginx
+  helm upgrade -i ingress-nginx ingress-nginx-repo/ingress-nginx --version=4.7.0 --values=../tilt-ingress-nginx-values.yaml --namespace $NAMESPACE --wait --timeout "${TIMEOUT}"
+}
+
 install_helm_chart_custom_images () {
   echo
   echo ________________Installing Lokahi________________
   echo
 
+  install_nginx
   if ! time helm upgrade -i lokahi ./../charts/lokahi \
   -f ./tmp/install-local-opennms-lokahi-custom-images-values.yaml \
   --namespace $NAMESPACE \
@@ -246,6 +252,7 @@ if [ $CONTEXT == "local" ]; then
   echo
   echo ________________Installing Lokahi________________
   echo
+  install_nginx
   time helm upgrade -i lokahi ./../charts/lokahi -f ./tmp/install-local-opennms-lokahi-values.yaml --namespace $NAMESPACE --wait --timeout "${TIMEOUT}"
   if [ $? -ne 0 ]; then exit; fi
 
@@ -297,6 +304,7 @@ elif [ $CONTEXT == "existing-k8s" ]; then
   echo
   echo ________________Installing Lokahi________________
   echo
+  install_nginx
   time helm upgrade -i lokahi ./../charts/lokahi -f ./tmp/install-local-opennms-lokahi-values.yaml --namespace $NAMESPACE --create-namespace --wait --timeout "${TIMEOUT}"
   if [ $? -ne 0 ]; then exit; fi
 

--- a/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/KeycloakTestSteps.java
+++ b/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/KeycloakTestSteps.java
@@ -113,8 +113,12 @@ public class KeycloakTestSteps {
                 .build()
         ;
 
-        AccessTokenResponse accessTokenResponse = keycloakClient.tokenManager().getAccessToken();
-        keycloakAccessToken = accessTokenResponse.getToken();
+        try {
+            AccessTokenResponse accessTokenResponse = keycloakClient.tokenManager().getAccessToken();
+            keycloakAccessToken = accessTokenResponse.getToken();
+        } finally {
+            keycloakClient.close();
+        }
 
         assertNotNull(keycloakAccessToken);
 

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -13,9 +13,6 @@ Keycloak:
   HostnamePort: 1443
   HostnameAdminUrl: https://onmshs.local:1443/auth
 
-Ingress:
-  Enabled: false
-
 MailServer:
   Enabled: true
 


### PR DESCRIPTION
- [x] Wait for #1190 to be merged
- [x] Wait for #1185 to be merged

- Add a new GitHub workflow to test 'tilt ci'
- external-it job: Pull namespace into an env variable
- Fix URL in pull request template: Jira is now in Atlassian Cloud
- Move ingress-nginx to Helm chart and version match dev environment
- Upgrade ingress-nginx to controller 1.8.0, Helm chart 4.7.0
- Increase nginx error log level to info so we see SSL handshake errors
- opennms-minion-gateway ingress: Add missing ingressClassName
- Disable built-in ingress, assume it is provided externally
- Improve failure messaging with 'set -e'
- XXX temp: add --debug

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
