### PR TITLE
HS-1796: Disable editing discovery inputs

### DIFF
--- a/ui/src/components/Discovery/DiscoveryAzureForm.vue
+++ b/ui/src/components/Discovery/DiscoveryAzureForm.vue
@@ -13,6 +13,7 @@
       class="name"
       :schema="nameV"
       data-test="azure-name-input"
+      :disabled="isDisabled"
     />
 
     <div class="row">
@@ -22,6 +23,7 @@
         class="column"
         :schema="clientIdV"
         data-test="azure-client-input"
+        :disabled="isDisabled"
       />
       <FeatherProtectedInput
         v-model="store.azure.clientSecret"
@@ -29,6 +31,7 @@
         class="column"
         :schema="clientSecretV"
         data-test="azure-secret-input"
+        :disabled="isDisabled"
       />
     </div>
 
@@ -39,6 +42,7 @@
         class="column"
         :schema="subIdV"
         data-test="azure-sub-input"
+        :disabled="isDisabled"
       />
       <FeatherInput
         v-model="store.azure.directoryId"
@@ -46,6 +50,7 @@
         class="column"
         :schema="dirIdV"
         data-test="azure-dir-input"
+        :disabled="isDisabled"
       />
     </div>
 
@@ -53,6 +58,7 @@
       @locationSelected="selectLocation"
       class="locations"
       type="single"
+      :disabled="isDisabled"
     />
     <BasicAutocomplete
       class="tags"
@@ -62,6 +68,7 @@
       :label="Common.tagsInput"
       ref="tagsAutocompleteRef"
       :preselectedItems="tags"
+      :disabled="isDisabled"
     />
 
     <div class="buttons">
@@ -105,6 +112,8 @@ const props = defineProps<{
   cancel: () => void
   discovery: AzureActiveDiscovery | null
 }>()
+
+const isDisabled = computed(() => Boolean(props.discovery))
 
 const tags = computed(() => (props.discovery?.id ? discoveryQueries.tagsByActiveDiscoveryId : []))
 

--- a/ui/src/components/Discovery/DiscoveryContentEditable.vue
+++ b/ui/src/components/Discovery/DiscoveryContentEditable.vue
@@ -43,9 +43,10 @@
         v-html="htmlString"
         @keyup="contentChange"
         ref="contentEditableRef"
-        contenteditable="true"
+        :contenteditable="!disabled"
         :id="'contentEditable_' + id"
         class="content-editable"
+        :class="{ 'disabled-editable-content': disabled }"
         @blur="validateContent"
       />
       <span
@@ -110,6 +111,10 @@ const props = defineProps({
   id: {
     type: Number,
     required: true
+  },
+  disabled: {
+    type: Boolean,
+    required: false
   }
 })
 
@@ -249,6 +254,10 @@ defineExpose({
     > .error {
       color: red;
     }
+  }
+
+  > .disabled-editable-content {
+    background: var(variables.$shade-4);
   }
   > .validate-format {
     position: absolute;

--- a/ui/src/components/Discovery/DiscoveryLocationsAutocomplete.vue
+++ b/ui/src/components/Discovery/DiscoveryLocationsAutocomplete.vue
@@ -19,6 +19,7 @@
       @update:modelValue="deboncedFn"
       :schema="locationV"
       ref="inputRef"
+      :disabled="disabled"
     ></FeatherAutocomplete>
 
     <!-- Locations selection -->
@@ -30,6 +31,7 @@
         <span>{{ selectedLocation.location }}</span>
         <template v-slot:icon
           ><FeatherIcon
+            v-if="!disabled"
             @click="removeLocation"
             :icon="Icons.Cancel"
         /></template>
@@ -64,7 +66,8 @@ const errMsgDisplay = ref('none') // for sub text css display
 const computedLocations = computed(() => discoveryQueries.locations)
 
 const props = defineProps<{
-  preLoadedlocation?: string
+  preLoadedlocation?: string,
+  disabled?: boolean
 }>()
 
 onMounted(() => discoveryQueries.getLocations())

--- a/ui/src/components/Discovery/DiscoverySnmpForm.vue
+++ b/ui/src/components/Discovery/DiscoverySnmpForm.vue
@@ -11,12 +11,14 @@
       :label="DiscoverySNMPForm.nameInputLabel"
       class="name-input"
       :schema="nameV"
+      :disabled="isDisabled"
     />
     <DiscoveryLocationsAutocomplete
       class="locations-select"
       type="single"
       :preLoadedlocation="props.discovery?.locationId"
       @location-selected="(loc: MonitoringLocation) => setSnmpConfig('locationId', loc.id)"
+      :disabled="isDisabled"
     />
     <BasicAutocomplete
       @items-selected="tagsSelectedListener"
@@ -27,6 +29,7 @@
       class="tags-autocomplete"
       data-test="tags-autocomplete"
       :preselectedItems="tags"
+      :disabled="isDisabled"
     />
     <div class="content-editable-container">
       <DiscoveryContentEditable
@@ -41,6 +44,7 @@
         :content="props.discovery?.ipAddresses?.join(', ')"
         isRequired
         :id="1"
+        :disabled="isDisabled"
       />
       <DiscoveryContentEditable
         @content-formatted="(val) => setSnmpConfig('snmpConfig.readCommunities', val)"
@@ -52,6 +56,7 @@
         class="community-input"
         :content="props.discovery?.snmpConfig?.readCommunities?.join(', ')"
         :id="2"
+        :disabled="isDisabled"
       />
       <DiscoveryContentEditable
         @content-formatted="(val) => setSnmpConfig('snmpConfig.ports', val)"
@@ -65,6 +70,7 @@
         :tooltipText="Common.tooltipPort"
         :content="props.discovery?.snmpConfig?.ports?.join(', ')"
         :id="3"
+        :disabled="isDisabled"
       />
     </div>
 
@@ -170,6 +176,8 @@ const saveHandler = async () => {
     discoveryInfo.value = {} as IcmpActiveDiscoveryCreateInput
   }
 }
+
+const isDisabled = computed(() => Boolean(props.discovery))
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## Description
Disables editing inputs for ICMP/SNMP and Azure forms. User should still be able to edit passive discoveries.

![screenshot-localhost_3009-2023 07 11-16_19_24](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/1569dc8a-21c7-4153-b541-a7c4e0d505fe)


## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1796

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
