### PR TITLE
HS-1829: Pendo Guides for Minion + Discovery

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -12,6 +12,7 @@
       <Spinner />
       <Snackbar />
       <router-view />
+      <div id="pendo-area"></div>
     </div>
   </FeatherAppLayout>
 </template>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -12,7 +12,7 @@
       <Spinner />
       <Snackbar />
       <router-view />
-      <div id="pendo-area"></div>
+      <div id="pendo-area" style="display:none;"></div>
     </div>
   </FeatherAppLayout>
 </template>

--- a/ui/src/components/Welcome/WelcomeSlideThree.vue
+++ b/ui/src/components/Welcome/WelcomeSlideThree.vue
@@ -9,18 +9,18 @@
             <div class="welcome-slide-three-form">
                 <FeatherInput label="Name" data-test="welcome-slide-three-name-input"
                     :modelValue="welcomeStore.firstDiscovery.name" :error="welcomeStore.firstDiscoveryErrors.name"
-                    @update:modelValue="(e) => welcomeStore.updateFirstDiscovery('name', e)" />
+                    @update:modelValue="(e: string) => welcomeStore.updateFirstDiscovery('name', e)" />
                 <FeatherInput label="Management IPV4" data-test="welcome-slide-three-ip-input"
                     :modelValue="welcomeStore.firstDiscovery.ip" :error="welcomeStore.firstDiscoveryErrors.ip"
-                    @update:modelValue="(e) => welcomeStore.updateFirstDiscovery('ip', e)" />
+                    @update:modelValue="(e: string) => welcomeStore.updateFirstDiscovery('ip', e)" />
                 <FeatherInput label="Community String (optional)" data-test="welcome-slide-three-community-string-input"
                     :modelValue="welcomeStore.firstDiscovery.communityString"
                     :error="welcomeStore.firstDiscoveryErrors.communityString"
-                    @update:modelValue="(e) => welcomeStore.updateFirstDiscovery('communityString', e)" />
+                    @update:modelValue="(e: string) => welcomeStore.updateFirstDiscovery('communityString', e)" />
                 <FeatherInput label="Port (optional)" data-test="welcome-slide-three-port-input"
                     :modelValue="welcomeStore.firstDiscovery.port"
                     :error="welcomeStore.firstDiscoveryErrors.communityString"
-                    @update:modelValue="(e) => welcomeStore.updateFirstDiscovery('port', e)" />
+                    @update:modelValue="(e: string) => welcomeStore.updateFirstDiscovery('port', e)" />
             </div>
 
             <ItemPreview v-if="welcomeStore.discoverySubmitted" :loading="welcomeStore.devicePreview.loading"

--- a/ui/src/components/Welcome/WelcomeSlideThree.vue
+++ b/ui/src/components/Welcome/WelcomeSlideThree.vue
@@ -9,18 +9,18 @@
             <div class="welcome-slide-three-form">
                 <FeatherInput label="Name" data-test="welcome-slide-three-name-input"
                     :modelValue="welcomeStore.firstDiscovery.name" :error="welcomeStore.firstDiscoveryErrors.name"
-                    @update:modelValue="(e: string) => welcomeStore.updateFirstDiscovery('name', e)" />
+                    @update:modelValue="(e) => welcomeStore.updateFirstDiscovery('name', e)" />
                 <FeatherInput label="Management IPV4" data-test="welcome-slide-three-ip-input"
                     :modelValue="welcomeStore.firstDiscovery.ip" :error="welcomeStore.firstDiscoveryErrors.ip"
-                    @update:modelValue="(e: string) => welcomeStore.updateFirstDiscovery('ip', e)" />
+                    @update:modelValue="(e) => welcomeStore.updateFirstDiscovery('ip', e)" />
                 <FeatherInput label="Community String (optional)" data-test="welcome-slide-three-community-string-input"
                     :modelValue="welcomeStore.firstDiscovery.communityString"
                     :error="welcomeStore.firstDiscoveryErrors.communityString"
