### PR TITLE
BTO-615: Minimize required Docker env vars

### DIFF
--- a/.github/actions/jib-maven-sonar/action.yml
+++ b/.github/actions/jib-maven-sonar/action.yml
@@ -38,7 +38,7 @@ runs:
         SONAR_TOKEN: ${{ inputs.sonar-token }}
         SONAR_PROJECT_KEY: ${{ inputs.sonar-project-key }}
       run: |
-        BASE_IMAGE=ghcr.io/opennms-cloud/$(cat ../.github/base-image-tag-ref.json | jq .image_tag_java | sed 's/\"//g')
+        BASE_IMAGE=ghcr.io/opennms-cloud/$(cat ../.github/base-image-tag-ref.json | jq -r .image_tag_java)
 
         mvn -B -Dstyle.color=always \
             -Pcicd,coverage \
@@ -55,7 +55,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         SONAR_TOKEN: ${{ inputs.sonar-token }}
       run: |
-        BASE_IMAGE=ghcr.io/opennms-cloud/$(cat ../.github/base-image-tag-ref.json | jq .image_tag_java | sed 's/\"//g')
+        BASE_IMAGE=ghcr.io/opennms-cloud/$(cat ../.github/base-image-tag-ref.json | jq -r .image_tag_java)
 
         mvn -B -Dstyle.color=always \
             -Pcicd,coverage \

--- a/.github/workflows/base-image-update.yml
+++ b/.github/workflows/base-image-update.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Pull Image & Push
         run: |
 
-          IMAGE=$(cat .github/base-image-tag-ref.json | jq .image_tag_java | sed 's/\"//g')
+          IMAGE=$(cat .github/base-image-tag-ref.json | jq -r .image_tag_java)
 
           docker pull $IMAGE
           docker tag $IMAGE ghcr.io/opennms-cloud/$IMAGE

--- a/minion/assembly/src/main/resources/etc/org.opennms.core.ipc.grpc.client.cfg
+++ b/minion/assembly/src/main/resources/etc/org.opennms.core.ipc.grpc.client.cfg
@@ -1,10 +1,10 @@
-grpc.host=${env:MINION_GATEWAY_HOST:-minion-gateway}
-grpc.port=${env:MINION_GATEWAY_PORT:-8990}
-grpc.tls.enabled=${env:MINION_GATEWAY_TLS:-false}
+grpc.host=${env:MINION_GATEWAY_HOST:-minion.onms-fb-prod.production.prod.dataservice.opennms.com}
+grpc.port=${env:MINION_GATEWAY_PORT:-443}
+grpc.tls.enabled=${env:MINION_GATEWAY_TLS:-true}
 grpc.max.message.size=${env:MINION_GATEWAY_MAX_MESSAGE_SIZE:-104857600}
 
 # The following only apply when TLS is enabled
-grpc.client.keystore=${env:GRPC_CLIENT_KEYSTORE}
+grpc.client.keystore=${env:GRPC_CLIENT_KEYSTORE:-/opt/karaf/minion.p12}
 grpc.client.keystore.type=${env:GRPC_CLIENT_KEYSTORE_TYPE:-pkcs12}
 grpc.client.keystore.password=${env:GRPC_CLIENT_KEYSTORE_PASSWORD}
 grpc.client.truststore=${env:GRPC_CLIENT_TRUSTSTORE}

--- a/minion/assembly/src/main/resources/etc/org.opennms.horizon.minion.ignite.worker.cfg
+++ b/minion/assembly/src/main/resources/etc/org.opennms.horizon.minion.ignite.worker.cfg
@@ -1,4 +1,4 @@
-useKubernetes=${env:USE_KUBERNETES:-true}
+useKubernetes=${env:USE_KUBERNETES:-false}
 kubernetes.service.name=${env:KUBERNETES_SERVICE_NAME:-ignite-minion-gateway}
 kubernetes.namespace=${env:KUBERNETES_NAMESPACE:-default}
 # Addresses are ignored when using Kubernetes

--- a/minion/docker-assembly/src/main/docker/app/Dockerfile
+++ b/minion/docker-assembly/src/main/docker/app/Dockerfile
@@ -85,13 +85,7 @@ CMD [ "daemon" ]
 STOPSIGNAL SIGTERM
 
 ### Runtime information and not relevant at build time
-ENV IGNITE_UPDATE_NOTIFIER="false" \
-    MINION_GATEWAY_HOST="minion.onms-fb-prod.production.prod.dataservice.opennms.com" \
-    MINION_GATEWAY_PORT="443" \
-    MINION_GATEWAY_TLS="true" \
-    USE_KUBERNETES="false" \
-    GRPC_CLIENT_KEYSTORE="/opt/karaf/minion.p12"
-
+ENV IGNITE_UPDATE_NOTIFIER="false"
 
 ##------------------------------------------------------------------------------
 ## EXPOSED PORTS

--- a/minion/docker-assembly/src/main/docker/app/Dockerfile
+++ b/minion/docker-assembly/src/main/docker/app/Dockerfile
@@ -86,10 +86,11 @@ STOPSIGNAL SIGTERM
 
 ### Runtime information and not relevant at build time
 ENV IGNITE_UPDATE_NOTIFIER="false" \
