### PR TITLE
HS-1841: Followup Fix

### DIFF
--- a/ui/src/components/Common/ItemPreview.vue
+++ b/ui/src/components/Common/ItemPreview.vue
@@ -18,7 +18,7 @@
         </div>
       </div>
     </div>
-    <div v-if="bottomCopy" class="bottom-copy">{{ bottomCopy }}</div>
+    <div v-if="bottomCopy && !loading" class="bottom-copy">{{ bottomCopy }}</div>
     <div class="item-preview-loading" v-if="loading">
       <div>
         <FeatherSpinner />


### PR DESCRIPTION
## Description
We added a new piece of text to the bottom of our device preview on the Welcome Guide, but we did not account for when that box is in a preview/loading state (the new text showed up). We don't want it to show up until loading is done, which is what this PR fixes.

### Visual Bug
![image](https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/2f10d498-56f2-411a-a7bd-cb8ff3e7ce54)

### Visual Fix
![image](https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/ce72fea8-3ba7-4f8e-89ad-d9646a4e9263)


### Final Result
![image](https://github.com/OpenNMS-Cloud/lokahi/assets/86311553/145ee121-232f-48bc-b3ba-2d595a31c3f3)


## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1841

## Checklist
* [X] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [X] Appropriate reviewer(s) have been selected.
* [X] Jira issue(s) have been updated to "In Review".
* ~~[ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)~~
* ~~[ ] Documentation has been updated as necessary.~~
* ~~[ ] Notify devops of changes to the Charts.~~
* ~~[ ] Notify documentation team of any changes to names of screens or features (affects URLs).~~
