### PR TITLE
Tilt: fix adding test location to database

### DIFF
--- a/build-tools/basic/helm-values.yaml
+++ b/build-tools/basic/helm-values.yaml
@@ -49,18 +49,6 @@ OpenNMS:
       Requests:
         Cpu: '0'
         Memory: '0'
-    IngressAnnotations:
-      cert-manager.io/cluster-issuer: opennms-ca
-      nginx.ingress.kubernetes.io/auth-tls-secret: default/client-root-ca-certificate
-      nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
-      nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
-      nginx.ingress.kubernetes.io/auth-url: "http://opennms-minion-certificate-verifier.default.svc.cluster.local:8080/certificate/debug"
-      nginx.ingress.kubernetes.io/auth-response-headers: "tenant-id, location"
-      nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "false"
-      nginx.ingress.kubernetes.io/server-snippet: |
-        grpc_read_timeout "1200s";
-        grpc_send_timeout "1200s";
-        client_body_timeout "1200s";
   MinionCertificateManager:
     Enabled: true
     CaSecretName: root-ca-certificate

--- a/charts/lokahi/templates/postgres/postgres-init-secret.yaml
+++ b/charts/lokahi/templates/postgres/postgres-init-secret.yaml
@@ -40,9 +40,5 @@ stringData:
     CREATE USER minion_gateway with password '{{ .Values.Postgres.MinionGatewayPassword }}';
     CREATE SCHEMA IF NOT EXISTS minion_gateway AUTHORIZATION minion_gateway;
 
-    {{- if .Values.Postgres.addTestLocation }}
-    INSERT INTO monitoring_location (tenant_id, location, latitude, longitude) values ('opennms-prime', 'TestLocation', 0, 0);
-    {{- end }}
-
 type: Opaque
 {{- end }}

