### PR TITLE
HS-1836: Stop tilt-helm-values from removing all OpenNMS.UI.IngressAnnotation settings

### DIFF
--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -37,7 +37,8 @@ OpenNMS:
       Requests:
         Cpu: '0'
         Memory: '0'
-    IngressAnnotations: ~
+    IngressAnnotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: ~
   Minion:
     Enabled: true
     addDefaultLocation: true


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
The setting 'add_header X-Frame-Options sameorigin;' needed to be removed from nginx.ingress.kubernetes.io/configuration-snippet to get the local dev server working. tilt-helm-values was changed to remove ALL IngressAnnotations, which caused a problem due to missing settings.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1836

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
