### PR TITLE
Minion: use default location instead of TestLocation, disable Minion by default

### DIFF
--- a/charts/lokahi/scripts/opennms/minion/init-create-test-location.sh
+++ b/charts/lokahi/scripts/opennms/minion/init-create-test-location.sh
@@ -18,7 +18,7 @@ while true; do
               -U https://$INGRESS_HOST_PORT \
               -k -c "--connect-to" -c "$INGRESS_HOST_PORT:ingress-nginx-controller:443" \
               -f "/cert/minion.p12" -P changeme \
-              -l TestLocation; then
+              -l default; then
     break
   fi
 

--- a/charts/lokahi/templates/opennms/minion/minion-configmap.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenNMS.Minion.Enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -24,3 +25,4 @@ data:
   opennms-minion-identity: |
     id=${env:HOSTNAME:-UNKNOWN}
     location=${env:LOCATION:-Default}
+{{- end }}

--- a/charts/lokahi/templates/opennms/minion/minion-configmap.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-configmap.yaml
@@ -9,7 +9,7 @@ data:
   grpc-config: |
     grpc.max.message.size=104857600
     # Properties below override these defined earlier in file!
-    {{- if .Values.OpenNMS.Minion.addTestLocation }}
+    {{- if .Values.OpenNMS.Minion.addDefaultLocation }}
     grpc.host: ingress-nginx-controller
     grpc.port: 443
     grpc.tls.enabled: true

--- a/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
@@ -45,7 +45,7 @@ spec:
             name: minion-config
         - name: maven-volume
           emptyDir: {}
-        {{- if .Values.OpenNMS.Minion.addTestLocation }}
+        {{- if .Values.OpenNMS.Minion.addDefaultLocation }}
         - name: scripts
           configMap:
             name: minion-scripts
@@ -72,7 +72,7 @@ spec:
           securityContext:
             privileged: true
         {{ end }}
-        {{- if .Values.OpenNMS.Minion.addTestLocation }}
+        {{- if .Values.OpenNMS.Minion.addDefaultLocation }}
         # This container is a development time helper which generates client certificate, key and signs it with
         # `Client CA` certificate which is running in cluster. It's a bit hacky, since it pulls CA private key
         # into minion. Please do not use this in production.
@@ -142,7 +142,7 @@ spec:
               subPath: "opennms-minion-identity"
             - name: maven-volume
               mountPath: /.m2
-            {{- if .Values.OpenNMS.Minion.addTestLocation }}
+            {{- if .Values.OpenNMS.Minion.addDefaultLocation }}
             - name: certificate-secrets
               mountPath: "/run/secrets/certificates"
               readOnly: true

--- a/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenNMS.Minion.Enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -170,3 +171,4 @@ spec:
               - unset JAVA_TOOL_OPTIONS; echo "opennms:task-set-print" | bin/client -b | grep -q taskDefinition
             initialDelaySeconds: 25
             periodSeconds: 5
+{{- end }}

--- a/charts/lokahi/templates/opennms/minion/minion-rolebinding.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenNMS.Minion.Enabled }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -13,3 +14,4 @@ roleRef:
   kind: Role
   name: role-endpoints
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/lokahi/templates/opennms/minion/minion-scripts-configmap.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-scripts-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenNMS.Minion.Enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -8,3 +9,4 @@ metadata:
     app: {{ .Values.OpenNMS.Minion.ServiceName }}
 data:
   {{- (.Files.Glob "scripts/opennms/minion/**").AsConfig | nindent 2 }}
+{{- end }}

--- a/charts/lokahi/templates/opennms/minion/minion-service.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenNMS.Minion.Enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
       name: http
   selector:
     app: {{ .Values.OpenNMS.Minion.ServiceName }}
+{{- end }}

--- a/charts/lokahi/templates/opennms/minion/minion-serviceaccount.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-serviceaccount.yaml
@@ -1,5 +1,7 @@
+{{- if .Values.OpenNMS.Minion.Enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.OpenNMS.Minion.ServiceName }}-sa
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/lokahi/values.yaml
+++ b/charts/lokahi/values.yaml
@@ -95,7 +95,7 @@ OpenNMS:
     ExtraMounts: []
     ExtraInitContainers: []
     GrpcConfig: {}
-    addTestLocation: false
+    addDefaultLocation: false
   MinionGateway:
     ServiceName: opennms-minion-gateway
     TlsSecretName: opennms-minion-gateway-certificate

--- a/charts/lokahi/values.yaml
+++ b/charts/lokahi/values.yaml
@@ -74,6 +74,7 @@ OpenNMS:
       nginx.ingress.kubernetes.io/proxy-body-size: 4m
       nginx.ingress.kubernetes.io/proxy-buffer-size: 6k
   Minion:
