### PR TITLE
BTO-604: Ensure Keycloak would work in prod-mode.

### DIFF
--- a/charts/lokahi/templates/keycloak/keycloak-deployment.yaml
+++ b/charts/lokahi/templates/keycloak/keycloak-deployment.yaml
@@ -60,11 +60,11 @@ spec:
               value: kubernetes
             - name: KC_CACHE
               value: ispn
-            - name: KC_HOSTNAME
-              value: "{{ .Values.Host }}"
+            - name: KC_HOSTNAME_URL # Required in prod-mod to terminate TLS at Ingress
             {{- if .Values.Keycloak.HostnamePort }}
-            - name: KC_HOSTNAME_PORT
-              value: "{{ .Values.Keycloak.HostnamePort }}"
+              value: "{{ .Values.Protocol }}://{{ .Values.Host }}:{{ .Values.Keycloak.HostnamePort }}{{ .Values.Keycloak.Path }}"
+            {{- else }}
+              value: "{{ .Values.Protocol }}://{{ .Values.Host }}{{ .Values.Keycloak.Path }}"
             {{- end }}
             {{- if .Values.Keycloak.HostnameAdminUrl }}
             - name: KC_HOSTNAME_ADMIN_URL
@@ -99,7 +99,7 @@ spec:
             - name: KC_HTTP_RELATIVE_PATH
               value: "{{ .Values.Keycloak.Path }}"
             - name: KC_PROXY
-              value: passthrough
+              value: edge # Required in prod-mod to terminate TLS at Ingress
             - name: jgroups.dns.query
               value: "{{ .Values.Keycloak.ServiceName }}.{{ .Release.Namespace }}"
             {{- if and .Values.TLS.Enabled .Values.Keycloak.TlsSecretName }}


### PR DESCRIPTION
## Description

By default, Keycloak was forced to be deployed in development mode (despite the `Dockerfile` being ready for both development and production mode). I verified the correct way to configure Keycloak behind a proxy for TLS termination when using production mode and found the following:

* We have to use `KC_HOSTNAME_URL` instead of the combination of `KC_HOSTNAME` and `KC_HOSTNAME_PORT`. If we don't do that, Keycloak won't start properly (tested with 19.x and 20.x).
* `KC_PROXY` must be set to `edge` to ensure that restricted access (enforced by production mode) works when having an Nginx Ingress controller terminating TLS (so we wouldn't need to pass the certificates to Keycloak ever).

Due to how the Helm chart was designed, the best approach I found to fix this while maintaining compatibility with how all the different environments are configured is what this PR brings in. I tested the solution with Tilt (Dev Mode) and a local version of our Fabric environment in Prod Mode, and it works as intended.

<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-604

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
