### PR TITLE
HS-1797: Hide address & coords inputs until map is ready post EAR

### DIFF
--- a/ui/src/components/Locations/LocationsAddForm.vue
+++ b/ui/src/components/Locations/LocationsAddForm.vue
@@ -23,7 +23,8 @@
             <template #pre> <FeatherIcon :icon="icons.Location" /> </template
           ></FeatherInput>
         </div>
-        <div class="row">
+        <!-- Hidden until the map is ready, post-EAR. Tracked with HS-1801 -->
+        <!-- <div class="row">
           <AddressAutocomplete
             :address-model="formInputs"
             class="input-address"
@@ -43,7 +44,7 @@
             class="input-longitude"
             data-test="input-longitude"
           />
-        </div>
+        </div> -->
       </div>
       <FooterSection>
         <template #buttons>

--- a/ui/src/components/Locations/LocationsEditForm.vue
+++ b/ui/src/components/Locations/LocationsEditForm.vue
@@ -35,7 +35,8 @@
             <template #pre><FeatherIcon :icon="icons.Location" /></template
           ></FeatherInput>
         </div>
-        <div class="row">
+        <!-- Hidden until the map is ready, post-EAR. Tracked with HS-1801 -->
+        <!-- <div class="row">
           <AddressAutocomplete
             :addressModel="formInputs"
             class="full-width"
@@ -55,7 +56,7 @@
             class="input-longitude"
             data-test="input-longitude"
           />
-        </div>
+        </div> -->
       </div>
       <div>
         <LocationsCertificateDownload

--- a/ui/tests/Locations/locationsAddForm.test.ts
+++ b/ui/tests/Locations/locationsAddForm.test.ts
@@ -28,15 +28,16 @@ describe('LocationsAddForm', () => {
     expect(elem.exists()).toBeTruthy()
   })
 
-  test('Should have an input longitude', () => {
-    const elem = wrapper.get('[data-test="input-longitude"]')
-    expect(elem.exists()).toBeTruthy()
-  })
+  // Skipped until the map is ready, post-EAR. Tracked with HS-1801
+  // test('Should have an input longitude', () => {
+  //   const elem = wrapper.get('[data-test="input-longitude"]')
+  //   expect(elem.exists()).toBeTruthy()
+  // })
 
-  test('Should have an input latitude', () => {
-    const elem = wrapper.get('[data-test="input-latitude"]')
-    expect(elem.exists()).toBeTruthy()
-  })
+  // test('Should have an input latitude', () => {
+  //   const elem = wrapper.get('[data-test="input-latitude"]')
+  //   expect(elem.exists()).toBeTruthy()
+  // })
 
   test('Should have a save button', () => {
     const elem = wrapper.get('[data-test="save-button"]')

--- a/ui/tests/Locations/locationsEditForm.test.ts
+++ b/ui/tests/Locations/locationsEditForm.test.ts
@@ -28,15 +28,16 @@ describe('LocationsEditForm', () => {
     expect(elem.exists()).toBeTruthy()
   })
 
-  test('Should have an input longitude', () => {
-    const elem = wrapper.get('[data-test="input-longitude"]')
-    expect(elem.exists()).toBeTruthy()
-  })
+  // Skipped until the map is ready, post-EAR. Tracked with HS-1801
+  // test('Should have an input longitude', () => {
+  //   const elem = wrapper.get('[data-test="input-longitude"]')
+  //   expect(elem.exists()).toBeTruthy()
+  // })
 
-  test('Should have an input latitude', () => {
-    const elem = wrapper.get('[data-test="input-latitude"]')
-    expect(elem.exists()).toBeTruthy()
-  })
+  // test('Should have an input latitude', () => {
+  //   const elem = wrapper.get('[data-test="input-latitude"]')
+  //   expect(elem.exists()).toBeTruthy()
+  // })
 
   test('Should have a regenrate key button', () => {
     const elem = wrapper.get('[data-test="revoke-btn"]')


### PR DESCRIPTION
## Description
Hides the address and coordinate inputs on the locations page.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1797

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
