### PR TITLE
HS-1776: Rename TriggerEvent to AlertCondition in APIs and UI 

### DIFF
--- a/alert/src/main/java/org/opennms/horizon/alertservice/mapper/AlertConditionMapper.java
+++ b/alert/src/main/java/org/opennms/horizon/alertservice/mapper/AlertConditionMapper.java
@@ -32,20 +32,16 @@ import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.NullValueCheckStrategy;
+import org.opennms.horizon.alerts.proto.AlertConditionProto;
 import org.opennms.horizon.alertservice.db.entity.AlertCondition;
-import org.opennms.horizon.alerts.proto.TriggerEventProto;
 
 @Mapper(componentModel = "spring")
 public interface AlertConditionMapper {
 
-    @Mapping(source = "triggerEvent", target = "triggerEventType")
-    @Mapping(source = "clearEvent", target = "clearEventType")
     @Mapping(target = "rule", ignore = true)
     @Mapping(target = "alertDefinition", ignore = true)
-    AlertCondition protoToEntity(TriggerEventProto proto);
+    AlertCondition protoToEntity(AlertConditionProto proto);
 
     @BeanMapping(nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
-    @Mapping(source = "triggerEventType", target = "triggerEvent")
-    @Mapping(source = "clearEventType", target = "clearEvent")
-    TriggerEventProto entityToProto(AlertCondition event);
+    AlertConditionProto entityToProto(AlertCondition event);
 }

--- a/alert/src/main/java/org/opennms/horizon/alertservice/service/MonitorPolicyService.java
+++ b/alert/src/main/java/org/opennms/horizon/alertservice/service/MonitorPolicyService.java
@@ -36,7 +36,7 @@ import org.opennms.horizon.alerts.proto.ManagedObjectType;
 import org.opennms.horizon.alerts.proto.MonitorPolicyProto;
 import org.opennms.horizon.alerts.proto.PolicyRuleProto;
 import org.opennms.horizon.alerts.proto.Severity;
-import org.opennms.horizon.alerts.proto.TriggerEventProto;
+import org.opennms.horizon.alerts.proto.AlertConditionProto;
 import org.opennms.horizon.alertservice.db.entity.AlertDefinition;
 import org.opennms.horizon.alertservice.db.entity.MonitorPolicy;
 import org.opennms.horizon.alertservice.db.entity.Tag;
@@ -75,13 +75,13 @@ public class MonitorPolicyService {
     @EventListener(ApplicationReadyEvent.class)
     public void defaultPolicies() {
         if(repository.findAllByTenantId(SYSTEM_TENANT).isEmpty()) {
-            TriggerEventProto coldReboot = TriggerEventProto.newBuilder()
-                .setTriggerEvent(EventType.SNMP_Cold_Start)
+            AlertConditionProto coldReboot = AlertConditionProto.newBuilder()
+                .setTriggerEventType(EventType.SNMP_Cold_Start)
                 .setCount(1)
                 .setSeverity(Severity.CRITICAL)
                 .build();
-            TriggerEventProto warmReboot = TriggerEventProto.newBuilder()
-                .setTriggerEvent(EventType.SNMP_Warm_Start)
+            AlertConditionProto warmReboot = AlertConditionProto.newBuilder()
+                .setTriggerEventType(EventType.SNMP_Warm_Start)
                 .setCount(1)
                 .setSeverity(Severity.MAJOR)
                 .build();

--- a/alert/src/test/java/org/opennms/horizon/alertservice/repository/MonitoringPolicyRepositoryTest.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/repository/MonitoringPolicyRepositoryTest.java
@@ -37,7 +37,7 @@ import org.opennms.horizon.alerts.proto.ManagedObjectType;
 import org.opennms.horizon.alerts.proto.MonitorPolicyProto;
 import org.opennms.horizon.alerts.proto.PolicyRuleProto;
 import org.opennms.horizon.alerts.proto.Severity;
-import org.opennms.horizon.alerts.proto.TriggerEventProto;
+import org.opennms.horizon.alerts.proto.AlertConditionProto;
 import org.opennms.horizon.alertservice.db.entity.MonitorPolicy;
 import org.opennms.horizon.alertservice.db.repository.MonitorPolicyRepository;
 import org.opennms.horizon.alertservice.db.repository.TagRepository;
@@ -137,13 +137,13 @@ public class MonitoringPolicyRepositoryTest {
     }
 
     MonitorPolicy createNewPolicy(MonitorPolicyMapper monitorPolicyMapper) {
-        TriggerEventProto coldReboot = TriggerEventProto.newBuilder()
-            .setTriggerEvent(EventType.SNMP_Cold_Start)
+        AlertConditionProto coldReboot = AlertConditionProto.newBuilder()
+            .setTriggerEventType(EventType.SNMP_Cold_Start)
             .setCount(1)
             .setSeverity(Severity.CRITICAL)
             .build();
-        TriggerEventProto warmReboot = TriggerEventProto.newBuilder()
-            .setTriggerEvent(EventType.SNMP_Warm_Start)
+        AlertConditionProto warmReboot = AlertConditionProto.newBuilder()
+            .setTriggerEventType(EventType.SNMP_Warm_Start)
             .setCount(1)
             .setSeverity(Severity.MAJOR)
             .build();

--- a/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/MonitorPolicySteps.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/MonitorPolicySteps.java
@@ -135,9 +135,9 @@ public class MonitorPolicySteps {
                 .setOvertime(Integer.parseInt(map.get("overtime")))
                 .setOvertimeUnit(OverTimeUnit.valueOf(map.get("overtime_unit").toUpperCase()))
                 .setSeverity(Severity.valueOf(map.get("severity").toUpperCase()));
-            String clearEvent = map.get("clear_event_type");
-            if(StringUtils.isNotBlank(clearEvent)) {
-                eventBuilder.setClearEventType(EventType.valueOf(clearEvent));
+            String clearEventType = map.get("clear_event_type");
+            if(StringUtils.isNotBlank(clearEventType)) {
+                eventBuilder.setClearEventType(EventType.valueOf(clearEventType));
             }
             eventType = eventBuilder.getTriggerEventType();
             triggerBuilders.add(eventBuilder);

--- a/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/MonitorPolicySteps.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/MonitorPolicySteps.java
@@ -47,7 +47,7 @@ import org.opennms.horizon.alerts.proto.MonitorPolicyProto;
 import org.opennms.horizon.alerts.proto.OverTimeUnit;
 import org.opennms.horizon.alerts.proto.PolicyRuleProto;
 import org.opennms.horizon.alerts.proto.Severity;
-import org.opennms.horizon.alerts.proto.TriggerEventProto;
+import org.opennms.horizon.alerts.proto.AlertConditionProto;
 import org.opennms.horizon.alertservice.AlertGrpcClientUtils;
 import org.opennms.horizon.alertservice.kafkahelper.KafkaTestHelper;
 import org.opennms.horizon.shared.common.tag.proto.Operation;
@@ -74,7 +74,7 @@ public class MonitorPolicySteps {
     private final AlertGrpcClientUtils grpcClient;
     private MonitorPolicyProto.Builder policyBuilder = MonitorPolicyProto.newBuilder();
     private PolicyRuleProto.Builder ruleBuilder = PolicyRuleProto.newBuilder();
-    private List<TriggerEventProto.Builder> triggerBuilders = new ArrayList<>();
+    private List<AlertConditionProto.Builder> triggerBuilders = new ArrayList<>();
     private Long policyId;
     private String tenantId;
     private String tagTopic;
@@ -130,16 +130,16 @@ public class MonitorPolicySteps {
     public void alertConditionData(DataTable data) {
         List<Map<String, String>> mapList = data.asMaps();
         mapList.forEach(map -> {
-            TriggerEventProto.Builder eventBuilder = TriggerEventProto.newBuilder().setTriggerEvent(EventType.valueOf(map.get("trigger_event_type")))
+            AlertConditionProto.Builder eventBuilder = AlertConditionProto.newBuilder().setTriggerEventType(EventType.valueOf(map.get("trigger_event_type")))
                 .setCount(Integer.parseInt(map.get("count")))
                 .setOvertime(Integer.parseInt(map.get("overtime")))
                 .setOvertimeUnit(OverTimeUnit.valueOf(map.get("overtime_unit").toUpperCase()))
                 .setSeverity(Severity.valueOf(map.get("severity").toUpperCase()));
             String clearEvent = map.get("clear_event_type");
             if(StringUtils.isNotBlank(clearEvent)) {
-                eventBuilder.setClearEvent(EventType.valueOf(clearEvent));
+                eventBuilder.setClearEventType(EventType.valueOf(clearEvent));
             }
-            eventType = eventBuilder.getTriggerEvent();
+            eventType = eventBuilder.getTriggerEventType();
             triggerBuilders.add(eventBuilder);
         });
     }
@@ -156,7 +156,7 @@ public class MonitorPolicySteps {
 
     @Then("Verify the new policy has been created")
     public void verifyTheNewPolicyHasBeenCreated() {
-        TriggerEventProto.Builder triggerBuilder = triggerBuilders.stream().filter(b -> b.getTriggerEvent().equals(eventType)).findFirst().get();
+        AlertConditionProto.Builder triggerBuilder = triggerBuilders.stream().filter(b -> b.getTriggerEventType().equals(eventType)).findFirst().get();
         MonitorPolicyProto policy = grpcClient.getPolicyStub().getPolicyById(Int64Value.of(policyId));
         assertThat(policy).isNotNull()
             .extracting("name", "memo", "tagsList")
@@ -165,8 +165,8 @@ public class MonitorPolicySteps {
             .extracting("name", "componentType")
             .containsExactly(Tuple.tuple(ruleBuilder.getName(), ruleBuilder.getComponentType()));
         assertThat(policy.getRulesList().get(0).getSnmpEventsList()).asList().hasSize(1)
-            .extracting("triggerEvent", "count", "overtime", "overtimeUnit", "severity", "clearEvent")
-            .containsExactly(Tuple.tuple(triggerBuilder.getTriggerEvent(), triggerBuilder.getCount(), triggerBuilder.getOvertime(),
+            .extracting("triggerEventType", "count", "overtime", "overtimeUnit", "severity", "clearEventType")
+            .containsExactly(Tuple.tuple(triggerBuilder.getTriggerEventType(), triggerBuilder.getCount(), triggerBuilder.getOvertime(),
                 triggerBuilder.getOvertimeUnit(), triggerBuilder.getSeverity(), EventType.UNKNOWN_EVENT));
     }
 
@@ -188,12 +188,12 @@ public class MonitorPolicySteps {
     @Then("Verify the default monitoring policy has the following data")
     public void verifyTheDefaultMonitoringPolicyHasTheFollowingData(DataTable dataTable) {
         List<Map<String, String>> rows = dataTable.asMaps();
-        List<TriggerEventProto> events = policy.getRulesList().get(0).getSnmpEventsList();
+        List<AlertConditionProto> events = policy.getRulesList().get(0).getSnmpEventsList();
         assertThat(events).asList().hasSize(rows.size());
         for(int i =0; i < events.size(); i++) {
             assertThat(events.get(i))
-                .extracting(e -> e.getTriggerEvent().name(), e -> e.getSeverity().name())
-                .containsExactly(rows.get(i).get("triggerEvent"), rows.get(i).get("severity"));
+                .extracting(e -> e.getTriggerEventType().name(), e -> e.getSeverity().name())
+                .containsExactly(rows.get(i).get("triggerEventType"), rows.get(i).get("severity"));
         }
     }
 

--- a/alert/src/test/resources/org/opennms/horizon/alertservice/monitor-policy.feature
+++ b/alert/src/test/resources/org/opennms/horizon/alertservice/monitor-policy.feature
@@ -16,9 +16,9 @@ Feature: Monitor policy gRPC Functionality
     Then The default monitoring policy exist with name "default_policy" and all notification enabled
     Then Verify the default policy rule has name "default_rule" and component type "NODE"
     Then Verify the default monitoring policy has the following data
-      | triggerEvent    | severity |
-      | SNMP_Cold_Start | CRITICAL |
-      | SNMP_Warm_Start | MAJOR    |
+      | triggerEventType | severity |
+      | SNMP_Cold_Start  | CRITICAL |
+      | SNMP_Warm_Start  | MAJOR    |
 
   Scenario: Verify alert can be created based on the default policy
     Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "new-tenant" with node 10

--- a/rest-server/src/main/java/org/opennms/horizon/server/mapper/alert/AlertConditionMapper.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/mapper/alert/AlertConditionMapper.java
@@ -30,12 +30,12 @@ package org.opennms.horizon.server.mapper.alert;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.NullValueCheckStrategy;
-import org.opennms.horizon.server.model.alerts.TriggerEvent;
-import org.opennms.horizon.alerts.proto.TriggerEventProto;
+import org.opennms.horizon.server.model.alerts.AlertCondition;
+import org.opennms.horizon.alerts.proto.AlertConditionProto;
 
 @Mapper(componentModel = "spring",
     nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
-public interface TriggerEventMapper {
-    TriggerEvent map(TriggerEventProto protoEvent);
-    TriggerEventProto map(TriggerEvent event);
+public interface AlertConditionMapper {
+    AlertCondition map(AlertConditionProto protoEvent);
+    AlertConditionProto map(AlertCondition event);
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/mapper/alert/PolicyRuleMapper.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/mapper/alert/PolicyRuleMapper.java
@@ -35,11 +35,11 @@ import org.mapstruct.NullValueCheckStrategy;
 import org.opennms.horizon.server.model.alerts.PolicyRule;
 import org.opennms.horizon.alerts.proto.PolicyRuleProto;
 
-@Mapper(componentModel = "spring", uses = {TriggerEventMapper.class},nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS,
+@Mapper(componentModel = "spring", uses = {AlertConditionMapper.class},nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS,
     collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED)
 public interface PolicyRuleMapper {
-    @Mapping(target = "triggerEvents", source = "snmpEventsList")
+    @Mapping(target = "alertConditions", source = "snmpEventsList")
     PolicyRule map(PolicyRuleProto proto);
-    @Mapping(target = "snmpEventsList", source = "triggerEvents")
+    @Mapping(target = "snmpEventsList", source = "alertConditions")
     PolicyRuleProto map(PolicyRule rule);
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/model/alerts/AlertCondition.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/model/alerts/AlertCondition.java
@@ -35,11 +35,11 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class TriggerEvent extends BaseModel {
-    private String triggerEvent;
+public class AlertCondition extends BaseModel {
+    private String triggerEventType;
     private Integer count;
     private Integer overtime;
     private String overtimeUnit;
     private String severity;
-    private String clearEvent;
+    private String clearEventType;
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/model/alerts/PolicyRule.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/model/alerts/PolicyRule.java
@@ -40,5 +40,5 @@ import lombok.Setter;
 public class PolicyRule extends BaseModel {
     private String name;
     private String componentType;
-    private List<TriggerEvent> triggerEvents;
+    private List<AlertCondition> alertConditions;
 }

--- a/rest-server/src/test/java/org/opennms/horizon/server/mapper/alert/MonitorPolicyMapperTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/mapper/alert/MonitorPolicyMapperTest.java
@@ -32,16 +32,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opennms.horizon.alerts.proto.EventType;
-import org.opennms.horizon.alerts.proto.ManagedObjectType;
-import org.opennms.horizon.alerts.proto.MonitorPolicyProto;
-import org.opennms.horizon.alerts.proto.OverTimeUnit;
-import org.opennms.horizon.alerts.proto.PolicyRuleProto;
-import org.opennms.horizon.alerts.proto.Severity;
+import org.opennms.horizon.alerts.proto.*;
+import org.opennms.horizon.server.model.alerts.AlertCondition;
 import org.opennms.horizon.server.model.alerts.MonitorPolicy;
 import org.opennms.horizon.server.model.alerts.PolicyRule;
-import org.opennms.horizon.server.model.alerts.TriggerEvent;
-import org.opennms.horizon.alerts.proto.TriggerEventProto;
+import org.opennms.horizon.alerts.proto.AlertConditionProto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -53,15 +48,15 @@ public class MonitorPolicyMapperTest {
 
     @BeforeEach
     void before() {
-        TriggerEventProto triggerEvent = TriggerEventProto.newBuilder()
-            .setTriggerEvent(EventType.SNMP_Warm_Start)
+        AlertConditionProto alertCondition = AlertConditionProto.newBuilder()
+            .setTriggerEventType(EventType.SNMP_Warm_Start)
             .setCount(1)
             .setSeverity(Severity.CRITICAL)
             .build();
         PolicyRuleProto rule = PolicyRuleProto.newBuilder()
             .setName("test-rule")
             .setComponentType(ManagedObjectType.NODE)
-            .addSnmpEvents(triggerEvent)
+            .addSnmpEvents(alertCondition)
             .build();
         policyProto = MonitorPolicyProto.newBuilder()
             .setName("test-policy")
@@ -85,11 +80,11 @@ public class MonitorPolicyMapperTest {
                 policyProto.getNotifyByEmail(), policyProto.getNotifyByPagerDuty(), policyProto.getNotifyByWebhooks(), policyProto.getNotifyInstruction());
         assertThat(policy.getTags()).isEqualTo(policyProto.getTagsList()); //the order doesn't matter here
         assertThat(policy.getRules().get(0))
-            .extracting(PolicyRule::getName, PolicyRule::getComponentType, r -> r.getTriggerEvents().size())
+            .extracting(PolicyRule::getName, PolicyRule::getComponentType, r -> r.getAlertConditions().size())
             .containsExactly("test-rule", ManagedObjectType.NODE.name(), 1);
-        assertThat(policy.getRules().get(0).getTriggerEvents().get(0))
-            .extracting(TriggerEvent::getTriggerEvent, TriggerEvent::getCount, TriggerEvent::getOvertime, TriggerEvent::getOvertimeUnit,
-                TriggerEvent::getSeverity, TriggerEvent::getClearEvent)
+        assertThat(policy.getRules().get(0).getAlertConditions().get(0))
+            .extracting(AlertCondition::getTriggerEventType, AlertCondition::getCount, AlertCondition::getOvertime, AlertCondition::getOvertimeUnit,
+                AlertCondition::getSeverity, AlertCondition::getClearEventType)
             .containsExactly(EventType.SNMP_Warm_Start.name(), 1, 0, OverTimeUnit.UNKNOWN_UNIT.name(), Severity.CRITICAL.name(), EventType.UNKNOWN_EVENT.name());
     }
 

--- a/shared-lib/alert/src/main/proto/alerts.proto
+++ b/shared-lib/alert/src/main/proto/alerts.proto
@@ -275,18 +275,18 @@ message PolicyRuleProto {
   string tenantId = 2;
   string name = 3;
   ManagedObjectType componentType = 4;
-  repeated TriggerEventProto snmpEvents = 5;
+  repeated AlertConditionProto snmpEvents = 5;
 }
 
-message TriggerEventProto {
+message AlertConditionProto {
   int64 id = 1;
   string tenantId = 2;
-  EventType triggerEvent = 3;
+  EventType triggerEventType = 3;
   int32 count = 4;
   int32 overtime = 5;
   OverTimeUnit overtimeUnit = 6;
   Severity severity = 7;
-  EventType clearEvent = 8;
+  EventType clearEventType = 8;
 }
 
 enum OverTimeUnit {

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesCard.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesCard.vue
@@ -55,7 +55,7 @@
       <div v-if="ruleStates[rule.id]">
         <div class="alert-title">Alert Conditions</div>
         <MonitoringPoliciesCardAlertRow
-          v-for="(condition, index) in rule.triggerEvents"
+          v-for="(condition, index) in rule.alertConditions"
           :key="condition.id"
           :rule="rule"
           :condition="condition"

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesCardAlertRow.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesCardAlertRow.vue
@@ -41,7 +41,7 @@
 
     <div class="mp-card-alert-row">
       <div class="subtitle">{{ conditionLetters[index] + '.' }}</div>
-      <div class="col subtitle double">{{ snakeToTitleCase(condition.triggerEvent as string) }}</div>
+      <div class="col subtitle double">{{ snakeToTitleCase(condition.triggerEventType as string) }}</div>
       <div class="col half box">{{ condition.count }}</div>
       <div class="col half box">{{ condition.overtime || '&nbsp' }}</div>
       <div class="col box double">

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesCardAlertRow.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesCardAlertRow.vue
@@ -59,7 +59,7 @@
       </div>
       <div class="col box double">
         {{
-          condition.clearEvent !== Unknowns.UNKNOWN_EVENT ? snakeToTitleCase(condition.clearEvent as string) : '&nbsp;'
+          condition.clearEventType !== Unknowns.UNKNOWN_EVENT ? snakeToTitleCase(condition.clearEventType as string) : '&nbsp;'
         }}
       </div>
     </div>

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesEventCondition.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesEventCondition.vue
@@ -15,10 +15,10 @@
       <BasicSelect
         label=""
         hideLabel
-        :list="triggerEventOptions"
-        @item-selected="(val: number) => updateConditionProp('triggerEvent', val)"
+        :list="triggerEventTypeOptions"
+        @item-selected="(val: number) => updateConditionProp('triggerEventType', val)"
         :disabled="policy.isDefault"
-        :selectedId="condition.triggerEvent"
+        :selectedId="condition.triggerEventType"
       />
     </div>
 
@@ -68,7 +68,7 @@
 
     <div
       class="inner-col"
-      v-if="condition.triggerEvent === SNMPEventType.SNMP_LINK_UP"
+      v-if="condition.triggerEventType === SNMPEventType.SNMP_LINK_UP"
     >
       <div class="text">Clear Event (optional)</div>
       <BasicSelect
@@ -115,7 +115,7 @@ const clearEventOptions = [
   { id: SNMPEventType.SNMP_LINK_DOWN, name: 'SNMP Link Down'},
 ]
 
-const triggerEventOptions = [
+const triggerEventTypeOptions = [
   { id: SNMPEventType.SNMP_COLD_START, name: 'SNMP Cold Start' },
   { id: SNMPEventType.SNMP_WARM_START, name: 'SNMP Warm Start' },
   { id: SNMPEventType.SNMP_AUTHEN_FAILURE, name: 'SNMP Authentication Failure' },

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesEventCondition.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesEventCondition.vue
@@ -72,9 +72,9 @@
     >
       <div class="text">Clear Event (optional)</div>
       <BasicSelect
-        :list="clearEventOptions"
-        @item-selected="(val: string) => updateConditionProp('clearEvent', val)"
-        :selectedId="condition.clearEvent"
+        :list="clearEventTypeOptions"
+        @item-selected="(val: string) => updateConditionProp('clearEventType', val)"
+        :selectedId="condition.clearEventType"
       />
     </div>
   </div>
@@ -110,7 +110,7 @@ const severityList = [
   { id: Severity.Cleared, name: 'Cleared'}
 ]
 
-const clearEventOptions = [
+const clearEventTypeOptions = [
   { id: Unknowns.UNKNOWN_EVENT, name: '' },
   { id: SNMPEventType.SNMP_LINK_DOWN, name: 'SNMP Link Down'},
 ]

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
@@ -73,13 +73,13 @@
         </div>
         <div
           class="row"
-          v-if="store.selectedRule!.triggerEvents.length"
+          v-if="store.selectedRule!.alertConditions.length"
         >
           <div class="col">
             <div class="form-title">Set Alert Conditions</div>
             <template v-if="store.selectedRule!.detectionMethod === DetectionMethodTypes.THRESHOLD">
               <MonitoringPoliciesThresholdCondition
-                v-for="(cond, index) in store.selectedRule!.triggerEvents"
+                v-for="(cond, index) in store.selectedRule!.alertConditions"
                 :key="cond.id"
                 :index="index"
                 :condition="(cond as ThresholdCondition)"
@@ -89,7 +89,7 @@
             </template>
             <template v-else>
               <MonitoringPoliciesEventCondition
-                v-for="(cond, index) in store.selectedRule!.triggerEvents"
+                v-for="(cond, index) in store.selectedRule!.alertConditions"
                 :key="cond.id"
                 :condition="(cond as EventCondition)"
                 :policy="store.selectedPolicy"
@@ -103,7 +103,7 @@
               class="add-params"
               text
               @click="store.addNewCondition"
-              :disabled="store.selectedRule.triggerEvents.length === 4 || store.selectedPolicy.isDefault"
+              :disabled="store.selectedRule.alertConditions.length === 4 || store.selectedPolicy.isDefault"
             >
               Additional Conditions
             </FeatherButton>

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesSaveButtons.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesSaveButtons.vue
@@ -36,7 +36,7 @@ const disableSavePolicyBtn = computed(
   () => store.selectedPolicy?.isDefault || !store.selectedPolicy?.rules.length || !store.selectedPolicy.name
 )
 const disableSaveRuleBtn = computed(
-  () => store.selectedPolicy?.isDefault || !store.selectedRule?.name || !store.selectedRule?.triggerEvents.length
+  () => store.selectedPolicy?.isDefault || !store.selectedRule?.name || !store.selectedRule?.alertConditions.length
 )
 </script>
 

--- a/ui/src/graphql/Views/monitoringPolicies.graphql
+++ b/ui/src/graphql/Views/monitoringPolicies.graphql
@@ -9,14 +9,14 @@ fragment MonitoringPolicyParts on MonitorPolicy {
     id
     name
     componentType
-    triggerEvents {
+    alertConditions {
       id
       count
-      clearEvent
+      clearEventType
       overtime
       overtimeUnit
       severity
-      triggerEvent
+      triggerEventType
     }
   }
   tags

--- a/ui/src/store/Views/monitoringPoliciesStore.ts
+++ b/ui/src/store/Views/monitoringPoliciesStore.ts
@@ -50,8 +50,8 @@ const getDefaultEventCondition = () => ({
   count: 1,
   severity: Severity.Critical,
   overtimeUnit: Unknowns.UNKNOWN_UNIT,
-  triggerEvent: SNMPEventType.SNMP_COLD_START,
-  clearEvent: Unknowns.UNKNOWN_EVENT
+  triggerEventType: SNMPEventType.SNMP_COLD_START,
+  clearEventType: Unknowns.UNKNOWN_EVENT
 })
 
 const getDefaultRule = () => ({
@@ -60,7 +60,7 @@ const getDefaultRule = () => ({
   componentType: ComponentType.NODE,
   detectionMethod: DetectionMethodTypes.EVENT,
   metricName: EventMetrics.SNMP_TRAP,
-  triggerEvents: [getDefaultEventCondition()]
+  alertConditions: [getDefaultEventCondition()]
 })
 
 export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore', {
@@ -88,25 +88,25 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
 
       // detection method THRESHOLD
       if (this.selectedRule.detectionMethod === DetectionMethodTypes.THRESHOLD) {
-        return (this.selectedRule.triggerEvents = [getDefaultThresholdCondition()])
+        return (this.selectedRule.alertConditions = [getDefaultThresholdCondition()])
       }
 
       // detection method EVENT
-      return (this.selectedRule.triggerEvents = [getDefaultEventCondition()])
+      return (this.selectedRule.alertConditions = [getDefaultEventCondition()])
     },
     addNewCondition() {
       if (!this.selectedRule) return
 
       // detection method THRESHOLD
       if (this.selectedRule.detectionMethod === DetectionMethodTypes.THRESHOLD) {
-        return this.selectedRule.triggerEvents.push(getDefaultThresholdCondition())
+        return this.selectedRule.alertConditions.push(getDefaultThresholdCondition())
       }
 
       // detection method EVENT
-      return this.selectedRule.triggerEvents.push(getDefaultEventCondition())
+      return this.selectedRule.alertConditions.push(getDefaultEventCondition())
     },
     updateCondition(id: string, condition: Condition) {
-      this.selectedRule!.triggerEvents.map((currentCondition) => {
+      this.selectedRule!.alertConditions.map((currentCondition) => {
         if (currentCondition.id === id) {
           return { ...currentCondition, ...condition }
         }
@@ -114,7 +114,7 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       })
     },
     deleteCondition(id: string) {
-      this.selectedRule!.triggerEvents = this.selectedRule!.triggerEvents.filter((c) => c.id !== id)
+      this.selectedRule!.alertConditions = this.selectedRule!.alertConditions.filter((c) => c.id !== id)
     },
     saveRule() {
       const existingItemIndex = findIndex(this.selectedPolicy!.rules, { id: this.selectedRule!.id })
@@ -136,7 +136,7 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       // modify payload to comply with current BE format
       const policy = cloneDeep(this.selectedPolicy!)
       policy.rules = policy.rules.map((rule) => {
-        rule.triggerEvents = rule.triggerEvents.map((condition) => {
+        rule.alertConditions = rule.alertConditions.map((condition) => {
           if (!policy.id) delete condition.id // don't send generated ids
           return condition
         })

--- a/ui/src/types/graphql.ts
+++ b/ui/src/types/graphql.ts
@@ -49,6 +49,29 @@ export type Alert = {
   uei?: Maybe<Scalars['String']>;
 };
 
+export type AlertCondition = {
+  __typename?: 'AlertCondition';
+  clearEventType?: Maybe<Scalars['String']>;
+  count?: Maybe<Scalars['Int']>;
+  id?: Maybe<Scalars['Long']>;
+  overtime?: Maybe<Scalars['Int']>;
+  overtimeUnit?: Maybe<Scalars['String']>;
+  severity?: Maybe<Scalars['String']>;
+  tenantId?: Maybe<Scalars['String']>;
+  triggerEventType?: Maybe<Scalars['String']>;
+};
+
+export type AlertConditionInput = {
+  clearEventType?: InputMaybe<Scalars['String']>;
+  count?: InputMaybe<Scalars['Int']>;
+  id?: InputMaybe<Scalars['Long']>;
+  overtime?: InputMaybe<Scalars['Int']>;
+  overtimeUnit?: InputMaybe<Scalars['String']>;
+  severity?: InputMaybe<Scalars['String']>;
+  tenantId?: InputMaybe<Scalars['String']>;
+  triggerEventType?: InputMaybe<Scalars['String']>;
+};
+
 export type AlertError = {
   __typename?: 'AlertError';
   databaseId: Scalars['Long'];
@@ -508,19 +531,19 @@ export type PassiveDiscoveryUpsertInput = {
 
 export type PolicyRule = {
   __typename?: 'PolicyRule';
+  alertConditions?: Maybe<Array<Maybe<AlertCondition>>>;
   componentType?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Long']>;
   name?: Maybe<Scalars['String']>;
   tenantId?: Maybe<Scalars['String']>;
-  triggerEvents?: Maybe<Array<Maybe<TriggerEvent>>>;
 };
 
 export type PolicyRuleInput = {
+  alertConditions?: InputMaybe<Array<InputMaybe<AlertConditionInput>>>;
   componentType?: InputMaybe<Scalars['String']>;
   id?: InputMaybe<Scalars['Long']>;
   name?: InputMaybe<Scalars['String']>;
   tenantId?: InputMaybe<Scalars['String']>;
-  triggerEvents?: InputMaybe<Array<InputMaybe<TriggerEventInput>>>;
 };
 
 /** Query root */
@@ -869,29 +892,6 @@ export type TrafficSummary = {
   bytesIn: Scalars['Long'];
   bytesOut: Scalars['Long'];
   label?: Maybe<Scalars['String']>;
-};
-
-export type TriggerEvent = {
-  __typename?: 'TriggerEvent';
-  clearEvent?: Maybe<Scalars['String']>;
-  count?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Long']>;
-  overtime?: Maybe<Scalars['Int']>;
-  overtimeUnit?: Maybe<Scalars['String']>;
-  severity?: Maybe<Scalars['String']>;
-  tenantId?: Maybe<Scalars['String']>;
-  triggerEvent?: Maybe<Scalars['String']>;
-};
-
-export type TriggerEventInput = {
-  clearEvent?: InputMaybe<Scalars['String']>;
-  count?: InputMaybe<Scalars['Int']>;
-  id?: InputMaybe<Scalars['Long']>;
-  overtime?: InputMaybe<Scalars['Int']>;
-  overtimeUnit?: InputMaybe<Scalars['String']>;
-  severity?: InputMaybe<Scalars['String']>;
-  tenantId?: InputMaybe<Scalars['String']>;
-  triggerEvent?: InputMaybe<Scalars['String']>;
 };
 
 export type AcknowledgeAlertsMutationVariables = Exact<{
@@ -1286,12 +1286,12 @@ export type NodesForMapQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type NodesForMapQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string }> };
 
-export type MonitoringPolicyPartsFragment = { __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: string, triggerEvents?: Array<{ __typename?: 'TriggerEvent', id?: any, count?: number, clearEvent?: string, overtime?: number, overtimeUnit?: string, severity?: string, triggerEvent?: string }> }> };
+export type MonitoringPolicyPartsFragment = { __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: string, alertConditions?: Array<{ __typename?: 'AlertCondition', id?: any, count?: number, clearEventType?: string, overtime?: number, overtimeUnit?: string, severity?: string, triggerEventType?: string }> }> };
 
 export type ListMonitoryPoliciesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ListMonitoryPoliciesQuery = { __typename?: 'Query', listMonitoryPolicies?: Array<{ __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: string, triggerEvents?: Array<{ __typename?: 'TriggerEvent', id?: any, count?: number, clearEvent?: string, overtime?: number, overtimeUnit?: string, severity?: string, triggerEvent?: string }> }> }>, defaultPolicy?: { __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: string, triggerEvents?: Array<{ __typename?: 'TriggerEvent', id?: any, count?: number, clearEvent?: string, overtime?: number, overtimeUnit?: string, severity?: string, triggerEvent?: string }> }> } };
+export type ListMonitoryPoliciesQuery = { __typename?: 'Query', listMonitoryPolicies?: Array<{ __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: string, alertConditions?: Array<{ __typename?: 'AlertCondition', id?: any, count?: number, clearEventType?: string, overtime?: number, overtimeUnit?: string, severity?: string, triggerEventType?: string }> }> }>, defaultPolicy?: { __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: string, alertConditions?: Array<{ __typename?: 'AlertCondition', id?: any, count?: number, clearEventType?: string, overtime?: number, overtimeUnit?: string, severity?: string, triggerEventType?: string }> }> } };
 
 export type EventsByNodeIdPartsFragment = { __typename?: 'Query', events?: Array<{ __typename?: 'Event', id: number, uei?: string, nodeId: number, ipAddress?: string, producedTime: any }> };
 
@@ -1343,7 +1343,7 @@ export const TagsPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"F
 export const TagsSearchPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"TagsSearchParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tags"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"searchTerm"},"value":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"tenantId"}}]}}]}}]} as unknown as DocumentNode<TagsSearchPartsFragment, unknown>;
 export const NodesTablePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodesTableParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"tenantId"}},{"kind":"Field","name":{"kind":"Name","value":"createTime"}},{"kind":"Field","name":{"kind":"Name","value":"monitoringLocationId"}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}},{"kind":"Field","name":{"kind":"Name","value":"scanType"}}]}}]}}]} as unknown as DocumentNode<NodesTablePartsFragment, unknown>;
 export const MinionsTablePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MinionsTableParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllMinions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"lastCheckedTime"}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"systemId"}}]}}]}}]} as unknown as DocumentNode<MinionsTablePartsFragment, unknown>;
