### PR TITLE
Tilt: Allow more time download container images for Helm charts, reduce memory requirements for Jaeger

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -60,8 +60,9 @@ cmd_button(name='reload-helm',
            location=location.NAV,
            icon_name='system_update_alt')
 
-# Give ourselves more time
-update_settings(k8s_upsert_timeout_secs=60)
+# Give ourselves more time -- this needs to include enough time to download container images (cert-manager, nginx, etc.)
+# if we don't have them locally. We try to be nice to people with slower connections.
+update_settings(k8s_upsert_timeout_secs=600)
 if os.getenv('CI'):
     # Be a little bit more aggressive in CI
     update_settings(max_parallel_updates=4)

--- a/tilt-jaeger-values.yaml
+++ b/tilt-jaeger-values.yaml
@@ -17,4 +17,4 @@ query:
 allInOne:
   enabled: true
   args:
-    - --memory.max-traces=10000
+    - --memory.max-traces=1000


### PR DESCRIPTION
- Tilt: Reduce memory requirements for Jaeger
- Tilt: Allow more time download container images for Helm charts

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
