### PR TITLE
HS-1485: Refactor Alert Service Cucumber Tests

### DIFF
--- a/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/AlertTestSteps.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/AlertTestSteps.java
@@ -40,6 +40,7 @@ import io.restassured.config.RestAssuredConfig;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.opennms.horizon.alerts.proto.Alert;
@@ -52,21 +53,20 @@ import org.opennms.horizon.alerts.proto.TimeRangeFilter;
 import org.opennms.horizon.alertservice.AlertGrpcClientUtils;
 import org.opennms.horizon.alertservice.RetryUtils;
 import org.opennms.horizon.alertservice.kafkahelper.KafkaTestHelper;
-import org.opennms.horizon.events.proto.Event;
-import org.opennms.horizon.events.proto.EventLog;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@RequiredArgsConstructor
 @Slf4j
 public class AlertTestSteps {
 
@@ -75,10 +75,11 @@ public class AlertTestSteps {
     //
     // Test Injectables
     //
-    private RetryUtils retryUtils;
-    private KafkaTestHelper kafkaTestHelper;
-    private AlertGrpcClientUtils clientUtils;
-    private BackgroundSteps background;
+    private final TenantSteps tenantSteps;
+    private final RetryUtils retryUtils;
+    private final KafkaTestHelper kafkaTestHelper;
+    private final AlertGrpcClientUtils clientUtils;
+    private final BackgroundSteps background;
 
     //
     // Test Runtime Data
@@ -87,186 +88,55 @@ public class AlertTestSteps {
     private JsonPath parsedJsonResponse;
     private List<Alert> alertsFromLastResponse;
     private Alert firstAlertFromLastResponse;
-    private Long lastAlertId;
-    private String testAlertReductionKey;
-
-//========================================
-// Constructor
-//----------------------------------------
-
-    public AlertTestSteps(RetryUtils retryUtils, KafkaTestHelper kafkaTestHelper, AlertGrpcClientUtils clientUtils, BackgroundSteps bgSteps) {
-        this.retryUtils = retryUtils;
-        this.kafkaTestHelper = kafkaTestHelper;
-        this.clientUtils = clientUtils;
-        this.background = bgSteps;
-        initKafka();
-    }
-
-    private void initKafka() {
-        kafkaTestHelper.setKafkaBootstrapUrl(background.getKafkaBootstrapUrl());
-        kafkaTestHelper.startConsumerAndProducer(background.getEventTopic(), background.getEventTopic());
-        kafkaTestHelper.startConsumerAndProducer(background.getAlertTopic(), background.getAlertTopic());
-    }
 
     @After
     public void cleanData() {
         log.info("clean alert data");
-        if(alertsFromLastResponse != null) {
-            alertsFromLastResponse.forEach(alert -> {
-                clientUtils.getAlertServiceStub()
-                    .deleteAlert(AlertRequest.newBuilder().addAlertId(alert.getDatabaseId()).build());
-            });
+        if (alertsFromLastResponse != null) {
+            alertsFromLastResponse.forEach(alert -> clientUtils.getAlertServiceStub().deleteAlert(
+                AlertRequest.newBuilder().addAlertId(alert.getDatabaseId()).build())
+            );
         }
     }
 
     //========================================
     // Gherkin Rules
     //========================================
-    @Then("Send event with UEI {string} with tenant {string} with node {int}")
-    public void sendMessageToKafkaAtTopicWithSeverity(String eventUei, String tenantId, int nodeId) {
-        EventLog eventLog = EventLog.newBuilder()
-            .setTenantId(tenantId)
-            .addEvents(Event.newBuilder()
-                .setTenantId(tenantId)
-                .setProducedTimeMs(System.currentTimeMillis())
-                .setNodeId(nodeId)
-                .setUei(eventUei))
-            .build();
-
-        kafkaTestHelper.sendToTopic(background.getEventTopic(), eventLog.toByteArray(), tenantId);
+    @Then("List alerts for the tenant, until JSON response matches the following JSON path expressions")
+    public void listAlertsForTenant(List<String> expectedJson) throws InterruptedException {
+        listAlertsForTenant(tenantSteps.getTenantId(), (int) Duration.ofSeconds(5).toMillis(), expectedJson);
     }
 
-    @Then("Send event with UEI {string} with tenant {string} with node {int} at {long} minutes ago")
-    public void sendMessageToKafkaAtTopicWithMockedTime(String eventUei, String tenantId, int nodeId, long minutes) {
-        long current = System.currentTimeMillis();
-        long eventTime = current - (minutes * 60000L);
-
-        EventLog eventLog = EventLog.newBuilder()
-            .setTenantId(tenantId)
-            .addEvents(Event.newBuilder()
-                .setTenantId(tenantId)
-                .setProducedTimeMs(eventTime)
-                .setNodeId(nodeId)
-                .setUei(eventUei))
-            .build();
-
-        kafkaTestHelper.sendToTopic(background.getEventTopic(), eventLog.toByteArray(), tenantId);
-    }
-
-    @Then("Send event with UEI {string} with tenant {string} with node {int} with produced time 23h ago")
-    public void sendMessageToKafkaAtTopicYesterday(String eventUei, String tenantId, int nodeId) {
-        EventLog eventLog = EventLog.newBuilder()
-            .setTenantId(tenantId)
-            .addEvents(Event.newBuilder()
-                .setTenantId(tenantId)
-                .setProducedTimeMs(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(23))
-                .setNodeId(nodeId)
-                .setUei(eventUei))
-            .build();
-
-        kafkaTestHelper.sendToTopic(background.getEventTopic(), eventLog.toByteArray(), tenantId);
-    }
-
-    @Then("Send event with UEI {string} with tenant {string} with node {int} with with produced time 1h ago")
-    public void sendMessageToKafkaAtTopic1hAgo(String eventUei, String tenantId, int nodeId) {
-        EventLog eventLog = EventLog.newBuilder()
-            .setTenantId(tenantId)
-            .addEvents(Event.newBuilder()
-                .setTenantId(tenantId)
-                .setProducedTimeMs(System.currentTimeMillis() - TimeUnit.HOURS.toMillis(1))
-                .setNodeId(nodeId)
-                .setUei(eventUei))
-            .build();
-
-        kafkaTestHelper.sendToTopic(background.getEventTopic(), eventLog.toByteArray(), tenantId);
-    }
-
-    @Then("Send event with UEI {string} with tenant {string} with node {int} with produced time 8 days ago")
-    public void sendMessageToKafkaAtTopicLastWeek(String eventUei, String tenantId, int nodeId) {
-        EventLog eventLog = EventLog.newBuilder()
-            .setTenantId(tenantId)
-            .addEvents(Event.newBuilder()
-                .setTenantId(tenantId)
-                .setProducedTimeMs(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8))
-                .setNodeId(nodeId)
-                .setUei(eventUei))
-            .build();
-
-        kafkaTestHelper.sendToTopic(background.getEventTopic(), eventLog.toByteArray(), tenantId);
-    }
-
-    @Then("Send event with UEI {string} with tenant {string} with node {int} with produced time last month")
-    public void sendMessageToKafkaAtTopicLastMonth(String eventUei, String tenantId, int nodeId) {
-        EventLog eventLog = EventLog.newBuilder()
-            .setTenantId(tenantId)
-            .addEvents(Event.newBuilder()
-                .setTenantId(tenantId)
-                .setProducedTimeMs(System.currentTimeMillis() - 30L * 24 * 60 * 60 * 1000)
-                .setNodeId(nodeId)
-                .setUei(eventUei))
-            .build();
-
-        kafkaTestHelper.sendToTopic(background.getEventTopic(), eventLog.toByteArray(), tenantId);
+    @Then("List alerts for the tenant, with timeout {int}ms, until JSON response matches the following JSON path expressions")
+    public void listAlertsForTenant(int timeout, List<String> expectedJson) throws InterruptedException {
+        listAlertsForTenant(tenantSteps.getTenantId(), timeout, expectedJson);
     }
 
     @Then("List alerts for tenant {string}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
-    public void listAlertsForTenant(String tenantId, int timeout, List<String> jsonPathExpressions) throws Exception {
-        log.info("List for tenant {}, timeout {}ms, data {}", tenantId, timeout, jsonPathExpressions);
-        Supplier<MessageOrBuilder> call = () -> {
-            clientUtils.setTenantId(tenantId);
-            ListAlertsResponse listAlertsResponse = clientUtils.getAlertServiceStub()
-                .listAlerts(ListAlertsRequest.newBuilder().setSortBy("id").setSortAscending(true).build());
-            alertsFromLastResponse = listAlertsResponse.getAlertsList();
-            return listAlertsResponse;
-        };
-        boolean success = retryUtils.retry(
-            () -> this.doRequestThenCheckJsonPathMatch(call, jsonPathExpressions),
-            result -> result,
-            100,
-            timeout,
-            false);
-        assertTrue("GET request expected to return JSON response matching JSON path expression(s)", success);
-    }
-
-    @Then("List alerts for tenant {string} and label {string}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
-    public void listAlertsForTenantByNode(String tenantId, String label,  int timeout, List<String> jsonPathExpressions) throws Exception {
-        log.info("List for tenant {}, label {}, timeout {}ms, data {}", tenantId, label, timeout, jsonPathExpressions);
-        Supplier<MessageOrBuilder> call = () -> {
-            clientUtils.setTenantId(tenantId);
-            Filter filter = Filter.newBuilder().setNodeLabel(label).build();
-            ListAlertsResponse listAlertsResponse = clientUtils.getAlertServiceStub()
-                .listAlerts(ListAlertsRequest.newBuilder().addFilters(filter).setSortBy("id").setSortAscending(true).build());
-            alertsFromLastResponse = listAlertsResponse.getAlertsList();
-            return listAlertsResponse;
-        };
-        boolean success = retryUtils.retry(
-            () -> this.doRequestThenCheckJsonPathMatch(call, jsonPathExpressions),
-            result -> result,
-            100,
-            timeout,
-            false);
-        assertTrue("GET request expected to return JSON response matching JSON path expression(s)", success);
-    }
-
-    @Then("List alerts for tenant {string} with hours {long}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
-    public void listAlertsForTenantFilteredByTime(String tenantId, long hours, int timeout, List<String> jsonPathExpressions) throws Exception {
-        final var request = ListAlertsRequest.newBuilder();
-        request.setSortBy("id")
+    public void listAlertsForTenant(String tenantId, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
+        var requestBuilder = ListAlertsRequest.newBuilder()
+            .setSortBy("id")
             .setSortAscending(true);
-        getTimeRangeFilter(hours, request);
-        Supplier<MessageOrBuilder> call = () -> {
-            clientUtils.setTenantId(tenantId);
-            ListAlertsResponse listAlertsResponse = clientUtils.getAlertServiceStub().listAlerts(request.build());
-            alertsFromLastResponse = listAlertsResponse.getAlertsList();
-            return listAlertsResponse;
-        };
-        boolean success = retryUtils.retry(
-            () -> this.doRequestThenCheckJsonPathMatch(call, jsonPathExpressions),
-            result -> result,
-            100,
-            timeout,
-            false);
-        assertTrue("GET request expected to return JSON response matching JSON path expression(s)", success);
+        listAlertsForTenant(tenantId, timeout, jsonPathExpressions, requestBuilder);
+    }
+
+    @Then("List alerts for the tenant and label {string}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
+    public void listAlertsForTenantByNode(String label, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
+        var filter = Filter.newBuilder().setNodeLabel(label).build();
+        var requestBuilder = ListAlertsRequest.newBuilder()
+            .addFilters(filter)
+            .setSortBy("id")
+            .setSortAscending(true);
+        listAlertsForTenant(tenantSteps.getTenantId(), timeout, jsonPathExpressions, requestBuilder);
+    }
+
+    @Then("List alerts for the tenant with hours {long}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
+    public void listAlertsForTenantFilteredByTime(long hours, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
+        var requestBuilder = ListAlertsRequest.newBuilder()
+            .setSortBy("id")
+            .setSortAscending(true);
+        getTimeRangeFilter(hours, requestBuilder);
+        listAlertsForTenant(tenantSteps.getTenantId(), timeout, jsonPathExpressions, requestBuilder);
     }
 
     @Then("Delete the alert")
@@ -301,9 +171,14 @@ public class AlertTestSteps {
         assertTrue("GET request expected to return JSON response matching JSON path expression(s)", success);
     }
 
+    @Then("Verify alert topic has {int} messages for the tenant")
+    public void verifyTopicContainsTenant(int expectedMessages) throws InterruptedException {
+        verifyTopicContainsTenant(expectedMessages, tenantSteps.getTenantId());
+    }
+
     @Then("Verify alert topic has {int} messages with tenant {string}")
     public void verifyTopicContainsTenant(int expectedMessages, String tenant) throws InterruptedException {
-         boolean success = retryUtils.retry(
+        boolean success = retryUtils.retry(
             () -> this.checkNumberOfMessageForOneTenant(tenant, expectedMessages),
             result -> result,
             100,
@@ -322,90 +197,59 @@ public class AlertTestSteps {
         }
     }
 
-    @Then("List alerts for tenant {string} with page size {int}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
-    public void listAlertsForTenantWithPageSize(String tenantId, int pageSize, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
-        Supplier<MessageOrBuilder> call = () -> {
-            clientUtils.setTenantId(tenantId);
-            ListAlertsResponse listAlertsResponse = clientUtils.getAlertServiceStub()
-                .listAlerts(ListAlertsRequest.newBuilder().setPageSize(pageSize).build());
-            alertsFromLastResponse = listAlertsResponse.getAlertsList();
-            return listAlertsResponse;
-        };
-        boolean success = retryUtils.retry(
-            () -> this.doRequestThenCheckJsonPathMatch(call, jsonPathExpressions),
-            result -> result,
-            100,
-            timeout,
-            false);
-        assertTrue("GET request expected to return JSON response matching JSON path expression(s)", success);
+    @Then("List alerts for the tenant with page size {int}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
+    public void listAlertsForTenantWithPageSize(int pageSize, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
+        var requestBuilder = ListAlertsRequest.newBuilder().setPageSize(pageSize);
+        listAlertsForTenant(tenantSteps.getTenantId(), timeout, jsonPathExpressions, requestBuilder);
     }
 
-    @Then("List alerts for tenant {string} sorted by {string} ascending {string}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
-    public void listAlertsForTenantSorted(String tenantId, String filter, String ascending, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
-        Supplier<MessageOrBuilder> call = () -> {
-            clientUtils.setTenantId(tenantId);
-            ListAlertsResponse listAlertsResponse = clientUtils.getAlertServiceStub()
-                .listAlerts(ListAlertsRequest.newBuilder().setSortBy(filter).setSortAscending(Boolean.parseBoolean(ascending)).build());
-            alertsFromLastResponse = listAlertsResponse.getAlertsList();
-            return listAlertsResponse;
-        };
-        boolean success = retryUtils.retry(
-            () -> this.doRequestThenCheckJsonPathMatch(call, jsonPathExpressions),
-            result -> result,
-            100,
-            timeout,
-            false);
-        assertTrue("GET request expected to return JSON response matching JSON path expression(s)", success);
+    @Then("List alerts for the tenant sorted by {string} ascending {string}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
+    public void listAlertsForTenantSorted(String filter, String ascending, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
+        var requestBuilder = ListAlertsRequest.newBuilder()
+            .setSortBy(filter)
+            .setSortAscending(Boolean.parseBoolean(ascending));
+        listAlertsForTenant(tenantSteps.getTenantId(), timeout, jsonPathExpressions, requestBuilder);
     }
 
-    @Then("List alerts for tenant {string} filtered by severity {string}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
-    public void listAlertsForTenantFilteredBySeverityWithTimeoutMsUntilJSONResponseMatchesTheFollowingJSONPathExpressions(String tenantId, String severity, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
-        Supplier<MessageOrBuilder> call = () -> {
-            clientUtils.setTenantId(tenantId);
-            ListAlertsResponse listAlertsResponse = clientUtils.getAlertServiceStub()
-                .listAlerts(ListAlertsRequest.newBuilder().addFilters(Filter.newBuilder().setSeverity(Severity.valueOf(severity)).build()).build());
-            alertsFromLastResponse = listAlertsResponse.getAlertsList();
-            return listAlertsResponse;
-        };
-        boolean success = retryUtils.retry(
-            () -> this.doRequestThenCheckJsonPathMatch(call, jsonPathExpressions),
-            result -> result,
-            100,
-            timeout,
-            false);
-        assertTrue("GET request expected to return JSON response matching JSON path expression(s)", success);
+    @Then("List alerts for the tenant filtered by severity {string}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
+    public void listAlertsForTenantFilteredBySeverity(String severity, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
+        Filter filter = Filter.newBuilder().setSeverity(Severity.valueOf(severity)).build();
+        var requestBuilder = ListAlertsRequest.newBuilder()
+            .addFilters(filter);
+        listAlertsForTenant(tenantSteps.getTenantId(), timeout, jsonPathExpressions, requestBuilder);
     }
 
-    @Then("List alerts for tenant {string} filtered by severity {string} and {string}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
-    public void listAlertsForTenantFilteredBySeverityWithTimeoutMsUntilJSONResponseMatchesTheFollowingJSONPathExpressions(String tenantId, String severity, String severity2, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
-        Supplier<MessageOrBuilder> call = () -> {
-            clientUtils.setTenantId(tenantId);
-            ListAlertsResponse listAlertsResponse = clientUtils.getAlertServiceStub()
-                .listAlerts(ListAlertsRequest.newBuilder()
-                    .addFilters(Filter.newBuilder().setSeverity(Severity.valueOf(severity)).build())
-                    .addFilters(Filter.newBuilder().setSeverity(Severity.valueOf(severity2)).build())
-                    .setSortBy("id").setSortAscending(true).build());
-            alertsFromLastResponse = listAlertsResponse.getAlertsList();
-            return listAlertsResponse;
-        };
-        boolean success = retryUtils.retry(
-            () -> this.doRequestThenCheckJsonPathMatch(call, jsonPathExpressions),
-            result -> result,
-            100,
-            timeout,
-            false);
-        assertTrue("GET request expected to return JSON response matching JSON path expression(s)", success);
+    @Then("List alerts for the tenant filtered by severity {string} and {string}, with timeout {int}ms, until JSON response matches the following JSON path expressions")
+    public void listAlertsForTenantFilteredBySeverities(
+        String severity, String severity2, int timeout, List<String> jsonPathExpressions
+    ) throws InterruptedException {
+        var requestBuilder = ListAlertsRequest.newBuilder()
+            .addFilters(Filter.newBuilder().setSeverity(Severity.valueOf(severity)).build())
+            .addFilters(Filter.newBuilder().setSeverity(Severity.valueOf(severity2)).build())
+            .setSortBy("id").setSortAscending(true);
+        listAlertsForTenant(tenantSteps.getTenantId(), timeout, jsonPathExpressions, requestBuilder);
     }
 
-    @Then("List alerts for tenant {string} today , with timeout {int}ms, until JSON response matches the following JSON path expressions")
-    public void listAlertsForTenantTodayWithTimeoutMsUntilJSONResponseMatchesTheFollowingJSONPathExpressions(String tenantId, int timeout, List<String> jsonPathExpressions) throws InterruptedException {
-        final var request = ListAlertsRequest.newBuilder();
-        request.setSortBy("id")
+    @Then("List alerts for the tenant today, with timeout {int}ms, until JSON response matches the following JSON path expressions")
+    public void listAlertsForTenantToday(int timeout, List<String> jsonPathExpressions) throws InterruptedException {
+        final var requestBuilder = ListAlertsRequest.newBuilder()
+            .setSortBy("id")
             .setSortAscending(true);
-        getTimeRangeFilter(LocalTime.MIDNIGHT.until(LocalTime.now(), ChronoUnit.HOURS), request);
+        getTimeRangeFilter(LocalTime.MIDNIGHT.until(LocalTime.now(), ChronoUnit.HOURS), requestBuilder);
+        listAlertsForTenant(tenantSteps.getTenantId(), timeout, jsonPathExpressions, requestBuilder);
+    }
+
+    public void listAlertsForTenant(
+        String tenantId,
+        int timeout,
+        List<String> jsonPathExpressions,
+        ListAlertsRequest.Builder requestBuilder
+    ) throws InterruptedException {
+        log.info("List for tenant {}, timeout {}ms, data {}", tenantId, timeout, jsonPathExpressions);
         Supplier<MessageOrBuilder> call = () -> {
             clientUtils.setTenantId(tenantId);
-            ListAlertsResponse listAlertsResponse = clientUtils.getAlertServiceStub().listAlerts(request.build());
+            ListAlertsResponse listAlertsResponse = clientUtils.getAlertServiceStub()
+                .listAlerts(requestBuilder.build());
             alertsFromLastResponse = listAlertsResponse.getAlertsList();
             return listAlertsResponse;
         };
@@ -418,9 +262,9 @@ public class AlertTestSteps {
         assertTrue("GET request expected to return JSON response matching JSON path expression(s)", success);
     }
 
-    @Then("Count alerts for tenant {string}, assert response is {int}")
-    public void countAlertsForTenantWithTimeoutMsUntilJSONResponseMatchesTheFollowingJSONPathExpressions(String tenantId, int expected) {
-        clientUtils.setTenantId(tenantId);
+    @Then("Count alerts for the tenant, assert response is {int}")
+    public void countAlertsForTenantWithTimeoutMsUntilJSONResponseMatchesTheFollowingJSONPathExpressions(int expected) {
+        clientUtils.setTenantId(tenantSteps.getTenantId());
         ListAlertsRequest listAlertsRequest = ListAlertsRequest.newBuilder().build();
         var countAlertsResponse = clientUtils.getAlertServiceStub()
             .countAlerts(listAlertsRequest);
@@ -428,9 +272,9 @@ public class AlertTestSteps {
 
     }
 
-    @Then("Count alerts for tenant {string} filtered by severity {string}, assert response is {int}")
-    public void countAlertsForTenantFilteredBySeverity(String tenantId, String severity, int expected) {
-        clientUtils.setTenantId(tenantId);
+    @Then("Count alerts for the tenant, filtered by severity {string}, assert response is {int}")
+    public void countAlertsForTenantFilteredBySeverity(String severity, int expected) {
+        clientUtils.setTenantId(tenantSteps.getTenantId());
         ListAlertsRequest listAlertsRequest = ListAlertsRequest.newBuilder().addFilters(Filter.newBuilder().setSeverity(Severity.valueOf(severity)).build()).build();
         var countAlertsResponse = clientUtils.getAlertServiceStub()
             .countAlerts(listAlertsRequest);
@@ -451,7 +295,7 @@ public class AlertTestSteps {
 
             if (actualValue != null) {
                 actualTrimmed = actualValue.trim();
-            }  else {
+            } else {
                 actualTrimmed = null;
             }
 
@@ -478,9 +322,10 @@ public class AlertTestSteps {
                 .config(restAssuredConfig);
 
         restAssuredResponse = requestSpecification
-                .get(requestUrl)
-                .thenReturn();
+            .get(requestUrl)
+            .thenReturn();
     }
+
     private RestAssuredConfig createRestAssuredTestConfig() {
         return RestAssuredConfig.config()
             .httpClient(HttpClientConfig.httpClientConfig()
@@ -516,8 +361,8 @@ public class AlertTestSteps {
         try {
             var message = supplier.get();
             var messageJson = JsonFormat.printer()
-                    .sortingMapKeys().includingDefaultValueFields()
-                    .print(message);
+                .sortingMapKeys().includingDefaultValueFields()
+                .print(message);
             parsedJsonResponse = JsonPath.from(messageJson);
             log.info("Json response: {}", messageJson);
             //commonParseJsonResponse();
@@ -537,7 +382,7 @@ public class AlertTestSteps {
     private boolean checkNumberOfMessageForOneTenant(String tenant, int expectedMessages) {
         int foundMessages = 0;
         List<ConsumerRecord<String, byte[]>> records = kafkaTestHelper.getConsumedMessages(background.getAlertTopic());
-        for (ConsumerRecord<String, byte[]> record: records) {
+        for (ConsumerRecord<String, byte[]> record : records) {
             if (record.value() == null) {
                 continue;
             }

--- a/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/BackgroundSteps.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/BackgroundSteps.java
@@ -30,11 +30,17 @@ package org.opennms.horizon.alertservice.stepdefs;
 
 import io.cucumber.java.en.Given;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.opennms.horizon.alertservice.kafkahelper.KafkaTestHelper;
 
+@RequiredArgsConstructor
 @Slf4j
 @Getter
 public class BackgroundSteps {
+
+    private final KafkaTestHelper kafkaTestHelper;
+
     //Test configuration
     private String applicationBaseHttpUrl;
     private String applicationBaseGrpcUrl;
@@ -42,21 +48,30 @@ public class BackgroundSteps {
     private String eventTopic;
     private String alertTopic;
     private String monitoringPolicyTopic;
-
+    private String tagTopic;
 
     @Given("Kafka event topic {string}")
     public void createKafkaTopicForEvents(String eventTopic) {
         this.eventTopic = eventTopic;
+        kafkaTestHelper.startConsumerAndProducer(eventTopic, eventTopic);
     }
 
     @Given("Kafka alert topic {string}")
     public void createKafkaTopicForAlerts(String alertTopic) {
         this.alertTopic = alertTopic;
+        kafkaTestHelper.startConsumerAndProducer(alertTopic, alertTopic);
     }
 
     @Given("Kafka monitoring policy topic {string}")
     public void createKafkaTopicForMonitoringPolicy(String monitoringPolicyTopic) {
         this.monitoringPolicyTopic = monitoringPolicyTopic;
+        kafkaTestHelper.startConsumerAndProducer(monitoringPolicyTopic, monitoringPolicyTopic);
+    }
+
+    @Given("Kafka tag topic {string}")
+    public void createKafkaTopicForTags(String tagTopic) {
+        this.tagTopic = tagTopic;
+        kafkaTestHelper.startConsumerAndProducer(tagTopic, tagTopic);
     }
 
     @Given("Application base HTTP URL in system property {string}")
@@ -77,6 +92,6 @@ public class BackgroundSteps {
     public void kafkaRestServerURLInSystemProperty(String systemProperty) {
         this.kafkaBootstrapUrl = System.getProperty(systemProperty);
         log.info("Using Kafka base URL: {}", this.kafkaBootstrapUrl);
+        kafkaTestHelper.setKafkaBootstrapUrl(kafkaBootstrapUrl);
     }
-
 }

--- a/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/EventSteps.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/EventSteps.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ */
+
+package org.opennms.horizon.alertservice.stepdefs;
+
+import io.cucumber.java.en.When;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opennms.horizon.alertservice.kafkahelper.KafkaTestHelper;
+import org.opennms.horizon.events.proto.Event;
+import org.opennms.horizon.events.proto.EventLog;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+public class EventSteps {
+
+    private final BackgroundSteps background;
+    private final TenantSteps tenantSteps;
+    private final KafkaTestHelper kafkaTestHelper;
+
+
+    @When("An event is sent with UEI {string} on node {int}")
+    public void sendEvent(String uei, int nodeId) {
+        sendEvent(uei, nodeId, System.currentTimeMillis());
+    }
+
+    @When("An event is sent with UEI {string} on node {int} with produced time {int} {} ago")
+    public void sendEvent(String uei, int nodeId, int duration, TimeUnit timeUnit) {
+        long producedTimeMs = System.currentTimeMillis() - timeUnit.toMillis(duration);
+        sendEvent(uei, nodeId, producedTimeMs);
+
+    }
+
+    public void sendEvent(String uei, int nodeId, long producedTimeMs) {
+        EventLog eventLog = EventLog.newBuilder()
+            .setTenantId(tenantSteps.getTenantId())
+            .addEvents(Event.newBuilder()
+                .setTenantId(tenantSteps.getTenantId())
+                .setProducedTimeMs(producedTimeMs)
+                .setNodeId(nodeId)
+                .setUei(uei))
+            .build();
+
+        kafkaTestHelper.sendToTopic(background.getEventTopic(), eventLog.toByteArray(), tenantSteps.getTenantId());
+    }
+}

--- a/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/MonitorPolicySteps.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/MonitorPolicySteps.java
@@ -40,6 +40,7 @@ import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Assertions;
 import org.junit.platform.commons.util.StringUtils;
 import org.opennms.horizon.alerts.proto.Alert;
+import org.opennms.horizon.alerts.proto.AlertConditionProto;
 import org.opennms.horizon.alerts.proto.AlertEventDefinitionProto;
 import org.opennms.horizon.alerts.proto.EventType;
 import org.opennms.horizon.alerts.proto.ListAlertEventDefinitionsRequest;
@@ -49,7 +50,6 @@ import org.opennms.horizon.alerts.proto.MonitorPolicyProto;
 import org.opennms.horizon.alerts.proto.OverTimeUnit;
 import org.opennms.horizon.alerts.proto.PolicyRuleProto;
 import org.opennms.horizon.alerts.proto.Severity;
-import org.opennms.horizon.alerts.proto.AlertConditionProto;
 import org.opennms.horizon.alertservice.AlertGrpcClientUtils;
 import org.opennms.horizon.alertservice.kafkahelper.KafkaTestHelper;
 import org.opennms.horizon.shared.common.tag.proto.Operation;
@@ -66,9 +66,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -155,8 +153,11 @@ public class MonitorPolicySteps {
 
     @Then("Create a new policy with give parameters")
     public void createANewPolicyWithGiveParameters() {
+        ruleBuilder.clearSnmpEvents();
         triggerBuilders.forEach(b -> ruleBuilder.addSnmpEvents(b.build()));
-        MonitorPolicyProto policy = policyBuilder.addRules(ruleBuilder.build()).build();
+        MonitorPolicyProto policy = policyBuilder
+            .clearRules()
+            .addRules(ruleBuilder.build()).build();
         MonitorPolicyProto dbPolicy = grpcClient.getPolicyStub().createPolicy(policy);
         policyId = dbPolicy.getId();
         log.info("Creating policy {}", policy);

--- a/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/MonitorPolicySteps.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/MonitorPolicySteps.java
@@ -32,12 +32,12 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.Int64Value;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.groups.Tuple;
-import org.junit.jupiter.api.Assertions;
 import org.junit.platform.commons.util.StringUtils;
 import org.opennms.horizon.alerts.proto.Alert;
 import org.opennms.horizon.alerts.proto.AlertConditionProto;
@@ -52,9 +52,6 @@ import org.opennms.horizon.alerts.proto.PolicyRuleProto;
 import org.opennms.horizon.alerts.proto.Severity;
 import org.opennms.horizon.alertservice.AlertGrpcClientUtils;
 import org.opennms.horizon.alertservice.kafkahelper.KafkaTestHelper;
-import org.opennms.horizon.shared.common.tag.proto.Operation;
-import org.opennms.horizon.shared.common.tag.proto.TagOperationList;
-import org.opennms.horizon.shared.common.tag.proto.TagOperationProto;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import java.util.ArrayList;
@@ -71,105 +68,99 @@ import static org.junit.Assert.*;
 @Slf4j
 @RequiredArgsConstructor
 public class MonitorPolicySteps {
+    private final TenantSteps tenantSteps;
     private final KafkaTestHelper kafkaTestHelper;
     private final BackgroundSteps background;
     private final AlertGrpcClientUtils grpcClient;
-    private MonitorPolicyProto.Builder policyBuilder = MonitorPolicyProto.newBuilder();
-    private PolicyRuleProto.Builder ruleBuilder = PolicyRuleProto.newBuilder();
+
+    private MonitorPolicyProto.Builder policyBuilder;
+    private PolicyRuleProto.Builder ruleBuilder;
+
     private List<AlertConditionProto.Builder> triggerBuilders = new ArrayList<>();
-    private Long policyId;
-    private String tenantId;
-    private String tagTopic;
-
-    private MonitorPolicyProto policy;
-
-    private AlertEventDefinitionProto triggerEventDefinition;
 
     private Map<String, AlertEventDefinitionProto> snmpTrapDefinitions;
 
+    private MonitorPolicyProto lastCreatedPolicy;
+    private MonitorPolicyProto defaultPolicy;
 
-    @Given("Monitoring policy kafka consumer")
-    public void setupMonitoringPolicyTopic() {
-        kafkaTestHelper.setKafkaBootstrapUrl(background.getKafkaBootstrapUrl());
-        kafkaTestHelper.startConsumerAndProducer(background.getMonitoringPolicyTopic(), background.getMonitoringPolicyTopic());
+    @Given("A monitoring policy named {string} with tag {string}, notifying by email")
+    public void defineNewPolicyNotifyViaEmail(String name, String tag) {
+        defineNewPolicy(name, tag);
+        policyBuilder.setNotifyByEmail(true);
     }
 
-    @Given("Kafka topic for tags {string}")
-    public void kafkaTopicForTags(String tagTopic) {
-        this.tagTopic = tagTopic;
-        kafkaTestHelper.setKafkaBootstrapUrl(background.getKafkaBootstrapUrl());
-        kafkaTestHelper.startConsumerAndProducer(tagTopic, tagTopic);
-    }
-
-    @Given("Tenant id {string}")
-    public void defaultTenantId(String tenantId) {
-        this.tenantId = tenantId;
-        grpcClient.setTenantId(tenantId);
-    }
-
-    @Given("Monitor policy name {string} and memo {string}")
-    public void monitorPolicyNameAndMemo(String name, String memo) {
-        policyBuilder
+    @Given("A monitoring policy named {string} with tag {string}")
+    public void defineNewPolicy(String name, String tag) {
+        policyBuilder = MonitorPolicyProto.newBuilder()
             .setName(name)
-            .setMemo(memo);
+            .addTags(tag);
+
+        ruleBuilder = PolicyRuleProto.newBuilder();
+        triggerBuilders = new ArrayList<>();
     }
 
-    @Given("tags for monitor policy {string}")
-    public void tagsForMonitorPolicy(String tag) {
-        policyBuilder.addTags(tag);
-    }
-
-    @Given("Notify by email {string}")
-    public void notifyByEmail(String notifyByEmail) {
-        policyBuilder.setNotifyByEmail(Boolean.parseBoolean(notifyByEmail));
-    }
-
-    @Given("Policy Rule name {string} and componentType {string}")
-    public void policyRuleNameAndComponentType(String name, String type) {
-        ruleBuilder
-            .setName(name)
+    @Given("The policy has a rule named {string} with component type {string} and trap definitions")
+    public void setPolicyRules(String ruleName, String type, DataTable alertConditions) {
+        ruleBuilder = PolicyRuleProto.newBuilder()
+            .setName(ruleName)
             .setComponentType(ManagedObjectType.valueOf(type.toUpperCase()));
-    }
 
-    @Given("Alert condition data")
-    public void alertConditionData(DataTable data) {
         snmpTrapDefinitions = this.loadSnmpTrapDefinitions();
-        List<Map<String, String>> mapList = data.asMaps();
-        mapList.forEach(map -> {
-            AlertConditionProto.Builder eventBuilder = AlertConditionProto.newBuilder()
-                .setTriggerEvent(snmpTrapDefinitions.get(map.get("trigger_event_name")))
-                .setCount(Integer.parseInt(map.get("count")))
-                .setOvertime(Integer.parseInt(map.get("overtime")))
-                .setOvertimeUnit(OverTimeUnit.valueOf(map.get("overtime_unit").toUpperCase()))
-                .setSeverity(Severity.valueOf(map.get("severity").toUpperCase()));
-            String clearEventType = map.get("clear_event_name");
-            if (StringUtils.isNotBlank(clearEventType)) {
-                eventBuilder.setClearEvent(snmpTrapDefinitions.get(clearEventType));
-            }
-            triggerEventDefinition = eventBuilder.getTriggerEvent();
-            triggerBuilders.add(eventBuilder);
-        });
+
+        alertConditions.asMaps().stream()
+            .map(map -> {
+                AlertConditionProto.Builder eventBuilder = AlertConditionProto.newBuilder()
+                    .setTriggerEvent(snmpTrapDefinitions.get(map.get("trigger_event_name")))
+                    .setCount(Integer.parseInt(map.get("count")))
+                    .setOvertime(Integer.parseInt(map.get("overtime")))
+                    .setOvertimeUnit(OverTimeUnit.valueOf(map.get("overtime_unit").toUpperCase()))
+                    .setSeverity(Severity.valueOf(map.get("severity").toUpperCase()));
+                String clearEventType = map.get("clear_event_name");
+                if (StringUtils.isNotBlank(clearEventType)) {
+                    eventBuilder.setClearEvent(snmpTrapDefinitions.get(clearEventType));
+                }
+                return eventBuilder;
+            })
+            .forEach(triggerBuilders::add);
     }
 
-    @Then("Create a new policy with give parameters")
-    public void createANewPolicyWithGiveParameters() {
-        ruleBuilder.clearSnmpEvents();
-        triggerBuilders.forEach(b -> ruleBuilder.addSnmpEvents(b.build()));
+    private Map<String, AlertEventDefinitionProto> loadSnmpTrapDefinitions() {
+        ListAlertEventDefinitionsRequest request = ListAlertEventDefinitionsRequest.newBuilder()
+            .setEventType(EventType.SNMP_TRAP)
+            .build();
+        List<AlertEventDefinitionProto> eventDefinitionsList = this.grpcClient.getAlertEventDefinitionStub()
+            .listAlertEventDefinitions(request)
+            .getAlertEventDefinitionsList();
+        return eventDefinitionsList.stream()
+            .collect(Collectors.toMap(AlertEventDefinitionProto::getName, Function.identity()));
+    }
+
+    @And("The policy is created in the tenant")
+    public void thePolicyIsCreatedInANewTenant() {
+        triggerBuilders.stream()
+            .map(AlertConditionProto.Builder::build)
+            .forEach(ruleBuilder::addSnmpEvents);
+
         MonitorPolicyProto policy = policyBuilder
-            .clearRules()
-            .addRules(ruleBuilder.build()).build();
-        MonitorPolicyProto dbPolicy = grpcClient.getPolicyStub().createPolicy(policy);
-        policyId = dbPolicy.getId();
+            .addRules(ruleBuilder.build())
+            .build();
+
         log.info("Creating policy {}", policy);
-        assertThat(dbPolicy).isNotNull();
+        lastCreatedPolicy = grpcClient.getPolicyStub().createPolicy(policy);
+        assertThat(lastCreatedPolicy).isNotNull();
     }
 
     @Then("Verify the new policy has been created")
     public void verifyTheNewPolicyHasBeenCreated() {
+        AlertEventDefinitionProto triggerEventDefinition = triggerBuilders.stream()
+            .findFirst()
+            .orElseThrow()
+            .getTriggerEvent();
+
         AlertConditionProto.Builder triggerBuilder = triggerBuilders.stream()
             .filter(b -> b.getTriggerEvent().equals(triggerEventDefinition))
             .findFirst().orElseThrow();
-        MonitorPolicyProto policy = grpcClient.getPolicyStub().getPolicyById(Int64Value.of(policyId));
+        MonitorPolicyProto policy = grpcClient.getPolicyStub().getPolicyById(Int64Value.of(lastCreatedPolicy.getId()));
         assertThat(policy).isNotNull()
             .extracting("name", "memo", "tagsList")
             .containsExactly(policyBuilder.getName(), policyBuilder.getMemo(), policyBuilder.getTagsList());
@@ -191,8 +182,8 @@ public class MonitorPolicySteps {
 
     @Then("The default monitoring policy exist with name {string} and all notification enabled")
     public void theDefaultMonitoringPolicyExistWithNameAndTag(String policyName) {
-         policy = grpcClient.getPolicyStub().getDefaultPolicy(Empty.getDefaultInstance());
-        assertThat(policy).isNotNull()
+        defaultPolicy = grpcClient.getPolicyStub().getDefaultPolicy(Empty.getDefaultInstance());
+        assertThat(defaultPolicy).isNotNull()
             .extracting("name", "notifyByEmail", "notifyByPagerDuty", "notifyByWebhooks")
             .containsExactly(policyName, true, true, true);
     }
@@ -200,9 +191,9 @@ public class MonitorPolicySteps {
     @Then("Verify the default monitoring policy has the following data")
     public void verifyTheDefaultMonitoringPolicyHasTheFollowingData(DataTable dataTable) {
         List<Map<String, String>> rows = dataTable.asMaps();
-        List<AlertConditionProto> events = policy.getRulesList().get(0).getSnmpEventsList();
+        List<AlertConditionProto> events = defaultPolicy.getRulesList().get(0).getSnmpEventsList();
         assertThat(events).asList().hasSize(rows.size());
-        for(int i = 0; i < events.size(); i++) {
+        for (int i = 0; i < events.size(); i++) {
             assertThat(events.get(i))
                 .extracting(e -> e.getTriggerEvent().getName(), e -> e.getSeverity().name())
                 .containsExactly(rows.get(i).get("triggerEventName"), rows.get(i).get("severity"));
@@ -211,10 +202,10 @@ public class MonitorPolicySteps {
 
     @Then("Verify the default policy rule has name {string} and component type {string}")
     public void verifyTheDefaultPolicyRuleHasNameAndComponentType(String name, String type) {
-        assertThat(policy.getRulesList()).asList().hasSize(1);
-        PolicyRuleProto rule = policy.getRulesList().get(0);
+        assertThat(defaultPolicy.getRulesList()).asList().hasSize(1);
+        PolicyRuleProto rule = defaultPolicy.getRulesList().get(0);
         assertThat(rule)
-            .extracting(PolicyRuleProto::getName, r->r.getComponentType().name())
+            .extracting(PolicyRuleProto::getName, r -> r.getComponentType().name())
             .containsExactly(name, type);
 
     }
@@ -233,13 +224,18 @@ public class MonitorPolicySteps {
         });
     }
 
+    @Then("Verify valid monitoring policy ID is set in alert for the tenant")
+    public void checkMonitoringPolicyIdSet() {
+        checkMonitoringPolicyIdSet(tenantSteps.getTenantId());
+    }
+
     @Then("Verify valid monitoring policy ID is set in alert for tenant {string}")
     public void checkMonitoringPolicyIdSet(String tenantId) {
         Awaitility.waitAtMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-                List<Alert> alerts = filterMessagesForTenant(tenantId, alert -> alert.getMonitoringPolicyIdCount() >= 1);
-                assertEquals(1, alerts.size());
+            List<Alert> alerts = filterMessagesForTenant(tenantId, alert -> alert.getMonitoringPolicyIdCount() >= 1);
+            assertEquals(1, alerts.size());
 
-                assertNotNull(grpcClient.getPolicyStub().getPolicyById(Int64Value.of(alerts.get(0).getMonitoringPolicyId(0))));
+            assertNotNull(grpcClient.getPolicyStub().getPolicyById(Int64Value.of(alerts.get(0).getMonitoringPolicyId(0))));
         });
     }
 
@@ -252,51 +248,5 @@ public class MonitorPolicySteps {
             }
         }).filter(predicate).toList();
 
-    }
-
-
-    @Then("Verify policy has tag {string}")
-    public void verifyPolicyHasTag(String tag) throws InterruptedException {
-        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
-            var policyProto = grpcClient.getPolicyStub().getPolicyById(Int64Value.newBuilder().setValue(policyId).build());
-            Assertions.assertFalse(policyProto.getTagsList().isEmpty());
-            String aTag = policyProto.getTags(0);
-            Assertions.assertEquals(tag, aTag);
-        });
-    }
-
-
-    @Given("Send tag operation data for existing monitoring policy")
-    public void sendTagOperationDataForExistingMonitoringPolicy(DataTable data) {
-
-        Map<String, String> map = data.asMaps().get(0);
-        var builder = TagOperationProto.newBuilder();
-        builder.setOperation(Operation.valueOf(map.get("action")))
-            .setTagName(map.get("name"))
-            .setTenantId(map.get("tenant-id"))
-            .addAllMonitoringPolicyId(List.of(policyId));
-        TagOperationList tagList = TagOperationList.newBuilder()
-            .addTags(builder.build()).build();
-        kafkaTestHelper.sendToTopic(tagTopic, tagList.toByteArray(), tenantId);
-    }
-
-    @Given("existing policy, get policy id")
-    public void existingPolicyGetPolicyId() {
-        var list = grpcClient.getPolicyStub().listPolicies(Empty.getDefaultInstance());
-        Assertions.assertFalse(list.getPoliciesList().isEmpty());
-        var monitoringPolicy = list.getPoliciesList().get(0);
-        policyId = monitoringPolicy.getId();
-    }
-
-    private Map<String, AlertEventDefinitionProto> loadSnmpTrapDefinitions() {
-        ListAlertEventDefinitionsRequest request = ListAlertEventDefinitionsRequest.newBuilder()
-            .setEventType(EventType.SNMP_TRAP)
-            .build();
-        List<AlertEventDefinitionProto> eventDefinitionsList = this.grpcClient.getAlertEventDefinitionStub()
-            .listAlertEventDefinitions(request)
-            .getAlertEventDefinitionsList();
-       return eventDefinitionsList.stream()
-            .collect(Collectors.toMap(
-            AlertEventDefinitionProto::getName, Function.identity()));
     }
 }

--- a/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/TenantSteps.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/TenantSteps.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ */
+
+package org.opennms.horizon.alertservice.stepdefs;
+
+import io.cucumber.java.en.Given;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opennms.horizon.alertservice.AlertGrpcClientUtils;
+
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TenantSteps {
+    private final AlertGrpcClientUtils grpcClient;
+
+    @Getter
+    private String tenantId;
+
+    /**
+     * Uses a new random tenantId.
+     */
+    @Given("A new tenant")
+    public String useRandomizedTenantId() {
+        return useSpecifiedTenantId(String.format("tenant-%s", UUID.randomUUID()));
+    }
+
+    /**
+     * Uses the specified tenantId. Note that if a feature specifies a
+     * hard-coded tenant in a Background section, then those setup steps are
+     * applied to the same tenant <i>on every scenario</i>, leading to duplicate
+     * monitoring policies, etc.
+     */
+    @Given("Tenant id {string}")
+    @Given("Tenant {string}")
+    @Given("A new tenant named {string}")
+    public String useSpecifiedTenantId(String tenantId) {
+        this.tenantId = tenantId;
+        grpcClient.setTenantId(tenantId);
+        log.info("New tenant-id is {}", tenantId);
+        return tenantId;
+    }
+}

--- a/alert/src/test/resources/org/opennms/horizon/alertservice/alert.feature
+++ b/alert/src/test/resources/org/opennms/horizon/alertservice/alert.feature
@@ -1,5 +1,6 @@
 @Alert
 Feature: Alert Service Basic Functionality
+
   Background: Configure base URLs
     Given Application base HTTP URL in system property "application.base-http-url"
     Given Application base gRPC URL in system property "application.base-grpc-url"
@@ -7,226 +8,211 @@ Feature: Alert Service Basic Functionality
     Given Kafka event topic "events"
     Given Kafka alert topic "alerts"
     Given Kafka tag topic "tag-operation"
-    Given Tenant id "tenantA"
-    Given Monitor policy name "tenantA-policy" and memo "tenantA policy"
-    Given tags for monitor policy "tag1"
-    Given Policy Rule name "tenantA-rule" and componentType "NODE"
-    And Alert condition data
+    Given A new tenant
+    And A monitoring policy named "my-policy" with tag "tag1"
+    And The policy has a rule named "my-rule" with component type "NODE" and trap definitions
       | trigger_event_name | count | overtime | overtime_unit | severity | clear_event_name |
       | SNMP Link Down     | 1     | 0        | MINUTE        | MINOR    |                  |
       | SNMP Link Up       | 1     | 0        | MINUTE        | CLEARED  | SNMP Link Down   |
       | SNMP Cold Start    | 1     | 0        | MINUTE        | MAJOR    |                  |
       | SNMP Warm Start    | 1     | 0        | MINUTE        | CRITICAL |                  |
-    And Create a new policy with give parameters
-    Given Tenant "tenantA"
-    Given Tag operation data
-      | action     | name     | node_ids |
-      | ASSIGN_TAG | tag1     | 10       |
-    And Sent tag operation message to Kafka topic
+    And The policy is created in the tenant
+    And Tag operations are applied to the tenant
+      | action     | name | node_ids |
+      | ASSIGN_TAG | tag1 | 10       |
     Then Verify list tag with size 1 and node ids
       | 10 |
-    Given Tenant id "tenantF"
-    And Create a new policy with give parameters
-    Given Tenant id "tenantG"
-    And Create a new policy with give parameters
-    Given Tenant id "tenantH"
-    And Create a new policy with give parameters
-    Given Tenant id "tenantI"
-    And Create a new policy with give parameters
-    Given Tenant id "tenantJ"
-    And Create a new policy with give parameters
-    Given Tenant id "tenantK"
-    And Create a new policy with give parameters
 
-  Scenario: Verify when an event is received from Kafka, a new alert is created
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantA" with node 10
-    Then List alerts for tenant "tenantA", with timeout 15000ms, until JSON response matches the following JSON path expressions
+  Scenario: When an event is received from Kafka, a new alert is created
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, with timeout 15000ms, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
-    Then Verify alert topic has 1 messages with tenant "tenantA"
-    Then Verify valid monitoring policy ID is set in alert for tenant "tenantA"
+    Then Verify alert topic has 1 messages for the tenant
+    Then Verify valid monitoring policy ID is set in alert for the tenant
 
-  Scenario: Verify when an event is received from Kafka, with no matching alert configuration, no new alert is created
-    Then Send event with UEI "uei.opennms.org/perspective/nodes/nodeLostService" with tenant "tenantB" with node 10
+  Scenario: When an event is received from Kafka, with no matching alert configuration, no new alert is created
+    When An event is sent with UEI "uei.opennms.org/perspective/nodes/nodeLostService" on node 10
     Then Send GET request to application at path "/metrics/events_without_alert_data_counter", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | measurements[0].value == 1.0 |
-    Then Verify alert topic has 0 messages with tenant "tenantB"
+    Then Verify alert topic has 0 messages for the tenant
 
-  Scenario: Verify when an event is received from Kafka with a different tenant id, you do not see the new alert
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantA" with node 10
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
+  Scenario: When an event is received from Kafka with a different tenant id, you do not see the new alert
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1     |
       | alerts[0].counter == 1 |
     Then List alerts for tenant "tenant-other", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | alerts.size() == 0 |
 
-  Scenario: Verify that alerts can be deleted
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1   |
+  Scenario: Alerts can be deleted
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1     |
       | alerts[0].counter == 1 |
     Then Remember the first alert from the last response
     Then Delete the alert
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 0 |
 
-  Scenario: Verify that alerts can be cleared by other events
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantA" with node 10
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
+  Scenario: Alerts can be cleared by other events
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Up" with tenant "tenantA" with node 10
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Up" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 1            |
       | alerts[0].counter == 2        |
       | alerts[0].severity == CLEARED |
 
-  Scenario: Verify that alerts can be cleared by other events, and then recreated
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantA" with node 10
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
+  Scenario: Alerts can be cleared by other events, and then recreated
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Up" with tenant "tenantA" with node 10
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Up" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 1            |
       | alerts[0].counter == 2        |
       | alerts[0].severity == CLEARED |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantA" with node 10
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 3      |
       | alerts[0].severity == MINOR |
 
-  Scenario: Verify alert can be acknowledged and unacknowledged
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantA" with node 10
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
+  Scenario: Alerts can be acknowledged and unacknowledged
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
     Then Remember the first alert from the last response
     Then Acknowledge the alert
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
-      | alerts[0].counter == 1 |
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1               |
+      | alerts[0].counter == 1           |
       | alerts[0].isAcknowledged == true |
-      | alerts[0].ackUser == me |
-      | alerts[0].ackTimeMs as long > 0 |
+      | alerts[0].ackUser == me          |
+      | alerts[0].ackTimeMs as long > 0  |
     Then Unacknowledge the alert
-    Then List alerts for tenant "tenantA", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
-      | alerts[0].counter == 1 |
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1                |
+      | alerts[0].counter == 1            |
       | alerts[0].isAcknowledged == false |
-      | alerts[0].ackTimeMs == 0 |
+      | alerts[0].ackTimeMs == 0          |
 
-  Scenario: Verify alert reduction for duplicate events
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantF" with node 10
-    Then List alerts for tenant "tenantF", with timeout 5000ms, until JSON response matches the following JSON path expressions
+  Scenario: Duplicate events reduce to a single alert
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
-    Then Verify alert topic has 1 messages with tenant "tenantF"
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantF" with node 10
-    Then List alerts for tenant "tenantF", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    Then Verify alert topic has 1 messages for the tenant
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 2      |
       | alerts[0].severity == MINOR |
-    Then Verify alert topic has 2 messages with tenant "tenantF"
+    Then Verify alert topic has 2 messages for the tenant
 
-  Scenario: Verify page size 1 should return only 1 alert
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantG" with node 10
-    Then List alerts for tenant "tenantG" with page size 1, with timeout 5000ms, until JSON response matches the following JSON path expressions
+  Scenario: Alert responses should be paged
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant with page size 1, with timeout 5000ms, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantG" with node 11
-    Then List alerts for tenant "tenantG" with page size 1, with timeout 5000ms, until JSON response matches the following JSON path expressions
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 11
+    Then List alerts for the tenant with page size 1, with timeout 5000ms, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
-    Then Verify alert topic has 2 messages with tenant "tenantG"
+    Then Verify alert topic has 2 messages for the tenant
 
-  Scenario: Verify find alert sorted by id
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantH" with node 10
-    Then List alerts for tenant "tenantH", with timeout 10000ms, until JSON response matches the following JSON path expressions
+  Scenario: Alert responses can be sorted by id
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, with timeout 10000ms, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "tenantH" with node 11
-    Then List alerts for tenant "tenantH" sorted by "id" ascending "true", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 11
+    Then List alerts for the tenant sorted by "id" ascending "true", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | alerts.size() == 2          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
       | alerts[1].severity == MAJOR |
-    Then Verify alert topic has 2 messages with tenant "tenantH"
+    Then Verify alert topic has 2 messages for the tenant
 
-  Scenario: Verify find alert filtered by severity MAJOR and MINOR
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantI" with node 10
-    Then List alerts for tenant "tenantI", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
-      | alerts[0].counter == 1 |
+  Scenario: Alert responses can be filtered by severity
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant filtered by severity "MINOR", with timeout 5000ms, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1          |
+      | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "tenantI" with node 11
-    Then List alerts for tenant "tenantI" filtered by severity "MAJOR", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 11
+    Then List alerts for the tenant filtered by severity "MAJOR", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MAJOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Warm_Start" with tenant "tenantI" with node 12
-    Then List alerts for tenant "tenantI" filtered by severity "MAJOR" and "MINOR", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Warm_Start" on node 12
+    Then List alerts for the tenant filtered by severity "MAJOR" and "MINOR", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | alerts.size() == 2          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
       | alerts[1].severity == MAJOR |
-    Then Verify alert topic has 3 messages with tenant "tenantI"
+    Then Verify alert topic has 3 messages for the tenant
 
-  Scenario: Verify find alert filtered by time
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantJ" with node 10 with produced time 23h ago
-    Then List alerts for tenant "tenantJ", with timeout 5000ms, until JSON response matches the following JSON path expressions
+  Scenario: Alert responses can be filtered by time
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10 with produced time 23 HOURS ago
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 1          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "tenantJ" with node 11
-    Then List alerts for tenant "tenantJ", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 11
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 2          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
       | alerts[1].severity == MAJOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantJ" with node 12 with produced time 8 days ago
-    Then List alerts for tenant "tenantJ", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 2              |
-      | alerts[0].counter == 1          |
-      | alerts[0].severity == MINOR     |
-      | alerts[1].severity == MAJOR     |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantJ" with node 13 with produced time last month
-    Then List alerts for tenant "tenantJ" with hours 168, with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 2              |
-      | alerts[0].counter == 1          |
-      | alerts[0].severity == MINOR     |
-      | alerts[1].severity == MAJOR     |
-    Then List alerts for tenant "tenantJ" today , with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1              |
-      | alerts[0].counter == 1          |
-      | alerts[0].severity == MAJOR     |
-    Then List alerts for tenant "tenantJ" with hours 24, with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 2              |
-      | alerts[0].counter == 1          |
-      | alerts[0].severity == MINOR     |
-      | alerts[1].severity == MAJOR     |
-    Then Verify alert topic has 4 messages with tenant "tenantJ"
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 12 with produced time 8 DAYS ago
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 2          |
+      | alerts[0].counter == 1      |
+      | alerts[0].severity == MINOR |
+      | alerts[1].severity == MAJOR |
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 13 with produced time 30 DAYS ago
+    Then List alerts for the tenant with hours 168, with timeout 5000ms, until JSON response matches the following JSON path expressions
+      | alerts.size() == 2          |
+      | alerts[0].counter == 1      |
+      | alerts[0].severity == MINOR |
+      | alerts[1].severity == MAJOR |
+    Then List alerts for the tenant today, with timeout 5000ms, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1          |
+      | alerts[0].counter == 1      |
+      | alerts[0].severity == MAJOR |
+    Then List alerts for the tenant with hours 24, with timeout 5000ms, until JSON response matches the following JSON path expressions
+      | alerts.size() == 2          |
+      | alerts[0].counter == 1      |
+      | alerts[0].severity == MINOR |
+      | alerts[1].severity == MAJOR |
+    Then Verify alert topic has 4 messages for the tenant
 
-    Scenario: Verify count alerts
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenantK" with node 10
-    Then List alerts for tenant "tenantK", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
-      | alerts[0].counter == 1 |
+  Scenario: Alerts can be counted
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1          |
+      | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "tenantK" with node 11
-    Then List alerts for tenant "tenantK", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 11
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 2          |
       | alerts[0].counter == 1      |
       | alerts[0].severity == MINOR |
       | alerts[1].severity == MAJOR |
-    Then Count alerts for tenant "tenantK", assert response is 2
-    Then Count alerts for tenant "tenantK" filtered by severity "MAJOR", assert response is 1
-    Then Verify alert topic has 2 messages with tenant "tenantK"
+    Then Count alerts for the tenant, assert response is 2
+    Then Count alerts for the tenant, filtered by severity "MAJOR", assert response is 1
+    Then Verify alert topic has 2 messages for the tenant

--- a/alert/src/test/resources/org/opennms/horizon/alertservice/monitor-policy.feature
+++ b/alert/src/test/resources/org/opennms/horizon/alertservice/monitor-policy.feature
@@ -7,9 +7,8 @@ Feature: Monitor policy gRPC Functionality
     Given Kafka bootstrap URL in system property "kafka.bootstrap-servers"
     Given Kafka event topic "events"
     Given Kafka alert topic "alerts"
-    Given Kafka topic for tags "tag-operation"
+    Given Kafka tag topic "tag-operation"
     Given Kafka monitoring policy topic "monitoring-policy"
-    Given Monitoring policy kafka consumer
 
   Scenario: The default monitoring policy should exist
     Given Tenant id "different-tenant"
@@ -21,20 +20,19 @@ Feature: Monitor policy gRPC Functionality
       | SNMP Warm Start  | MAJOR    |
 
   Scenario: Verify alert can be created based on the default policy
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "new-tenant" with node 10
-    Then List alerts for tenant "new-tenant", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
+    Given Tenant id "new-tenant"
+    When An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1     |
       | alerts[0].counter == 1 |
 
   Scenario: Create a monitor policy with SNMP Trap event rule
     Given Tenant id "test-tenant"
-    Given Monitor policy name "test-policy" and memo "the test policy"
-    Given Notify by email "true"
-    Given Policy Rule name "snmp rule" and componentType "NODE"
-    Given Alert condition data
+    Given A monitoring policy named "test-policy" with tag "tag1", notifying by email
+    Given The policy has a rule named "snmp-rule" with component type "NODE" and trap definitions
       | trigger_event_name | count | overtime | overtime_unit | severity | clear_event_name |
       | SNMP Cold Start    | 1     | 3        | MINUTE        | MAJOR    |                  |
-    Then Create a new policy with give parameters
+    And The policy is created in the tenant
     Then Verify the new policy has been created
     Then List policy should contain 1
     Then Verify monitoring policy for tenant "test-tenant" is sent to Kafka

--- a/alert/src/test/resources/org/opennms/horizon/alertservice/node.feature
+++ b/alert/src/test/resources/org/opennms/horizon/alertservice/node.feature
@@ -8,55 +8,59 @@ Feature: Node operation feature
     Given Kafka node topic "node"
     Given Kafka event topic "events"
     Given Kafka alert topic "alerts"
+
+  Scenario: Insert node when receive new message
     Given Tenant id "tenant-1"
-    Given Monitor policy name "tenantA-policy" and memo "tenantA policy"
-    Given Policy Rule name "tenantA-rule" and componentType "NODE"
-    And Alert condition data
+    And A monitoring policy named "my-policy" with tag "tag1"
+    And The policy has a rule named "my-rule" with component type "NODE" and trap definitions
       | trigger_event_name | count | overtime | overtime_unit | severity | clear_event_name |
       | SNMP Link Down     | 1     | 0        | MINUTE        | MINOR    |                  |
       | SNMP Link Up       | 1     | 0        | MINUTE        | CLEARED  | SNMP Link Down   |
       | SNMP Cold Start    | 1     | 0        | MINUTE        | MAJOR    |                  |
       | SNMP Warm Start    | 1     | 0        | MINUTE        | CRITICAL |                  |
-    And Create a new policy with give parameters
-    Given Tenant id "tenant-3"
-    And Create a new policy with give parameters
-
-  Scenario: Insert node when receive new message
-    Given [Node] Tenant "tenant-1"
+    And The policy is created in the tenant
     Given [Node] operation data
-      | id  | tenant_id     | label    |
-      | 1   | tenant-1      | first    |
-      | 2   | tenant-2      | second   |
+      | id | tenant_id | label  |
+      | 1  | tenant-1  | first  |
+      | 2  | tenant-2  | second |
     And Sent node message to Kafka topic
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "tenant-1" with node 2
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenant-1" with node 1
-    Then List alerts for tenant "tenant-1", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 2                      |
-      | alerts[0].label == SNMP Cold Start      |
-      | alerts[0].nodeName == BLANK             |
-      | alerts[1].label == SNMP Link Down       |
-      | alerts[1].nodeName == first             |
-    Then List alerts for tenant "tenant-1" and label "first", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1                      |
-      | alerts[0].label == SNMP Link Down       |
-      | alerts[0].nodeName == first             |
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 2
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 1
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 2                 |
+      | alerts[0].label == SNMP Cold Start |
+      | alerts[0].nodeName == BLANK        |
+      | alerts[1].label == SNMP Link Down  |
+      | alerts[1].nodeName == first        |
+    Then List alerts for the tenant and label "first", with timeout 5000ms, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1                |
+      | alerts[0].label == SNMP Link Down |
+      | alerts[0].nodeName == first       |
 
   Scenario: Update node when receive new message
-    Given [Node] Tenant "tenant-3"
+    Given Tenant id "tenant-3"
+    And A monitoring policy named "my-policy" with tag "tag1"
+    And The policy has a rule named "my-rule" with component type "NODE" and trap definitions
+      | trigger_event_name | count | overtime | overtime_unit | severity | clear_event_name |
+      | SNMP Link Down     | 1     | 0        | MINUTE        | MINOR    |                  |
+      | SNMP Link Up       | 1     | 0        | MINUTE        | CLEARED  | SNMP Link Down   |
+      | SNMP Cold Start    | 1     | 0        | MINUTE        | MAJOR    |                  |
+      | SNMP Warm Start    | 1     | 0        | MINUTE        | CRITICAL |                  |
+    And The policy is created in the tenant
     Given [Node] operation data
-      | id  | tenant_id     | label    |
-      | 1   | tenant-3      | first    |
-      | 2   | tenant-2      | second   |
+      | id | tenant_id | label  |
+      | 1  | tenant-3  | first  |
+      | 2  | tenant-2  | second |
     And Sent node message to Kafka topic
     Given [Node] operation data
-      | id  | tenant_id     | label    |
-      | 1   | tenant-3      | third    |
+      | id | tenant_id | label |
+      | 1  | tenant-3  | third |
     And Sent node message to Kafka topic
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "tenant-3" with node 2
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "tenant-3" with node 1
-    Then List alerts for tenant "tenant-3", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 2                      |
-      | alerts[0].label == SNMP Cold Start      |
-      | alerts[0].nodeName == BLANK             |
-      | alerts[1].label == SNMP Link Down       |
-      | alerts[1].nodeName == third             |
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 2
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 1
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 2                 |
+      | alerts[0].label == SNMP Cold Start |
+      | alerts[0].nodeName == BLANK        |
+      | alerts[1].label == SNMP Link Down  |
+      | alerts[1].nodeName == third        |

--- a/alert/src/test/resources/org/opennms/horizon/alertservice/tag.feature
+++ b/alert/src/test/resources/org/opennms/horizon/alertservice/tag.feature
@@ -10,10 +10,10 @@ Feature: Tag operation feature
     Given Kafka alert topic "alerts"
 
   Scenario: Insert tag when receive new message
-    Given Tenant "tenant-1"
+    Given A new tenant
     Given Tag operation data
       | action     | name     | node_ids | policy_ids |
-      | ASSIGN_TAG | test-tag | 100,200  | 101,201   |
+      | ASSIGN_TAG | test-tag | 100,200  | 101,201    |
     And Sent tag operation message to Kafka topic
     Then Verify list tag with size 1 and node ids
       | 100 | 200 |

--- a/alert/src/test/resources/org/opennms/horizon/alertservice/threshold.feature
+++ b/alert/src/test/resources/org/opennms/horizon/alertservice/threshold.feature
@@ -5,91 +5,82 @@ Feature: Alert Service Thresholding Functionality
     Given Kafka bootstrap URL in system property "kafka.bootstrap-servers"
     Given Kafka event topic "events"
     Given Kafka alert topic "alerts"
-    Given Tenant id "thresholdTenantA"
-    Given Monitor policy name "thresholdTenantA-policy" and memo "thresholdTenantA policy"
-    Given Policy Rule name "thresholdTenantA-rule" and componentType "NODE"
-    And Alert condition data
+    Given A new tenant
+    And A monitoring policy named "my-policy" with tag "tag1"
+    And The policy has a rule named "my-rule" with component type "NODE" and trap definitions
       | trigger_event_name | count | overtime | overtime_unit | severity | clear_event_name |
       | SNMP Link Down     | 2     | 0        | MINUTE        | MAJOR    |                  |
       | SNMP Link Up       | 1     | 0        | MINUTE        | CLEARED  | SNMP Link Down   |
       | SNMP Cold Start    | 3     | 10       | MINUTE        | MAJOR    |                  |
       | SNMP Warm Start    | 1     | 0        | MINUTE        | CLEARED  |                  |
-    And Create a new policy with give parameters
-    Given Tenant id "thresholdTenantF"
-    And Create a new policy with give parameters
-    Given Tenant id "thresholdTenantG"
-    And Create a new policy with give parameters
-    Given Tenant id "thresholdTenantH"
-    And Create a new policy with give parameters
-    Given Tenant id "thresholdTenantB"
-    And Create a new policy with give parameters
+    And The policy is created in the tenant
 
-  Scenario: Verify when a thresholding event is received from Kafka, a new alert is only created on passing the threshold
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "thresholdTenantA" with node 10
-    Then Verify alert topic has 0 messages with tenant "thresholdTenantA"
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "thresholdTenantA" with node 10
-    Then Verify alert topic has 0 messages with tenant "thresholdTenantA"
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "thresholdTenantA" with node 10
-    Then List alerts for tenant "thresholdTenantA", with timeout 15000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
-      | alerts[0].counter == 1 |
+  Scenario: When a thresholding event is received from Kafka, a new alert is only created on passing the threshold
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 10
+    Then Verify alert topic has 0 messages for the tenant
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 10
+    Then Verify alert topic has 0 messages for the tenant
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 10
+    Then List alerts for the tenant, with timeout 15000ms, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1          |
+      | alerts[0].counter == 1      |
       | alerts[0].severity == MAJOR |
-    Then Verify alert topic has 1 messages with tenant "thresholdTenantA"
+    Then Verify alert topic has 1 messages for the tenant
 
-  Scenario: Verify when a thresholding event is received from Kafka, a new alert is only created on passing the threshold within the timeframe
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "thresholdTenantB" with node 10 at 15 minutes ago
-    Then Verify alert topic has 0 messages with tenant "thresholdTenantB"
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "thresholdTenantB" with node 10 at 7 minutes ago
-    Then Verify alert topic has 0 messages with tenant "thresholdTenantB"
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "thresholdTenantB" with node 10 at 3 minutes ago
-    Then Verify alert topic has 0 messages with tenant "thresholdTenantB"
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" with tenant "thresholdTenantB" with node 10 at 2 minutes ago
-    Then List alerts for tenant "thresholdTenantB", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
-      | alerts[0].counter == 1 |
+  Scenario: When a thresholding event is received from Kafka, a new alert is only created on passing the threshold within the timeframe
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 10 with produced time 15 MINUTES ago
+    Then Verify alert topic has 0 messages for the tenant
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 10 with produced time 7 MINUTES ago
+    Then Verify alert topic has 0 messages for the tenant
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 10 with produced time 3 MINUTES ago
+    Then Verify alert topic has 0 messages for the tenant
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Cold_Start" on node 10 with produced time 2 MINUTES ago
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1          |
+      | alerts[0].counter == 1      |
       | alerts[0].severity == MAJOR |
-    Then Verify alert topic has 1 messages with tenant "thresholdTenantB"
+    Then Verify alert topic has 1 messages for the tenant
 
-  Scenario: Verify when a thresholding event with no time limit is received from Kafka, a new alert is only created on passing the threshold
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "thresholdTenantF" with node 10
-    Then Verify alert topic has 0 messages with tenant "thresholdTenantF"
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "thresholdTenantF" with node 10
-    Then List alerts for tenant "thresholdTenantF", with timeout 15000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
-      | alerts[0].counter == 1 |
+  Scenario: When a thresholding event with no time limit is received from Kafka, a new alert is only created on passing the threshold
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then Verify alert topic has 0 messages for the tenant
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, with timeout 15000ms, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1          |
+      | alerts[0].counter == 1      |
       | alerts[0].severity == MAJOR |
-    Then Verify alert topic has 1 messages with tenant "thresholdTenantF"
+    Then Verify alert topic has 1 messages for the tenant
 
 
-  Scenario: Verify a thresholded alert can be cleared by other events
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "thresholdTenantG" with node 10
-    Then Verify alert topic has 0 messages with tenant "thresholdTenantG"
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "thresholdTenantG" with node 10
-    Then List alerts for tenant "thresholdTenantG", with timeout 15000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
-      | alerts[0].counter == 1 |
+  Scenario: A thresholded alert can be cleared by other events
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then Verify alert topic has 0 messages for the tenant
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1          |
+      | alerts[0].counter == 1      |
       | alerts[0].severity == MAJOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Up" with tenant "thresholdTenantG" with node 10
-    Then List alerts for tenant "thresholdTenantG", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Up" on node 10
+    Then List alerts for the tenant, with timeout 15000ms, until JSON response matches the following JSON path expressions
       | alerts.size() == 1            |
       | alerts[0].counter == 2        |
       | alerts[0].severity == CLEARED |
 
-  Scenario: Verify a thresholded alert can be cleared by other events, and then recreated
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "thresholdTenantH" with node 10
-    Then Verify alert topic has 0 messages with tenant "thresholdTenantH"
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "thresholdTenantH" with node 10
-    Then List alerts for tenant "thresholdTenantH", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
-      | alerts[0].counter == 1 |
+  Scenario: A thresholded alert can be cleared by other events, and then recreated
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then Verify alert topic has 0 messages for the tenant
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1          |
+      | alerts[0].counter == 1      |
       | alerts[0].severity == MAJOR |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Up" with tenant "thresholdTenantH" with node 10
-    Then List alerts for tenant "thresholdTenantH", with timeout 5000ms, until JSON response matches the following JSON path expressions
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Up" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
       | alerts.size() == 1            |
       | alerts[0].counter == 2        |
       | alerts[0].severity == CLEARED |
-    Then Send event with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" with tenant "thresholdTenantH" with node 10
-    Then List alerts for tenant "thresholdTenantH", with timeout 5000ms, until JSON response matches the following JSON path expressions
-      | alerts.size() == 1 |
-      | alerts[0].counter == 3 |
+    Then An event is sent with UEI "uei.opennms.org/generic/traps/SNMP_Link_Down" on node 10
+    Then List alerts for the tenant, until JSON response matches the following JSON path expressions
+      | alerts.size() == 1          |
+      | alerts[0].counter == 3      |
       | alerts[0].severity == MAJOR |

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -116,7 +116,7 @@
         <micrometer.version>1.11.1</micrometer.version>
         <pax.jdbc.version>1.5.2</pax.jdbc.version>
         <postgresql.version>42.5.1</postgresql.version>
-        <testcontainers.version>1.17.4</testcontainers.version>
+        <testcontainers.version>1.18.3</testcontainers.version>
         <prometheus.version>0.16.0</prometheus.version>
         <protobuf.version>3.19.6</protobuf.version>   <!-- WARNING: this also controls the version of the protobuf compiler, change at your risk!-->
         <rate.limitted.logger.version>2.0.2</rate.limitted.logger.version>


### PR DESCRIPTION
## Description
This PR is intended to precede the actual changes for HS-1485; I figure that it might be easier to review & merge this PR separately. 

The scope of this PR is the alert service cucumber tests. The major changes are that:
- Many steps have been updated remove explicit references to the `tenantId`.
- Step classes have been streamlined by removing dead and duplicated code.
- Some scenario and step descriptions have been reworded to reduce verbosity.

No tests have been added or removed. This refactoring is necessary with the upcoming changes. Previously, on each scenario many duplicates of all of a tenant's alert conditions were created, for each policy specified in a background step. This means that an event would generate way too many alerts for duplicate policies that probably should not be allowed to exist together regardless.

In my prior PR I had attempted to get around this with tenantId aliases, to which I received feedback that it was hard to understand. In this altered approach we no longer have to care about the tenant in each step, having a reference to it via the `TenantSteps` class.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1485

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
