### PR TITLE
HS-1202: Fix gql service to handle invalid args error messages

### DIFF
--- a/ui/src/services/gqlService.ts
+++ b/ui/src/services/gqlService.ts
@@ -25,6 +25,10 @@ const errorNotificationPlugin = definePlugin(({ afterQuery }) => {
 
     const errorsMsgs = [
       {
+        err: 'INVALID_ARGUMENT:',
+        msg: error.message.split('INVALID_ARGUMENT:')[1]
+      },
+      {
         err: 'INTERNAL:',
         msg: error.message.split('INTERNAL:')[1]
       },


### PR DESCRIPTION
## Description
Validation messages for invalid args come from the BE, but were showing on the UI as unknown errors. This fixes the gqlService to properly display invalid args messages across the app. Additional validation for specific inputs on the Minions page is not for EAR, and this page will soon be removed.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1202


## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
