### PR TITLE
HS-1833: Fix steps for application series query

### DIFF
--- a/ui/src/components/Flows/LineChart.vue
+++ b/ui/src/components/Flows/LineChart.vue
@@ -50,6 +50,10 @@ const props = defineProps({
   format: {
     required: true,
     type: Function as PropType<(val: string) => string>
+  },
+  getChartAreaWidthForDataPoints: {
+    required: true,
+    type: Function as PropType<(width: number) => void>
   }
 })
 const lineChart = ref()
@@ -148,6 +152,14 @@ onThemeChange(() => {
   chartOptions.value.plugins.legend.labels.color = isDark.value ? 'rgba(10, 12, 27, .9)' : '#000000'
 })
 
+const getChartAreaWidth = () => {
+  if (lineChart.value?.chart) {
+    props.getChartAreaWidthForDataPoints(lineChart.value.chart.chartArea.width)
+  }
+}
+
+onMounted(() => getChartAreaWidth())
+useResizeObserver(lineChart, () => getChartAreaWidth())
 
 defineExpose({
   downloadChart

--- a/ui/src/containers/Flows.vue
+++ b/ui/src/containers/Flows.vue
@@ -143,6 +143,7 @@
         :chart-data="appStore.lineChartData"
         :table-data="appStore.tableData"
         :format="flowsStore.convertToDate"
+        :get-chart-area-width-for-data-points="setMaxDataPointsAndUpdateCharts"
       />
       <div
         v-if="
@@ -242,6 +243,13 @@ const timeOptions = ref([
 const isDrawerOpen = ref(false)
 const toggleDrawer = () => {
   isDrawerOpen.value = !isDrawerOpen.value
+}
+
+const setMaxDataPointsAndUpdateCharts = (width: number) => {
+  if (width && width !== flowsStore.filters.maxDataPoints) {
+    flowsStore.filters.maxDataPoints = width
+    flowsStore.updateApplicationCharts()
+  }
 }
 
 onUnmounted(() => flowsStore.$reset)

--- a/ui/src/store/Views/flowsApplicationStore.ts
+++ b/ui/src/store/Views/flowsApplicationStore.ts
@@ -123,8 +123,8 @@ export const useFlowsApplicationStore = defineStore('flowsApplicationStore', {
               borderColor: flowsStore.randomColours(index),
               backgroundColor: flowsStore.randomColours(index, true),
               // hide the last point, which tracks the gap between the previous point and now
-              pointRadius: Array.from(Array(mappedData.length).keys()).map((_, index) => element.data.length === index ? 0 : 3),
-              spanGaps: 1000 * 60 * 5 // no line over 5+ minute gaps
+              pointRadius: Array.from(Array(mappedData.length).keys()).map((_, index) => element.data.length === index ? 0 : 1),
+              spanGaps: flowsStore.getSpanGap()
             }
           })
         }
@@ -154,7 +154,7 @@ export const useFlowsApplicationStore = defineStore('flowsApplicationStore', {
       flowsStore.filters.dateFilter = TimeRange.Last_24Hours
       const exporter = get(flowsStore.filters.selectedExporterTopApplication, 'value') as IExporter
       const exporters: IExporter[] = exporter ? [exporter] : []
-      const requestData = flowsStore.getRequestData(10, 2000000, exporters, [])
+      const requestData = flowsStore.getRequestData(10, exporters, [])
 
       const topApplications = await flowsQueries.getApplicationsSummaries(requestData)
       flowsStore.topApplications = [

--- a/ui/tests/Dashboard/dashboardApplication.test.ts
+++ b/ui/tests/Dashboard/dashboardApplication.test.ts
@@ -20,7 +20,6 @@ setActiveClient(
 const timeRange = { startTime: 1682025158863, endTime: 1682111558863 }
 const filterValuesMock = {
   count: 10,
-  step: 2000000,
   exporter: [{ nodeId: 1, ipInterfaceId: 1 }],
   timeRange,
   applications: []

--- a/ui/tests/Flows/flows.test.ts
+++ b/ui/tests/Flows/flows.test.ts
@@ -117,11 +117,36 @@ describe('Flows', () => {
     appStore.createApplicationLineChartData()
     expect(appStore.lineChartData.datasets.length).toBe(2)
   })
+
   test('The Flows store createTableChart should populate TableGraphData', () => {
     appStore.tableChartData = { labels: [], datasets: [] }
     expect(appStore.tableChartData.datasets.length).toBe(0)
     appStore.tableData = TableGraphData
     appStore.createApplicationTableChartData()
     expect(appStore.tableChartData.datasets.length).toBe(2)
+  })
+
+  test('The step from the getRequestData function returns properly', () => {
+    const store = useFlowsStore()
+    const testDataPoints = 500
+    store.filters.maxDataPoints = testDataPoints
+    const data = store.getRequestData(10, [], [])
+    const startTime = new Date(new Date().setHours(0, 0, 0, 0)).getTime()
+    const result = Math.floor((Date.now() - startTime) / testDataPoints)
+
+    // helps prevent flakiness from exact ms match
+    const lowerResult = result - 5
+    const upperResult = result + 5
+    expect(data.step).toBeGreaterThan(lowerResult)
+    expect(data.step).toBeLessThan(upperResult)
+  })
+
+  test('The span gap fn', () => {
+    const store = useFlowsStore()
+    let spanGap = store.getSpanGap()
+    expect(spanGap).toBe(300000)
+    store.filters.dateFilter = TimeRange.SevenDays
+    spanGap = store.getSpanGap()
+    expect(spanGap).toBe(3600000)
   })
 })


### PR DESCRIPTION
## Description
Step property was hardcoded to 2000000, which creates an interval of about 33 mins.

Grafana makes use of the `maxDataPoints` property which is tied to pixel width: _"The default value is the width (or number of pixels) of the graph, because you can only visualize as many data points as the graph panel has room to display."_

This PR grabs the width of the chart using the Chart.js chartArea property, then calculates the step with the formula `Math.floor((endTime - startTime) / maxDataPoints)`. Time is in ms here.  This formula is the same used in the grafana plugin.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1833

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
