### PR TITLE
HS-1654: Fix extra URL fragments caused by an incompatibility between Keycloak and VueJS router

### DIFF
--- a/ui/src/components/Inventory/InventoryTextAnchorList.vue
+++ b/ui/src/components/Inventory/InventoryTextAnchorList.vue
@@ -33,7 +33,8 @@
 
 <script lang="ts" setup>
 import { Anchor } from '@/types/inventory'
-import router from '@/router'
+
+const router = useRouter()
 
 defineProps<{
   anchor: Anchor

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,6 +1,5 @@
 import { createApp } from 'vue'
 import App from './App.vue'
-import router from './router'
 import { createPinia } from 'pinia'
 import VueKeycloak from '@dsb-norge/vue-keycloak-js'
 import Keycloak from 'keycloak-js'
@@ -16,22 +15,30 @@ import { getGqlClient } from './services/gqlService'
 const { setKeycloak } = useKeycloak()
 
 const app = createApp(App)
-  .use(router)
   .use(createPinia())
   .use(VueKeycloak, {
     init: {
-      onLoad: 'login-required',
-      redirectUri: window.location.href
+      onLoad: 'login-required'
     },
     config: {
       realm: keycloakConfig.realm,
       url: keycloakConfig.url,
       clientId: keycloakConfig.clientId
     },
-    onReady: (kc: Keycloak) => {
+    onReady: async (kc: Keycloak) => {
       setKeycloak(kc)
       const gqlClient = getGqlClient(kc)
       app.use(gqlClient)
+
+      // FIXME: This is a workaround for these issues:
+      //  https://github.com/keycloak/keycloak/issues/14742
+      //  https://opennms.atlassian.net/browse/HS-1654
+      //  VueJS's `createRouter` function interferes with the routing Keycloak does as part of its auth process.
+      //  Keycloak needs to be fully initialized before the router is imported.
+      //  Other components should prefer `const router = useRouter()`, importing `@/router` can cause this to regress.
+      const router = await import('./router')
+      app.use(router.default)
+
       app.mount('#app')
     }
   })

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -25,7 +25,7 @@ const app = createApp(App)
       url: keycloakConfig.url,
       clientId: keycloakConfig.clientId
     },
-    onReady: async (kc: Keycloak) => {
+    onReady: (kc: Keycloak) => {
       setKeycloak(kc)
       const gqlClient = getGqlClient(kc)
       app.use(gqlClient)
@@ -36,10 +36,11 @@ const app = createApp(App)
       //  VueJS's `createRouter` function interferes with the routing Keycloak does as part of its auth process.
       //  Keycloak needs to be fully initialized before the router is imported.
       //  Other components should prefer `const router = useRouter()`, importing `@/router` can cause this to regress.
-      const router = await import('./router')
-      app.use(router.default)
-
-      app.mount('#app')
+      import('./router')
+        .then((router) => {
+          app.use(router.default)
+          app.mount('#app')
+        })
     }
   })
   .directive('date', dateFormatDirective)

--- a/ui/src/store/Views/welcomeStore.ts
+++ b/ui/src/store/Views/welcomeStore.ts
@@ -6,7 +6,6 @@ import {
   Node
 } from '@/types/graphql'
 import { createAndDownloadBlobFile } from '@/components/utils'
-import router from '@/router'
 import { ItemPreviewProps } from '@/components/Common/commonTypes'
 import { useLocationMutations } from '../Mutations/locationMutations'
 import { useDiscoveryMutations } from '../Mutations/discoveryMutations'
@@ -16,6 +15,8 @@ import { validationErrorsToStringRecord } from '@/services/validationService'
 import useMinionCmd from '@/composables/useMinionCmd'
 import { ComputedRef } from 'vue'
 import { useWelcomeQueries } from '../Queries/welcomeQueries'
+
+const router = useRouter()
 
 interface WelcomeStoreState {
   copied: boolean


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
Keycloak uses URL fragments to keep track of items in localStorage. VueJS's router is incompatible with how Keycloak does this, which causes the fragments to stick around and accumulate. When the URL gets long enough it causes the nginx ingress to return 502 errors.

This is a workaround that fixes the issue. Keycloak needs to be fully initialized before the `@/router` file is imported anywhere - in main.ts the import was moved to the onReady callback, but it also needed to be changed in welcomeStore since it's imported in App.vue. 

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1654

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
