### PR TITLE
HS-1819: Fix multiple modal loc delete

### DIFF
--- a/ui/src/components/Common/DeleteConfirmationModal.vue
+++ b/ui/src/components/Common/DeleteConfirmationModal.vue
@@ -18,7 +18,7 @@
       <ButtonWithSpinner
         data-test="delete-btn"
         primary
-        :click="deleteHandler"
+        :click="deleteAndCloseModal"
         :isFetching="isDeleting"
       >
         Delete
@@ -28,11 +28,16 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
-  name: string
+const props = defineProps<{
+  name?: string
   isVisible: boolean
-  deleteHandler: (...p: any) => any
+  deleteHandler: (...p: any) => Promise<any>
   closeModal: () => void
-  isDeleting: boolean
+  isDeleting?: boolean
 }>()
+
+const deleteAndCloseModal = async () => {
+  await props.deleteHandler()
+  props.closeModal()
+} 
 </script>

--- a/ui/src/components/Locations/LocationsCard.vue
+++ b/ui/src/components/Locations/LocationsCard.vue
@@ -33,13 +33,6 @@
       />
     </div>
   </div>
-  <DeleteConfirmationModal
-    :isVisible="isVisible"
-    :name="item.location!"
-    :closeModal="() => closeModal()"
-    :deleteHandler="() => deleteLocation()"
-    :isDeleting="locationStore.isDeleting"
-  />
 </template>
 
 <script lang="ts" setup>
@@ -49,13 +42,12 @@ import { Severity } from '@/types/graphql'
 import { LocationTemp } from '@/types/locations.d'
 import { useLocationStore } from '@/store/Views/locationStore'
 import { useMinionsQueries } from '@/store/Queries/minionsQueries'
-import useModal from '@/composables/useModal'
 
 const props = defineProps<{
-  item: LocationTemp
+  item: LocationTemp,
+  openModalForDelete: (item: LocationTemp) => void
 }>()
 
-const { openModal, closeModal, isVisible } = useModal()
 const locationStore = useLocationStore()
 const minionsQueries = useMinionsQueries()
 
@@ -72,14 +64,9 @@ const statusPill = {
   style: props.item.status === 'UP' ? Severity.Normal : Severity.Critical
 }
 
-const deleteLocation = async () => {
-  await locationStore.deleteLocation(props.item.id)
-  await minionsQueries.refreshMinionsById()
-}
-
 const contextMenuItems = [
   { label: 'Edit', handler: () => locationStore.selectLocation(props.item.id) },
-  { label: 'Delete', handler: () => openModal() }
+  { label: 'Delete', handler: () => props.openModalForDelete(props.item) }
 ]
 
 const icons = markRaw({

--- a/ui/src/components/Locations/LocationsList.vue
+++ b/ui/src/components/Locations/LocationsList.vue
@@ -41,23 +41,53 @@
           :key="index"
           data-test="card"
         >
-          <LocationsCard :item="item" />
+          <LocationsCard :item="item" :openModalForDelete="openModalForDelete" />
         </li>
       </ul>
     </div>
   </div>
+  <DeleteConfirmationModal
+    :isVisible="isVisible"
+    :name="locationToDelete?.location"
+    :closeModal="() => closeModal()"
+    :deleteHandler="() => deleteLocation()"
+    :isDeleting="locationStore.isDeleting"
+  />
 </template>
 
 <script setup lang="ts">
 import HeadlineSection from '@/components/Common/HeadlineSection.vue'
 import Help from '@featherds/icon/action/Help'
 import { LocationTemp } from '@/types/locations.d'
+import useModal from '@/composables/useModal'
+import { useLocationStore } from '@/store/Views/locationStore'
+import { useMinionsQueries } from '@/store/Queries/minionsQueries'
+import { MonitoringLocation } from '@/types/graphql'
 
 const props = defineProps<{
   items: LocationTemp[]
 }>()
 
+defineEmits(['show-instructions'])
+
+const locationStore = useLocationStore()
+const minionsQueries = useMinionsQueries()
+const { openModal, closeModal, isVisible } = useModal()
+
+const locationToDelete = ref<MonitoringLocation>()
 const locationsList = computed(() => props.items)
+
+const deleteLocation = async () => {
+  if (locationToDelete.value) {
+    await locationStore.deleteLocation(locationToDelete.value.id)
+    await minionsQueries.refreshMinionsById()
+  }
+}
+
+const openModalForDelete = (item: MonitoringLocation) => {
+  locationToDelete.value = item
+  openModal()
+}
 
 const icons = markRaw({
   Help


### PR DESCRIPTION
## Description
Fixes an issue where the delete modal stays open and asks if you want to delete the next location in the list.
The main issue here was that multiple DeleteConfirmationModal components were rendering because of a v-for loop. This PR moves the comp to the parent, out of the loop, but does mean we need to pass up which item to delete.

[screencast-localhost_3009-2023.07.19-13_10_25.webm](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/af2dc6d3-33bf-443c-b948-b9f69942e643)


## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1819

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