--- a/install-local/install-local.sh
+++ b/install-local/install-local.sh
@@ -105,7 +105,7 @@ pull_docker_images () {
 		"${IMAGE_PREFIX}/lokahi-minion-certificate-manager:${IMAGE_TAG}" \
 		"${IMAGE_PREFIX}/lokahi-minion-certificate-verifier:${IMAGE_TAG}" \
 		"${IMAGE_PREFIX}/lokahi-minion:${IMAGE_TAG}" \
-		"${IMAGE_PREFIX}/lokahi-minion:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/lokahi-minion-gateway:${IMAGE_TAG}" \
 		"${IMAGE_PREFIX}/lokahi-notification:${IMAGE_TAG}" \
 		"${IMAGE_PREFIX}/lokahi-rest-server:${IMAGE_TAG}" \
 		"${IMAGE_PREFIX}/lokahi-ui:${IMAGE_TAG}"

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
@@ -75,6 +75,8 @@ import com.google.protobuf.Message;
 
 import io.grpc.BindableService;
 import io.grpc.Context;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -323,7 +325,12 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
 
             @Override
             public void onError(Throwable throwable) {
-                LOG.error("Error in sink streaming", throwable);
+                if (throwable instanceof StatusRuntimeException statusRuntimeException
+                    && statusRuntimeException.getStatus().getCode() == Status.Code.CANCELLED) {
+                    LOG.warn("Got status code CANCELLED in sink streaming");
+                } else {
+                    LOG.error("Error in sink streaming", throwable);
+                }
             }
 
             @Override

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -78,7 +78,7 @@ OpenNMS:
           - -c
           - |
             set -euo pipefail
-            trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+            trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; if [ -f /tmp/curl-headers.txt ]; then grep server-timing: /tmp/curl-headers.txt; fi; exit $s' ERR
 
             url="https://onmshs.local:1443"
             set -- --connect-to onmshs.local:1443:ingress-nginx-controller.default.svc.cluster.local:443
@@ -87,6 +87,7 @@ OpenNMS:
             graphql="${url}/"
 
             token=$(curl "$@" -sSf -k -X POST -H "Content-Type\\: application/x-www-form-urlencoded" \
+              --dump-header /tmp/curl-headers.txt \
               -d 'username=admin' \
               -d 'password=admin' \
               -d 'grant_type=password' \
@@ -98,6 +99,7 @@ OpenNMS:
             query="{\"query\": \"query { searchLocation(searchTerm: \\\"LOC_NAME\\\") { id, location } }\"}"
             query=${query/LOC_NAME/$locationName}
             result=$(curl "$@" -sSf -k -H "Content-Type: application/json" \
+              --dump-header /tmp/curl-headers.txt \
               -H "Authorization: Bearer $token" \
               --data "${query}" \
               "${graphql}api/graphql")
@@ -115,6 +117,7 @@ OpenNMS:
               query="{\"query\": \"mutation { createLocation(location: {location: \\\"LOC_NAME\\\"}) { id, location } }\"}"
               query=${query/LOC_NAME/$locationName}
               result=$(curl "$@" -sSf -k -H "Content-Type: application/json" \
+                --dump-header /tmp/curl-headers.txt \
                 -H "Authorization: Bearer $token" \
                 --data "${query}" \
                 "${graphql}api/graphql")

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -13,9 +13,6 @@ Keycloak:
   HostnamePort: 1443
   HostnameAdminUrl: https://onmshs.local:1443/auth
 
-Postgres:
-  addTestLocation: True
-
 Ingress:
   Enabled: false
 
@@ -73,18 +70,70 @@ OpenNMS:
       # into minion. Please do not use this in production.
       # Remarks - working directory for this container is /cert which is emptyDir. This empty dir is later mounted
       # into minion container itself under /opt/karaf/certs/.
-      - image: finalgene/openssh@sha256:5b8073b8720ddb204c48a79e68e2a9f8c470404d475640280eb5df2d6a843eca
+      - image: opennms/deploy-base:ubuntu-3.0.1.b223-jre-11
         imagePullPolicy: "IfNotPresent"
         name: cert-generator
         command:
           - /bin/bash
           - -c
           - |
+            set -euo pipefail
+            trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+            url="https://onmshs.local:1443"
+            set -- --connect-to onmshs.local:1443:ingress-nginx-controller.default.svc.cluster.local:443
+
+            keycloak="${url}/auth/"
+            graphql="${url}/"
+
+            token=$(curl "$@" -sSf -k -X POST -H "Content-Type\\: application/x-www-form-urlencoded" \
+              -d 'username=admin' \
+              -d 'password=admin' \
+              -d 'grant_type=password' \
+              -d 'scope=openid' \
+              -d 'client_id=lokahi' \
+              "${keycloak}realms/opennms/protocol/openid-connect/token" | cut -d "\"" -f 4)
+
+            locationName="TestLocation"
+            query="{\"query\": \"query { searchLocation(searchTerm: \\\"LOC_NAME\\\") { id, location } }\"}"
+            query=${query/LOC_NAME/$locationName}
+            result=$(curl "$@" -sSf -k -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $token" \
+              --data "${query}" \
+              "${graphql}api/graphql")
+
+            if grep -q '^{"errors":' <<< "$result"; then
+              echo "error getting location: $result" >&2
+              exit 1
+            fi
+
+            locationId=$(echo "$result" | cut -d ":" -f 4|cut -d , -f 1)
+
+            if [ -n "${locationId}" ]; then
+              echo "Found existing location ID ${locationId} for '${locationName}'"
+            else # if it doesn't exist, create it
+              query="{\"query\": \"mutation { createLocation(location: {location: \\\"LOC_NAME\\\"}) { id, location } }\"}"
+              query=${query/LOC_NAME/$locationName}
+              result=$(curl "$@" -sSf -k -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $token" \
+                --data "${query}" \
+                "${graphql}api/graphql")
+
+              if grep -q '^{"errors":' <<< "$result"; then
+                echo "error getting location: $result" >&2
+                exit 1
+              fi
+
+              locationId=$(echo "$result" | cut -d ":" -f 4|cut -d , -f 1)
+              echo "Created new location ID ${locationId} for '${locationName}'"
+            fi
+
             openssl genrsa -out /cert/client.key.pkcs1 2048
             openssl pkcs8 -topk8 -in /cert/client.key.pkcs1 -out /cert/client.key -nocrypt
-            openssl req -new -key /cert/client.key -out /cert/client.unsigned.cert -subj "/C=CA/ST=TBD/L=TBD/O=OpenNMS/CN=local-minion/OU=L:1/OU=T:opennms-prime"
+            openssl req -new -key /cert/client.key -out /cert/client.unsigned.cert -subj "/C=CA/ST=TBD/L=TBD/O=OpenNMS/CN=local-minion/OU=L:${locationId}/OU=T:opennms-prime"
             openssl x509 -req -in /cert/client.unsigned.cert -days 14 -CA /run/secrets/mtls/tls.crt -CAkey /run/secrets/mtls/tls.key -out /cert/client.signed.cert
             openssl pkcs12 -export -out "/cert/minion.p12" -inkey /cert/client.key -in /cert/client.signed.cert -passout "pass:changeme"
+
         securityContext:
           privileged: false
           runAsUser: 10001

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -166,16 +166,6 @@ OpenNMS:
     env:
       OTEL_JAVAAGENT_ENABLED: "true" # Enable for local development since it adds useful data
     IngressAnnotations:
-      nginx.ingress.kubernetes.io/auth-tls-secret: default/client-root-ca-certificate
-      nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
-      nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
-      nginx.ingress.kubernetes.io/auth-url: "http://opennms-minion-certificate-verifier.default.svc.cluster.local:8080/certificate/debug"
-      nginx.ingress.kubernetes.io/auth-response-headers: "tenant-id, location"
-      nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "false"
-      nginx.ingress.kubernetes.io/server-snippet: |
-        grpc_read_timeout "1200s";
-        grpc_send_timeout "1200s";
-        client_body_timeout "1200s";
       nginx.ingress.kubernetes.io/configuration-snippet: |
         # This adds the tenant-id and location to the response headers sent to the client so we can use them in
         # logging. This is bit circuitous, and it is unnecessary to send these to the client, but this was a way I

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -176,6 +176,9 @@ OpenNMS:
         grpc_read_timeout "1200s";
         grpc_send_timeout "1200s";
         client_body_timeout "1200s";
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        set $dummy_val "$opentelemetry_context_traceparent"; # workaround for https://github.com/kubernetes/ingress-nginx/issues/9811
+        grpc_set_header 'traceparent' $opentelemetry_context_traceparent; # This doesn't get sent downstream normally. :(
   MinionCertificateManager:
     Enabled: true
     CaSecretName: root-ca-certificate

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -177,6 +177,18 @@ OpenNMS:
         grpc_send_timeout "1200s";
         client_body_timeout "1200s";
       nginx.ingress.kubernetes.io/configuration-snippet: |
+        # This adds the tenant-id and location to the response headers sent to the client so we can use them in
+        # logging. This is bit circuitous, and it is unnecessary to send these to the client, but this was a way I
+        # could figure out how to get the tenant and minion information in the logs using $sent_http_x_tenant_id
+        # and $sent_http_x_location once these response headers are added. They also seem to need to be in the
+        # location block to work.
+        # Note: The response headers are prefixed with "x-", although the headers from the auth service are not.
+        # Note: I am being a little naughty and depending an internal implementation detail of ingress-nginx by
+        # using the authHeader* variables. These are created by ingress-nginx from the auth-response-headers
+        # annotation. The naming of the authHeader* variables is sensitive to the order of the headers in the
+        # nginx.ingress.kubernetes.io/auth-response-headers annotation.
+        add_header x-tenant-id "$authHeader0" always;
+        add_header x-location "$authHeader1" always;
         set $dummy_val "$opentelemetry_context_traceparent"; # workaround for https://github.com/kubernetes/ingress-nginx/issues/9811
         grpc_set_header 'traceparent' $opentelemetry_context_traceparent; # This doesn't get sent downstream normally. :(
   MinionCertificateManager:

--- a/tilt-ingress-nginx-values.yaml
+++ b/tilt-ingress-nginx-values.yaml
@@ -1,4 +1,6 @@
 controller:
+  podAnnotations:
+    kubectl.kubernetes.io/default-container: controller # needs to be the same as controller.containerName
   opentelemetry:
     enabled: true
   config:

--- a/tilt-ingress-nginx-values.yaml
+++ b/tilt-ingress-nginx-values.yaml
@@ -6,7 +6,7 @@ controller:
   config:
     enable-access-log-for-default-backend: true
     error-log-level: info
-    log-format-upstream: $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $opentelemetry_trace_id
+    log-format-upstream: $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $opentelemetry_trace_id $sent_http_x_tenant_id $sent_http_x_location $upstream_http_grpc_status $upstream_trailer_grpc_status
     enable-opentelemetry: true
     otlp-collector-host: jaeger-collector
     opentelemetry-operation-name: HTTP $request_method $service_name $location_path

--- a/tilt-ingress-nginx-values.yaml
+++ b/tilt-ingress-nginx-values.yaml
@@ -20,7 +20,7 @@ controller:
     location-snippet: |
       # This appears to need to be a location snippet to work, although it should supposedly work in the http context.
       # http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
-      add_header Server-Timing "traceparent;desc=\"$opentelemetry_context_traceparent\"";
+      add_header Server-Timing "traceparent;desc=\"$opentelemetry_context_traceparent\"" always;
 
 # opentelemetry config options in this configmap:
 #   https://kubernetes.github.io/ingress-nginx/user-guide/third-party-addons/opentelemetry/


### PR DESCRIPTION
This is best reviewed commit-by-commit because there's one main change, plus a number of things cleaned-up/improved along the way. This is one ancillary change that I wanted to highlight which is bolded.

The main change: [Tilt: fix adding test location to database](https://github.com/OpenNMS-Cloud/lokahi/pull/1211/commits/bc38390cc4b8bd07c366f1f4d58533144f2746d8) 

Follow the pattern in tests/minion-cert.sh for adding a location
(it it doesn't already exist) in the initContainer for the minion
that sets up certificates.

Added error checking so the init container won't successfully
finish until the location exists and the certificate is created.
In my experience, it takes 2-3 passes until everything is up, but
it does eventually complete.

Ancillary changes:
* Always return server-timing header, even when there are errors 
* Add default-container annotation for ingress-nginx controller pod
* Tilt: minion initContainer: display traceparent if there's an error w… 
* OpenTelemetry workarounds for gRPC and auth service propagation
* **======= LOOK AT THIS ONE: [Tilt: add tenant-id, location, and gRPC status to ingress-nginx access logs](https://github.com/OpenNMS-Cloud/lokahi/pull/1211/commits/09be0125bfeb2ec3a00d6cde1828d10c72676558) =======**
* Remove duplicate ingress annotations
* minion-gateway sink streaming: Reduce exception noise when the client… 
* install-local.sh: fix name of lokahi-minion-gateway image in pull_doc… 

Here is an example with the logging change in Tilt (which will be expanded later if this works well):
```
$ kubectl logs ingress-nginx-controller-5d5ccb976-96hrk| grep TestLocation
10.244.0.59 - - [12/Jun/2023:02:10:37 +0000] "POST /minion.CloudService/MinionToCloudRPC HTTP/2.0" 200 2689 "-" "grpc-java-okhttp/1.54.1" 323 0.968 [default-opennms-minion-gateway-8990] [] 10.244.0.56:8990 2722 0.146 200 da99bab43b128a3d09c12cc15921bcf1 opennms-prime TestLocation - 0
```
- tenant-id: `opennms-prime`
- location: `TestLocation`
- GRPC status codes: `- 0`

Here is the trace for that same transaction, showing the details of the certificate verification (this was made possible with both the workaround for passing the trace context to the auth subrequest and for passing the trace context downstream in gRPC requests from nginx):
<img width="1540" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/4461073/b4675b6b-131a-4637-a8a8-742d1a91c47a">


## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
