### PR TITLE
HS-1740: Force isDark to always be false

### DIFF
--- a/ui/src/composables/useTheme.ts
+++ b/ui/src/composables/useTheme.ts
@@ -19,7 +19,7 @@ const useTheme = () => {
     }
   })
 
-  return { isDark, toggleDark, onThemeChange }
+  return { isDark: ref(false), toggleDark, onThemeChange }
 }
 
 export default useTheme


### PR DESCRIPTION
## Description
Dark theme was disabled but custom overrides using isDark still work. This sets isDark to always be false.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1740

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
