### PR TITLE
HS-1843: Add time range for exporters query

### DIFF
--- a/ui/src/store/Views/nodeStatusStore.ts
+++ b/ui/src/store/Views/nodeStatusStore.ts
@@ -19,7 +19,6 @@ export const useNodeStatusStore = defineStore('nodeStatusStore', () => {
     const endTime = Date.now()
 
     const payload: RequestCriteriaInput = {
-      count: 1000,
       exporter: [{
         nodeId: id
       }],

--- a/ui/src/store/Views/nodeStatusStore.ts
+++ b/ui/src/store/Views/nodeStatusStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { useNodeStatusQueries } from '@/store/Queries/nodeStatusQueries'
+import { useFlowsStore } from './flowsStore'
 import { AZURE_SCAN, DeepPartial } from '@/types'
 import { Exporter, RequestCriteriaInput } from '@/types/graphql'
 
@@ -13,10 +14,20 @@ export const useNodeStatusStore = defineStore('nodeStatusStore', () => {
   }
 
   const fetchExporters = async (id: number) => {
+    // flows can be queried up to last 7 days.
+    const now = new Date()
+    const startTime = now.setDate(now.getDate() - 7)
+    const endTime = Date.now()
+
     const payload: RequestCriteriaInput = {
+      count: 1000,
       exporter: [{
         nodeId: id
-      }]
+      }],
+      timeRange: {
+        startTime,
+        endTime
+      }
     }
     const data = await nodeStatusQueries.fetchExporters(payload)
     exporters.value = data.value?.findExporters || []

--- a/ui/src/store/Views/nodeStatusStore.ts
+++ b/ui/src/store/Views/nodeStatusStore.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { useNodeStatusQueries } from '@/store/Queries/nodeStatusQueries'
-import { useFlowsStore } from './flowsStore'
 import { AZURE_SCAN, DeepPartial } from '@/types'
 import { Exporter, RequestCriteriaInput } from '@/types/graphql'
 

--- a/ui/tests/store/Views/nodeStatusStore.test.ts
+++ b/ui/tests/store/Views/nodeStatusStore.test.ts
@@ -17,6 +17,16 @@ describe('Node Status Store', () => {
 
     const store = useNodeStatusStore()
     const queries = useNodeStatusQueries()
+
+    const capturedNowInMs = new Date().getTime()
+    const testDate = new Date(capturedNowInMs)
+    
+    global.Date = vitest.fn().mockImplementation(() => testDate) as any
+    global.Date.now = vitest.fn().mockImplementation(() => capturedNowInMs)
+    
+    const endTime = Date.now()
+    const startTime = endTime - 1000 * 60 * 60 * 24 * 7 // endTime - 7 days
+
     await store.fetchExporters(1)
 
     expect(queries.fetchExporters).toHaveBeenCalledOnce()
@@ -25,7 +35,11 @@ describe('Node Status Store', () => {
         {
           nodeId: 1
         }
-      ]
+      ],
+      timeRange: {
+        startTime,
+        endTime
+      }
     })
   })
 })


### PR DESCRIPTION
## Description
Time range is listed as optional in GQL playground, but looks like it's required somewhere on the BE.
Uses the last 7 days because that's the maximum range the user can filter on the flows page.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1843

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