-                    @update:modelValue="(e: string) => welcomeStore.updateFirstDiscovery('communityString', e)" />
+                    @update:modelValue="(e) => welcomeStore.updateFirstDiscovery('communityString', e)" />
                 <FeatherInput label="Port (optional)" data-test="welcome-slide-three-port-input"
                     :modelValue="welcomeStore.firstDiscovery.port"
                     :error="welcomeStore.firstDiscoveryErrors.communityString"
-                    @update:modelValue="(e: string) => welcomeStore.updateFirstDiscovery('port', e)" />
+                    @update:modelValue="(e) => welcomeStore.updateFirstDiscovery('port', e)" />
             </div>
 
             <ItemPreview v-if="welcomeStore.discoverySubmitted" :loading="welcomeStore.devicePreview.loading"

--- a/ui/src/services/pendoService.ts
+++ b/ui/src/services/pendoService.ts
@@ -1,0 +1,59 @@
+/**
+ * Pendo Service
+ * 
+ * Pendo offers an API in order to trigger certain events, but this method
+ * allows our Pendo team to activate items on their end.
+ * Everything they do is based on changes to the page, so we add/remove elements 
+ * from the page when we want them to show up.
+ */
+
+
+/**
+ * 
+ * @param id id to add to div
+ */
+const addDivToPendoAreaWithID = (id: string) => {
+    const pendoArea = document.querySelector('#pendo-area');
+    const idWithHash = id.includes('#') ? id : '#' + id;
+
+    if (pendoArea) {
+        const existingOption = pendoArea.querySelector(idWithHash)
+        if (!existingOption) {
+            const newDiv = document.createElement('div');
+            newDiv.id = id.replace('#', '');
+            pendoArea.appendChild(newDiv)
+        }
+    }
+}
+/**
+ * 
+ * @param id for element to remove from pendo area
+ */
+const removeDivFromPendoAreaWithID = (id: string) => {
+    const pendoArea = document.querySelector('#pendo-area');
+    const idWithHash = id.includes('#') ? id : '#' + id;
+    if (pendoArea) {
+        const element = pendoArea.querySelector(idWithHash)
+        if (element) {
+            element.remove();
+        }
+    }
+}
+
+const minionHelpId = 'minion-help-guide'
+export const activateMinionHelpGuide = () => {
+    addDivToPendoAreaWithID(minionHelpId)
+}
+
+export const disableMinionHelpGuide = () => {
+    removeDivFromPendoAreaWithID(minionHelpId)
+}
+
+const discoveryHelpId = 'discovery-help-guide'
+export const activateDiscoveryHelpGuide = () => {
+    addDivToPendoAreaWithID(discoveryHelpId)
+}
+
+export const disableDiscoveryHelpGuide = () => {
+    removeDivFromPendoAreaWithID(discoveryHelpId)
+}

--- a/ui/src/services/pendoService.ts
+++ b/ui/src/services/pendoService.ts
@@ -21,6 +21,7 @@ const addDivToPendoAreaWithID = (id: string) => {
         if (!existingOption) {
             const newDiv = document.createElement('div');
             newDiv.id = id.replace('#', '');
+            newDiv.innerText = '1';
             pendoArea.appendChild(newDiv)
         }
     }


### PR DESCRIPTION
## Description
Bonnie needed some additional support for Pendo and triggering guides in certain situations.

I've added a PendoService to the project, that is a standardized way of adding <div> tags to a <div> at the root of the project with id 'pendo-area.' The idea here is that you use our new pendo service to add/remove Divs (with a value of 1) to the pendo area, which should be enough for Bonnie to activate/de-activate anything within Pendo.

If this process works (we need the code to be in Dev to even try), we will probably push an additional update for the Resource Center in another ticket, so that Bonnie can trigger it for every page aside for the welcome guide and login.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1829

## Flagged for review
It's tough to test this one, as there's a 3 and 10 minute timeout involved, and then all it does is add a div to the page (which won't trigger anything locally). If the Divs show up though, that's enough for a successful test for now. There should be no visual changes for this change.

## Checklist
* [X] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