+    Enabled: false
     ServiceName: opennms-minion
     Image: opennms/lokahi-minion
     ImagePullPolicy: IfNotPresent

--- a/install-local/install-local-opennms-lokahi-custom-images-values.yaml
+++ b/install-local/install-local-opennms-lokahi-custom-images-values.yaml
@@ -44,7 +44,7 @@ OpenNMS:
       Requests:
         Cpu: '0'
         Memory: '0'
-    addTestLocation: true
+    addDefaultLocation: true
   MinionGateway:
     Image: opennms/lokahi-minion-gateway:local
     Resources:

--- a/install-local/install-local-opennms-lokahi-custom-images-values.yaml
+++ b/install-local/install-local-opennms-lokahi-custom-images-values.yaml
@@ -44,6 +44,7 @@ OpenNMS:
       Requests:
         Cpu: '0'
         Memory: '0'
+    Enabled: true
     addDefaultLocation: true
   MinionGateway:
     Image: opennms/lokahi-minion-gateway:local

--- a/test-automation/integration-tests/src/main/java/org/opennms/horizon/exttest/CucumberCommandLineRunner.java
+++ b/test-automation/integration-tests/src/main/java/org/opennms/horizon/exttest/CucumberCommandLineRunner.java
@@ -33,6 +33,10 @@ public class CucumberCommandLineRunner {
                 commandlineOptionsParser.parse(arguments.toArray(DEFAULT_CUCUMBER_OPTIONS))
                     .build();
 
+        if (commandlineOptionsParser.exitStatus().isPresent()) {
+            System.exit(commandlineOptionsParser.exitStatus().get());
+        }
+
         Runtime cucumberRuntime =
                 Runtime.builder()
                         .withRuntimeOptions(runtimeOptions)

--- a/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/InventoryTestSteps.java
+++ b/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/InventoryTestSteps.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -126,7 +127,7 @@ public class InventoryTestSteps {
     public void queryLocationDoNotExist(String location) throws MalformedURLException {
         List<LocationData> locationData = helper.commonQueryLocations().getData().getFindAllLocations().stream()
             .filter(data -> data.getLocation().equals(location)).toList();
-        assertTrue(locationData.isEmpty());
+        assertTrue("locations should be empty but was: " + Arrays.deepToString(locationData.toArray()), locationData.isEmpty());
     }
 
     @Then("Location {string} do exist")
@@ -145,7 +146,7 @@ public class InventoryTestSteps {
     @Given("No Minion running with location {string}")
     public void check(String location) throws MalformedURLException {
         atLeastOneMinionIsRunningWithLocation(location);
-        assertFalse(checkAtLeastOneMinionAtGivenLocation());
+        assertFalse("there should be no minions at location '" + location + "': " +  Arrays.deepToString(getMinionsAtGivenLocation().toArray()), checkAtLeastOneMinionAtGivenLocation());
     }
 
 
@@ -364,13 +365,17 @@ public class InventoryTestSteps {
     }
 
 
-    private boolean checkAtLeastOneMinionAtGivenLocation() throws MalformedURLException {
+    private List<MinionData> getMinionsAtGivenLocation() throws MalformedURLException {
         FindAllMinionsQueryResult findAllMinionsQueryResult = commonQueryMinions();
         List<MinionData> filtered = commonFilterMinionsAtLocation(findAllMinionsQueryResult);
 
         LOG.debug("MINIONS for location: count={}; location={}", filtered.size(), minionLocation);
 
-        return ( ! filtered.isEmpty() );
+        return filtered;
+    }
+
+    private boolean checkAtLeastOneMinionAtGivenLocation() throws MalformedURLException {
+        return ( ! getMinionsAtGivenLocation().isEmpty() );
     }
 
     /** @noinspection rawtypes*/

--- a/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/InventoryTestSteps.java
+++ b/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/InventoryTestSteps.java
@@ -1,47 +1,41 @@
 package org.opennms.horizon.it;
 
-import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.StopContainerCmd;
-import com.github.dockerjava.api.command.WaitContainerCmd;
-import com.github.dockerjava.api.model.Container;
-import io.cucumber.java.After;
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
-import io.cucumber.java.en.When;
-import io.restassured.path.json.JsonPath;
-import io.restassured.response.Response;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
-import org.awaitility.Awaitility;
-import org.junit.Assert;
-import org.opennms.horizon.it.gqlmodels.CreateNodeData;
-import org.opennms.horizon.it.gqlmodels.GQLQuery;
-import org.opennms.horizon.it.gqlmodels.LocationData;
-import org.opennms.horizon.it.gqlmodels.querywrappers.CreateNodeResult;
-import org.opennms.horizon.it.gqlmodels.querywrappers.FindAllLocationsData;
-import org.opennms.horizon.it.gqlmodels.querywrappers.FindAllMinionsQueryResult;
-import org.opennms.horizon.it.gqlmodels.MinionData;
-import org.opennms.horizon.it.helper.TestsExecutionHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.net.MalformedURLException;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.awaitility.Awaitility;
+import org.opennms.horizon.it.gqlmodels.CreateNodeData;
+import org.opennms.horizon.it.gqlmodels.GQLQuery;
+import org.opennms.horizon.it.gqlmodels.LocationData;
+import org.opennms.horizon.it.gqlmodels.MinionData;
+import org.opennms.horizon.it.gqlmodels.querywrappers.CreateNodeResult;
+import org.opennms.horizon.it.gqlmodels.querywrappers.FindAllMinionsQueryResult;
+import org.opennms.horizon.it.helper.TestsExecutionHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
-import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -49,13 +43,17 @@ import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
-import org.testcontainers.utility.ResourceReaper;
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.WaitContainerCmd;
+import com.github.dockerjava.api.model.Container;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import io.cucumber.java.After;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
 
 public class InventoryTestSteps {
 
@@ -399,7 +397,7 @@ public class InventoryTestSteps {
 
         lastMinionQueryResultBody = restAssuredResponse.getBody().asString();
 
-        Assert.assertEquals(200, restAssuredResponse.getStatusCode());
+        assertEquals(200, restAssuredResponse.getStatusCode());
         assertFalse(helper.responseContainsErrors(restAssuredResponse));
 
         return restAssuredResponse.getBody().as(FindAllMinionsQueryResult.class);

--- a/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/InventoryTestSteps.java
+++ b/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/InventoryTestSteps.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.StopContainerCmd;
 import com.github.dockerjava.api.command.WaitContainerCmd;
 import com.github.dockerjava.api.model.Container;
+import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -77,6 +78,20 @@ public class InventoryTestSteps {
 
     // certificate related runtime info location -> [keystore password=pkcs12 byte sequence]
     private Map<String, Entry<String, byte[]>> keystores = new ConcurrentHashMap<>();
+
+//========================================
+// Hooks
+//----------------------------------------
+
+    @After
+    // Cleanup non-default locations so we don't break later runs
+    public void after() throws Exception {
+        if (minionLocation != null && !"default".equals(minionLocation)) {
+            if (getLocationData(minionLocation).findFirst().isPresent()) {
+                deleteLocation(minionLocation);
+            }
+        }
+    }
 
 //========================================
 // Getters and Setters

--- a/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/gqlmodels/LocationData.java
+++ b/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/gqlmodels/LocationData.java
@@ -19,4 +19,12 @@ public class LocationData {
     public void setLocation(String location) {
         this.location = location;
     }
+
+    @Override
+    public String toString() {
+        return "LocationData{" +
+            "id='" + id + '\'' +
+            ", location=" + location +
+            '}';
+    }
 }

--- a/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/gqlmodels/MinionData.java
+++ b/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/gqlmodels/MinionData.java
@@ -46,4 +46,16 @@ public class MinionData {
     public void setLocation(LocationData location) {
         this.location = location;
     }
+
+
+    @Override
+    public String toString() {
+        return "MinionData{" +
+            "id='" + id + '\'' +
+            ", label=" + label +
+            ", status=" + status +
+            ", systemId=" + systemId +
+            ", location=" + location +
+            '}';
+    }
 }

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -39,7 +39,7 @@ OpenNMS:
         Memory: '0'
     IngressAnnotations: {}
   Minion:
-    addTestLocation: true
+    addDefaultLocation: true
     Resources:
       Limits:
         Cpu: '0'

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -39,6 +39,7 @@ OpenNMS:
         Memory: '0'
     IngressAnnotations: {}
   Minion:
+    Enabled: true
     addDefaultLocation: true
     Resources:
       Limits:


### PR DESCRIPTION
- Minion: use default location instead of TestLocation
- Helm: Disable Minion by default, enable in Tilt and install-local
- CucumberCommandLineRunner: exit if command line options parsing fails
- InventoryTestSteps: debugging when unexpected locations exist
- InventoryTestSteps: deduplicate LocationData retrieval
- InventoryTestSteps: add @After to clean up minion location if it still exists
- InventoryTestSteps: organize imports

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
