### PR TITLE
Be able to parse Subject/DN generated by cert-manager.

### DIFF
--- a/minion-certificate-verifier/main/src/main/java/org/opennms/horizon/minioncertverifier/parser/BasicDnParser.java
+++ b/minion-certificate-verifier/main/src/main/java/org/opennms/horizon/minioncertverifier/parser/BasicDnParser.java
@@ -50,7 +50,7 @@ public class BasicDnParser implements CertificateDnParser {
         }
 
         try {
-            LdapName name = new LdapName(dn);
+            LdapName name = new LdapName(dn.replaceAll("\\+OU", ",OU"));
             List<String> values = new ArrayList<>();
             for (Rdn rdn : name.getRdns()) {
                 if (type.equals(rdn.getType())) {

--- a/minion-certificate-verifier/main/src/test/java/org/opennms/horizon/minioncertverifier/parser/BasicDnParserTest.java
+++ b/minion-certificate-verifier/main/src/test/java/org/opennms/horizon/minioncertverifier/parser/BasicDnParserTest.java
@@ -44,6 +44,13 @@ public class BasicDnParserTest {
         List<String> values = parser.get(dn, "OU");
         assertThat(values).isNotNull()
             .contains("T:tenant01", "L:LOC01");
+
+        // cert-manager use case
+        dn = "OU=T:tenant01+OU=OpenNMSCloud+OU=L:LOC01,CN=opennms-minion-ssl-gateway,O=OpenNMS,L=TBD,ST=TBD,C=CA";
+
+        values = parser.get(dn, "OU");
+        assertThat(values).isNotNull()
+            .contains("T:tenant01", "L:LOC01");
     }
 
     @Test


### PR DESCRIPTION
## Description

For testing purposes, I use a PKI Layer based on [cert-manager](https://cert-manager.io/), an alternative to the local `minion-certificate-manager`. The problem is that, when adding multiple `OU` fields to the Subject, it is rendered with `+` instead of `,` as a separator confusing the `minion-certificate-validator`.

This small PR contains a patch that will fix the Subject/DN before parse it so it works regardless of what generated the certificate.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