-    MINION_LOCATION="MINION" \
-    MINION_GATEWAY_HOST="minion-gateway" \
-    MINION_GATEWAY_PORT="8990" \
-    MINION_GATEWAY_TLS="false"
+    MINION_GATEWAY_HOST="minion.onms-fb-prod.production.prod.dataservice.opennms.com" \
+    MINION_GATEWAY_PORT="443" \
+    MINION_GATEWAY_TLS="true" \
+    USE_KUBERNETES="false" \
+    GRPC_CLIENT_KEYSTORE="/opt/karaf/minion.p12"
 
 
 ##------------------------------------------------------------------------------

--- a/minion/docker-assembly/src/main/docker/entrypoint/entrypoint.sh
+++ b/minion/docker-assembly/src/main/docker/entrypoint/entrypoint.sh
@@ -6,12 +6,8 @@ trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 ### Required: GRPC_CLIENT_KEYSTORE file encrypted with GRPC_CLIENT_KEYSTORE_PASSWORD
 
-if ! [[ -v GRPC_CLIENT_KEYSTORE ]]; then
-	echo "Required keystore file environment variable 'GRPC_CLIENT_KEYSTORE' not set." >&2
-	echo "This should always be set by the Dockerfile, so this error is unexpected." >&2
-	echo "Workaround: example docker argument to pass keystore file: -e GRPC_CLIENT_KEYSTORE=/opt/karaf/minion.p12" >&2
-	exit 1
-fi
+# This needs to match the default in assembly/src/main/resources/etc/org.opennms.core.ipc.grpc.client.cfg
+GRPC_CLIENT_KEYSTORE="${GRPC_CLIENT_KEYSTORE:-/opt/karaf/minion.p12}"
 
 if [ ! -e "${GRPC_CLIENT_KEYSTORE}" ]; then
 	echo "Required keystore file not found inside the container." >&2

--- a/minion/docker-assembly/src/main/docker/entrypoint/entrypoint.sh
+++ b/minion/docker-assembly/src/main/docker/entrypoint/entrypoint.sh
@@ -8,7 +8,8 @@ trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 if ! [[ -v GRPC_CLIENT_KEYSTORE ]]; then
 	echo "Required keystore file environment variable 'GRPC_CLIENT_KEYSTORE' not set." >&2
-	echo "Example docker argument to pass keystore file: -e GRPC_CLIENT_KEYSTORE=/opt/karaf/minion.p12" >&2
+	echo "This should always be set by the Dockerfile, so this error is unexpected." >&2
+	echo "Workaround: example docker argument to pass keystore file: -e GRPC_CLIENT_KEYSTORE=/opt/karaf/minion.p12" >&2
 	exit 1
 fi
 

--- a/minion/minion-grpc/grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/minion/minion-grpc/grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -10,9 +10,9 @@
 
     <cm:property-placeholder id="serverProperties" persistent-id="org.opennms.core.ipc.grpc.client" update-strategy="reload">
         <cm:default-properties>
-            <cm:property name="grpc.tls.enabled" value="false"/>
+            <cm:property name="grpc.tls.enabled" value="true"/>
 
-            <cm:property name="grpc.client.keystore" value="false"/>
+            <cm:property name="grpc.client.keystore" value="/opt/karaf/minion.p12"/>
             <cm:property name="grpc.client.keystore.type" value="pkcs12"/>
             <cm:property name="grpc.client.keystore.password" value=""/>
             <cm:property name="grpc.client.truststore" value="false"/>
@@ -21,8 +21,8 @@
 
             <cm:property name="grpc.override.authority" value="opennms-minion-ssl-gateway"/>
             <cm:property name="grpc.max.message.size" value="104857600"/>
-            <cm:property name="grpc.host" value="localhost"/>
-            <cm:property name="grpc.port" value="8990"/>
+            <cm:property name="grpc.host" value="minion.onms-fb-prod.production.prod.dataservice.opennms.com"/>
+            <cm:property name="grpc.port" value="443"/>
 
             <cm:property name="sendQueue.memory" value="4096"/> <!-- 4K Elements -->
             <cm:property name="sendQueue.offHeap" value="4194304"/> <!-- 4M Elements -->


### PR DESCRIPTION
- BTO-615: minion: Update default env vars in Dockerfile
- GitHub workflows: Use "jq -r" instead of sed to strip quotes.
- Minion: Move defaults from the Dockerfile to the resources/blueprint

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
This reduces the number of environment variables that are needed to be passed to Docker to 1: the password.

Here's what I was able to use to connect to production:
```
docker run --rm \
    -p 162:1162/udp \
    -p 9999:9999/udp \
    -e GRPC_CLIENT_KEYSTORE_PASSWORD='<password>' \
    --mount type=bind,source="$(pwd)/default-certificate (5).p12",target="/opt/karaf/minion.p12",readonly \
    localhost:62186/opennms_lokahi-minion:tilt-build-1690391803
```

Follow-on work:
1. After this is merged **and** we have a release made so that `opennms/lokahi-minion:latest` is updated, we can update the UI. I'll add another PR for the UI change.
2. Cleanup all of the tests, docker-compose files, and documentation to remove unnecessary environment variables.
3. Can we de-duplicate default values that are set in both the resource files and the blueprint? Maybe only put it in the resource files and have the blueprint bomb if they aren't set? Having to do this in two places **sucks**. We should at least add comments to the files to remind people to update both copies (and maybe have tests to verify?).

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-615

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
