### PR TITLE
Make some env vars optional for the UI tests

### DIFF
--- a/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/CucumberHooks.java
+++ b/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/CucumberHooks.java
@@ -56,6 +56,8 @@ public class CucumberHooks {
     public static String minionDockerTag = "latest";
     public static boolean keycloakLogin = true;
 
+    public static String defaultMinionName = "testMinion";
+
     @BeforeAll
     public static void setUp() {
         Configuration.fileDownload = FileDownloadMode.FOLDER;
@@ -87,9 +89,6 @@ public class CucumberHooks {
         }
 
         overrideAuthority = System.getenv("MINION_INGRESS_OVERRIDE_AUTHORITY");
-        if (overrideAuthority == null) {
-            overrideAuthority = "minion.onmshs.local";
-        }
         instanceUrl = System.getenv("INGRESS_BASE_URL");
         if (instanceUrl == null) {
             instanceUrl = "https://onmshs.local:" + gatewayPort;
@@ -100,7 +99,7 @@ public class CucumberHooks {
             minionDockerTag = "latest";
         }
 
-        SetupSteps.loggedInWithANamedMinion("testMinion");
+        SetupSteps.loggedInWithANamedMinion(defaultMinionName);
     }
 
 

--- a/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/UiCucumberRunnerTest.java
+++ b/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/UiCucumberRunnerTest.java
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith;
     plugin = {"pretty",
         "json:cucumber.reports/cucumber-report.json",
         "html:cucumber.reports/cucumber-report.html"},
-    tags = "not @ignore"
+    tags = "@welcome or @discovery and not @ignore"
 )
 public class UiCucumberRunnerTest {
 }

--- a/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/pages/InventoryPage.java
+++ b/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/pages/InventoryPage.java
@@ -60,14 +60,14 @@ public class InventoryPage {
         // The inventory page doesn't refresh on its own. Need to periodically check and force a refresh
         String itemStatusSearch = "//ul[@class='cards']/li[//li[@data-test='management-ip']/span/text()='" + nodename + "']//div[@title='Status']//span[text()='" + status + "']";
         SelenideElement statusCheck = $(By.xpath(itemStatusSearch));
-        int iterations = 10;
+        int iterations = 20;
         while (!statusCheck.exists() && iterations > 0) {
             --iterations;
             Selenide.refresh();
             LeftPanelPage.clickOnPanelSection("inventory");
 
             try {
-                Thread.sleep(500);
+                Thread.sleep(2000);
             } catch (InterruptedException e) {
                 // Ignore and busy-loop it
             }

--- a/test-automation/ui-tests/src/test/java/testcontainers/MinionContainer.java
+++ b/test-automation/ui-tests/src/test/java/testcontainers/MinionContainer.java
@@ -73,7 +73,6 @@ public class MinionContainer extends GenericContainer<MinionContainer> {
             .withEnv("GRPC_CLIENT_KEYSTORE", "/opt/karaf/minion.p12")
             .withEnv("GRPC_CLIENT_KEYSTORE_PASSWORD", bundlePwd)
             .withCopyFileToContainer(MountableFile.forHostPath(certBundle.getPath()), "/opt/karaf/minion.p12")
-            .withEnv("GRPC_CLIENT_OVERRIDE_AUTHORITY", CucumberHooks.overrideAuthority)
             .withLabel("label", minionId)
 
             .waitingFor(
@@ -99,9 +98,13 @@ public class MinionContainer extends GenericContainer<MinionContainer> {
             .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(3)));
 
         String ca = System.getenv("MINION_INGRESS_CA");
-        if (ca != null) {
+        if (ca != null && !ca.isBlank()) {
             withCopyFileToContainer(MountableFile.forHostPath(ca), "/opt/karaf/ca.crt")
             .withEnv("GRPC_CLIENT_TRUSTSTORE", "/opt/karaf/ca.crt");
+        }
+
+        if (CucumberHooks.overrideAuthority != null && !CucumberHooks.overrideAuthority.isBlank()) {
+            withEnv("GRPC_CLIENT_OVERRIDE_AUTHORITY", CucumberHooks.overrideAuthority);
         }
 
         // expose UDP ports here


### PR DESCRIPTION
## Description
Making some of the UI test env vars optional to allow more versatility in the testing environment.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1866

## Flagged for review

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