-export const MonitoringPolicyPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MonitoringPolicyParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"MonitorPolicy"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"memo"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"notifyByEmail"}},{"kind":"Field","name":{"kind":"Name","value":"notifyByPagerDuty"}},{"kind":"Field","name":{"kind":"Name","value":"notifyByWebhooks"}},{"kind":"Field","name":{"kind":"Name","value":"rules"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}},{"kind":"Field","name":{"kind":"Name","value":"triggerEvents"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"count"}},{"kind":"Field","name":{"kind":"Name","value":"clearEvent"}},{"kind":"Field","name":{"kind":"Name","value":"overtime"}},{"kind":"Field","name":{"kind":"Name","value":"overtimeUnit"}},{"kind":"Field","name":{"kind":"Name","value":"severity"}},{"kind":"Field","name":{"kind":"Name","value":"triggerEvent"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"tags"}}]}}]} as unknown as DocumentNode<MonitoringPolicyPartsFragment, unknown>;
+export const MonitoringPolicyPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MonitoringPolicyParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"MonitorPolicy"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"memo"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"notifyByEmail"}},{"kind":"Field","name":{"kind":"Name","value":"notifyByPagerDuty"}},{"kind":"Field","name":{"kind":"Name","value":"notifyByWebhooks"}},{"kind":"Field","name":{"kind":"Name","value":"rules"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}},{"kind":"Field","name":{"kind":"Name","value":"alertConditions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"count"}},{"kind":"Field","name":{"kind":"Name","value":"clearEventType"}},{"kind":"Field","name":{"kind":"Name","value":"overtime"}},{"kind":"Field","name":{"kind":"Name","value":"overtimeUnit"}},{"kind":"Field","name":{"kind":"Name","value":"severity"}},{"kind":"Field","name":{"kind":"Name","value":"triggerEventType"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"tags"}}]}}]} as unknown as DocumentNode<MonitoringPolicyPartsFragment, unknown>;
 export const EventsByNodeIdPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"EventsByNodeIdParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"events"},"name":{"kind":"Name","value":"findEventsByNodeId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"uei"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"producedTime"}}]}}]}}]} as unknown as DocumentNode<EventsByNodeIdPartsFragment, unknown>;
 export const NodeByIdPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodeByIdParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"node"},"name":{"kind":"Name","value":"findNodeById"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"objectId"}},{"kind":"Field","name":{"kind":"Name","value":"systemContact"}},{"kind":"Field","name":{"kind":"Name","value":"systemDescr"}},{"kind":"Field","name":{"kind":"Name","value":"systemLocation"}},{"kind":"Field","name":{"kind":"Name","value":"systemName"}},{"kind":"Field","name":{"kind":"Name","value":"scanType"}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"location"}}]}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"hostname"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"netmask"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}},{"kind":"Field","name":{"kind":"Name","value":"snmpInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ifAdminStatus"}},{"kind":"Field","name":{"kind":"Name","value":"ifAlias"}},{"kind":"Field","name":{"kind":"Name","value":"ifDescr"}},{"kind":"Field","name":{"kind":"Name","value":"ifIndex"}},{"kind":"Field","name":{"kind":"Name","value":"ifName"}},{"kind":"Field","name":{"kind":"Name","value":"ifOperatorStatus"}},{"kind":"Field","name":{"kind":"Name","value":"ifSpeed"}},{"kind":"Field","name":{"kind":"Name","value":"ifType"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"physicalAddr"}}]}}]}}]}}]} as unknown as DocumentNode<NodeByIdPartsFragment, unknown>;
 export const AcknowledgeAlertsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AcknowledgeAlerts"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"ids"}},"type":{"kind":"ListType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"acknowledgeAlert"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"ids"},"value":{"kind":"Variable","name":{"kind":"Name","value":"ids"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"alertList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"acknowledged"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}}]}},{"kind":"Field","name":{"kind":"Name","value":"alertErrorList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"databaseId"}},{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]}}]} as unknown as DocumentNode<AcknowledgeAlertsMutation, AcknowledgeAlertsMutationVariables>;

