### PR TITLE
HS-1841: Addressing UX/Design Feedback for Onboarding Guide

### DIFF
--- a/ui/src/components/Common/CollapsingCard.vue
+++ b/ui/src/components/Common/CollapsingCard.vue
@@ -3,7 +3,7 @@
     <div :class="['collapse-box', open ? 'collapse-box-open' : 'collapse-box-closed']" data-test="collapsing-card-wrapper">
         <div class="collapse-box-header" @click="headerClicked" v-bind="$attrs">
             <span class="collapse-box-header-icon-wrapper">
-                <span class="collapse-box-header-icon">
+                <span class="collapse-box-header-icon" v-if="slots.icon">
                     <slot name="icon"></slot>
                 </span>
                 <span class="collapse-box-header-title">{{ title }}</span>
@@ -20,6 +20,7 @@
 <script lang='ts' setup>
 import ExpandMore from '@featherds/icon/navigation/ExpandMore'
 import { PropType } from 'vue'
+const slots = useSlots();
 defineOptions({ inheritAttrs: false })
 defineProps({
     title: { type: String, default: '' },
@@ -33,8 +34,7 @@ defineProps({
 @import '@featherds/styles/themes/variables';
 
 .collapse-box {
-    border: 1px solid var($border-light-on-surface);
-    padding: 8px 16px;
+    border: 1px solid rgb(0, 146, 199, 0.4);
     margin-bottom: 16px;
     color: var($secondary-text-on-surface);
     background-color: var($surface);
@@ -43,11 +43,13 @@ defineProps({
 
 .collapse-box-header {
     display: flex;
+    height: 44px;
+    padding: 4px 16px;
     justify-content: space-between;
     align-items: center;
-    max-height: 26px;
     cursor: pointer;
     color: var($secondary-text-on-surface);
+    background-color: rgba(0, 146, 199, 0.16);
 }
 
 .collapse-box-contents :deep(a) {
@@ -84,8 +86,8 @@ defineProps({
     max-height: 0vh;
     padding-top: 0px;
     padding-bottom: 0px;
-    padding-left: 32px;
-    padding-right: 32px;
+    padding-left: 16px;
+    padding-right: 16px;
 }
 
 .collapse-box-open .collapse-box-contents {
@@ -94,8 +96,8 @@ defineProps({
     max-height: 100vh;
     padding-top: 16px;
     padding-bottom: 16px;
-    padding-left: 32px;
-    padding-right: 32px;
+    padding-left: 16px;
+    padding-right: 16px;
 }
 
 .collapse-box-header svg {

--- a/ui/src/components/Common/ItemPreview.vue
+++ b/ui/src/components/Common/ItemPreview.vue
@@ -12,16 +12,18 @@
         <div class="item-preview-statuses">
           <div class="item-preview-status" v-for="(item, index) in itemStatuses" :key="index">
             <span>{{ item.title }}</span>
-            <div data-test="item-preview-status-id" :style="{ backgroundColor: item.statusColor, color: item.statusText }">{{ item.status }}</div>
+            <div data-test="item-preview-status-id"
+              :style="{ backgroundColor: item.statusColor, color: item.statusText }">{{ item.status }}</div>
           </div>
         </div>
       </div>
     </div>
+    <div v-if="bottomCopy" class="bottom-copy">{{ bottomCopy }}</div>
     <div class="item-preview-loading" v-if="loading">
       <div>
         <FeatherSpinner />
       </div>
-      <div data-test="welcome-discovery-status-txt">Loading first discovery.</div>
+      <div data-test="welcome-discovery-status-txt">Loading first discovery. This can take up to 3 minutes.</div>
     </div>
   </div>
 </template>
@@ -33,6 +35,7 @@ withDefaults(defineProps<ItemPreviewProps>(), {
   title: '',
   itemTitle: '',
   itemSubtitle: '',
+  bottomCopy: '',
   itemStatuses: () => []
 })
 </script>
@@ -112,5 +115,10 @@ withDefaults(defineProps<ItemPreviewProps>(), {
     height: 24px;
     margin-right: 12px;
   }
+}
+
+.bottom-copy {
+  padding: 2px 12px;
+  @include caption();
 }
 </style>

--- a/ui/src/components/Common/commonTypes.ts
+++ b/ui/src/components/Common/commonTypes.ts
@@ -11,4 +11,5 @@ export interface ItemPreviewProps {
     itemTitle: string;
     itemSubtitle: string;
     itemStatuses: ItemStatus[];
+    bottomCopy: string;
 }

--- a/ui/src/components/Welcome/WelcomeSlideOne.vue
+++ b/ui/src/components/Welcome/WelcomeSlideOne.vue
@@ -2,7 +2,7 @@
     <div :class="['welcome-slide-one-wrapper', visible ? 'visible' : 'hidden',
     ]">
         <div class="welcome-text">
-            <h1 data-test="welcome-slide-one-title">Welcome to <br />OpenNMS&nbsp;Cloud</h1>
+            <h1 data-test="welcome-slide-one-title">Welcome to OpenNMS&nbsp;Cloud</h1>
             <p class="margin-bottom">To start monitoring, you need to install our Minion on your system. This lightweight,
                 secure collector monitors and communicates with the devices on your network, shares collected data,
                 and connects your network with OpenNMS&nbsp;Cloud. </p>
@@ -11,11 +11,6 @@
         </div>
         <CollapsingCard title="Requirements: Before You Begin" data-test="welcome-slide-one-toggler"
             :open="welcomeStore.slideOneCollapseVisible" :headerClicked="welcomeStore.toggleSlideOneCollapse">
-            <template #icon>
-                <div>
-                    <FeatherIcon :icon="Lightbulb" title="Lightbulb" :class="isDark ? 'icon-dark' : 'icon-light'" />
-                </div>
-            </template>
             <template #body>
                 <div>
                     <h4>Minimum System Requirements:</h4>
@@ -62,22 +57,20 @@
                         <a href="https://docs.docker.com/desktop/install/linux-install/" target="_blank"
                             rel="noopener noreferrer">Linux
                         </a>
-                        ,&nbsp;
                         <a href="https://docs.docker.com/desktop/install/mac-install/" target="_blank"
                             rel="noopener noreferrer">Mac
                         </a>
-                        ,&nbsp;
                         <a href="https://docs.docker.com/desktop/install/windows-install/" target="_blank"
                             rel="noopener noreferrer">Windows
                         </a>
-
-
                     </span>
                 </div>
             </template>
         </CollapsingCard>
-        <FeatherButton primary @click="welcomeStore.nextSlide" data-test="welcome-slide-one-setup-button">Start Setup
-        </FeatherButton>
+        <div class="footer-button">
+            <FeatherButton primary @click="welcomeStore.nextSlide" data-test="welcome-slide-one-setup-button">Start Setup
+            </FeatherButton>
+        </div>
     </div>
 </template>
 <script lang="ts" setup>
@@ -143,7 +136,12 @@ ul li {
 .welcome-text {
     margin-top: 24px;
     margin-bottom: 24px;
+
+    h1 {
+        font-size: 28px;
+    }
 }
+
 
 .visible {
     opacity: 1;
@@ -181,5 +179,19 @@ ul li {
 
 .docker-setup {
     display: flex;
+
+    a {
+        margin-left: 16px;
+        display: inline-block;
+        color: var(--feather-primary);
+        text-decoration: underline;
+        font-weight: 700;
+    }
+}
+
+.footer-button {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
 }
 </style>

--- a/ui/src/components/Welcome/WelcomeSlideThree.vue
+++ b/ui/src/components/Welcome/WelcomeSlideThree.vue
@@ -25,7 +25,7 @@
 
             <ItemPreview v-if="welcomeStore.discoverySubmitted" :loading="welcomeStore.devicePreview.loading"
                 :title="welcomeStore.devicePreview.title" :itemTitle="welcomeStore.devicePreview.itemTitle"
-                :itemSubtitle="welcomeStore.devicePreview.itemSubtitle"
+                :itemSubtitle="welcomeStore.devicePreview.itemSubtitle" :bottomCopy="welcomeStore.devicePreview.bottomCopy"
                 :itemStatuses="welcomeStore.devicePreview.itemStatuses" />
             <div class="welcome-slide-footer">
                 <FeatherButton data-test="welcome-store-slide-three-skip-button" text @click="welcomeStore.skipSlideThree">

--- a/ui/src/components/Welcome/WelcomeSlideTwo.vue
+++ b/ui/src/components/Welcome/WelcomeSlideTwo.vue
@@ -8,23 +8,19 @@
     ]">
         <div class="welcome-slide-two-inner">
             <div class="welcome-slide-two-title">
-                <h1 data-test="welcome-slide-two-title">Minion Installation</h1>
+                <h1 data-test="welcome-slide-two-title">Minion<FeatherIcon class="info-icon" :icon="InformationIcon">
+                    </FeatherIcon>
+                    Installation
+                </h1>
                 <p>The Minion installation can take up to 10 minutes. You will download an encrypted certificate for the
                     Minion and run a Docker command.</p>
             </div>
-            <div class="welcome-slide-two-location-callout">
-                <div class="welcome-slide-two-location-callout-left" data-test="welcome-slide-two-callout">
-                    <InformationIcon />
-                </div>
-                <div class="welcome-slide-two-location-callout-right">
-                    <span>We have created a default location for your first Minion.</span>
-                    <a href="https://docs.opennms.com/cloud/locations.html" target="_blank" rel="noopener noreferrer">Learn
-                        More About
-                        Locations</a>
-                </div>
-            </div>
+
             <div class="welcome-slide-step">
                 <h2>Step 1: Download Encrypted Minion Certificate</h2>
+                <pre
+                    class="pre-wrap">Select a permanent location for the download (e.g., /minion/default-certificate.p12). Future Minion restarts require the certificate.</pre>
+
                 <div class="welcome-slide-table">
                     <div class="welcome-slide-table-header">
                         <div>Encrypted Minion Certificate</div>
@@ -43,8 +39,6 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="welcome-slide-table-body">
                     </div>
                 </div>
             </div>
@@ -72,6 +66,7 @@
                                 :value="welcomeStore.dockerCmd()" class="styled-like-pre" />
                         </div>
                         <div class="password-right">Password:&nbsp;{{ welcomeStore.minionCert.password }}
+                            Save the password somewhere safe.
                             <span v-if="passwordCopyEnabled">
                                 <FeatherButton icon="CopyIcon" @click="copyPassword" v-if="!copied">
                                     <FeatherIcon :icon="CopyIcon"></FeatherIcon>
@@ -217,7 +212,6 @@ const { isDark } = useTheme();
 
 .welcome-slide-two-wrapper.dark {
 
-    .welcome-slide-two-location-callout,
     .welcome-slide-table-body {
         background-color: #e5f4f9;
         color: var($primary-text-on-color);
@@ -226,39 +220,12 @@ const { isDark } = useTheme();
 
 .welcome-slide-two-wrapper.light {
 
-    .welcome-slide-two-location-callout,
     .welcome-slide-table-body {
         background-color: var(--feather-background);
     }
 
-    .welcome-slide-two-location-callout {
-        background-color: #e5f4f9;
-    }
 }
 
-
-.welcome-slide-two-location-callout {
-    display: flex;
-    align-items: center;
-    border-radius: 3px;
-    gap: 16px;
-    padding: 12px 16px;
-    margin: 28px 0;
-
-    .welcome-slide-two-location-callout-left {
-        width: 30px;
-        font-size: 24px;
-
-        svg {
-            fill: #5cb9db;
-        }
-    }
-
-    a {
-        color: #273180;
-        display: block;
-    }
-}
 
 .welcome-slide-step {
     margin-bottom: 32px;
@@ -302,6 +269,7 @@ const { isDark } = useTheme();
     border-radius: 3px;
     margin-top: 24px;
     color: var($disabled-text-on-surface);
+    font-size: 0.9em;
 
     :deep(.spinner-container) {
         width: 24px;
@@ -349,6 +317,7 @@ const { isDark } = useTheme();
 .welcome-slide-minion-success .copy {
     color: var($primary-text-on-surface);
     font-weight: 700;
+    font-size: 0.9em;
 }
 
 .loader-button {
@@ -413,10 +382,28 @@ const { isDark } = useTheme();
 
 .pre-wrap {
     white-space: pre-wrap;
+    @include body-small();
 }
 
 .copy-icon {
     font-size: 36px;
     margin-left: var(--feather-spacing-s);
+}
+
+.welcome-slide-two-title {
+    margin-bottom: 16px;
+
+    :deep(svg) {
+        cursor: pointer;
+    }
+}
+
+.info-icon {
+    color: var(--feather-shade-2);
+    font-size: 22px;
+    top: -3px;
+    position: relative;
+    margin-left: 4px;
+    margin-right: 8px;
 }
 </style>

--- a/ui/src/store/Views/welcomeStore.ts
+++ b/ui/src/store/Views/welcomeStore.ts
@@ -73,7 +73,8 @@ export const useWelcomeStore = defineStore('welcomeStore', {
       itemTitle: '',
       itemSubtitle: '',
       itemStatuses: [
-      ]
+      ],
+      bottomCopy: 'We assigned your device to a location called \'default.\''
     },
     discoverySubmitted: false,
     discoveryErrorTimeout: -1,
@@ -86,7 +87,7 @@ export const useWelcomeStore = defineStore('welcomeStore', {
     firstDiscoveryErrors: { name: '', ip: '', communityString: '', port: '' },
     firstDiscoveryValidation: yup.object().shape({
       name: yup.string().required("Please enter a name."),
-      ip: yup.string().required("Please enter an IP.").matches(new RegExp(REGEX_EXPRESSIONS.IP[0]), 'Must be a valid IP.'),
+      ip: yup.string().required("Please enter an IP.").matches(new RegExp(REGEX_EXPRESSIONS.IP[0]), 'Single IP address only. You cannot enter a range.'),
       communityString: yup.string(),
       port: yup.number()
     }).required(),


### PR DESCRIPTION
## Description
We've addressed a variety of small design and copy updates for the welcome guide in this PR. The changes are as follows:

## First Screen

### Remove Break and reduce font size to 28px
<img width="786" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/58e5b355-3715-4647-af10-561b94031a21">

### Update Style of Requirements Box to provided specs
<img width="736" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/084021d0-acf7-480f-befa-ed5767f668f6">

### Update Link Styling
<img width="652" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/3002aef5-a25b-412f-9e16-30213a0cd2fa">

### Update Button Position
<img width="698" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/849b2c45-d11c-410b-b11c-698c04884c36">

### Full changes to first screen
<img width="1704" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/e7d9fb21-e779-4377-9a5c-708ef7396cab">

## Second Screen

### Addition of Information Icon to Header
<img width="664" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/212ada0b-aec2-488d-bf7f-44c6d2b63895">

### New copy for selecting a location for the downloaded file
<img width="647" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/a12fcff2-8aae-4bc4-8edc-3a4a776684b1">

### Removal of Blue Box under Download
<img width="743" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/1171eac3-74f8-4b12-9133-5b692f295263">

### Addition of text next to password
<img width="615" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/c5e5e752-25fc-43fc-bfcd-94d9005eb2bc">

### Slight reduction of text size so copy does not wrap
<img width="626" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/2d9b29f8-f615-4fe7-ab99-23144b3432f2">

### Screen 2 Full View
<img width="735" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/4720d967-3b8f-489e-86e5-ea6d2c2542c3">
<img width="645" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/3b822a42-5e9d-4496-b0d1-201b8d54aa5e">

## Screen 3

### New copy for error
<img width="644" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/e22b9bbc-7a2c-4632-aee1-704dd7ce6687">

### New copy for Device Preview
<img width="637" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/5fd657ca-1397-44bf-ade5-690861429561">

### Full Page 3
<img width="758" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/38ec16cd-2704-47f4-b7b3-5c5ccd481094">


## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1841

## Checklist
* [X] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [X] Jira issue(s) have been updated to "In Review".
* ~~[ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)~~ (style updates only)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [X] Notify documentation team of any changes to names of screens or features (affects URLs).