--- a/ui/src/types/policies.d.ts
+++ b/ui/src/types/policies.d.ts
@@ -1,4 +1,4 @@
-import { MonitorPolicy, PolicyRule, TriggerEvent } from './graphql'
+import { MonitorPolicy, PolicyRule, AlertCondition } from './graphql'
 
 export interface Policy extends MonitorPolicy {
   rules: Rule[]
@@ -8,7 +8,7 @@ export interface Policy extends MonitorPolicy {
 export interface Rule extends PolicyRule {
   detectionMethod?: string
   metricName?: string
-  triggerEvents: Condition[]
+  alertConditions: Condition[]
 }
 
 interface IObjectKeys {
@@ -24,8 +24,8 @@ export interface ThresholdCondition extends IObjectKeys {
   duringLast: number
   periodUnit: string
   severity: string
-  triggerEvent: string
+  triggerEventType: string
 }
 
-export type EventCondition = TriggerEvent & IObjectKeys
+export type EventCondition = AlertCondition & IObjectKeys
 export type Condition = ThresholdCondition | EventCondition

--- a/ui/tests/MonitoringPolicies/monitoringPolicies.test.ts
+++ b/ui/tests/MonitoringPolicies/monitoringPolicies.test.ts
@@ -17,13 +17,13 @@ const testingPayload = {
     {
       name: 'Rule1',
       componentType: ComponentType.NODE,
-      triggerEvents: [
+      alertConditions: [
         {
           count: 1,
           severity: Severity.Critical,
-          triggerEvent: SNMPEventType.SNMP_COLD_START,
+          triggerEventType: SNMPEventType.SNMP_COLD_START,
           overtimeUnit: Unknowns.UNKNOWN_UNIT,
-          clearEvent: Unknowns.UNKNOWN_EVENT
+          clearEventType: Unknowns.UNKNOWN_EVENT
         }
       ]
     }


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
Changes the APIs and UI to use AlertCondition instead of TriggerEvent.

This follows #1268, which changes the internals of the Alert service. Will rebase once that one is merged.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1776

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
