### PR TITLE
HS-1861: Adding /sec to charts

### DIFF
--- a/ui/src/components/Flows/LineChart.vue
+++ b/ui/src/components/Flows/LineChart.vue
@@ -140,7 +140,7 @@ const chartOptions = computed<ChartOptions<any>>(() => {
         },
         ticks: {
           callback: function (value: any) {
-            return humanFileSize(value)
+            return humanFileSize(value) + props.labelSuffix
           }
         },
         title: {

--- a/ui/src/components/Flows/LineChart.vue
+++ b/ui/src/components/Flows/LineChart.vue
@@ -25,7 +25,7 @@ import {
   Legend,
   ChartOptions
 } from 'chart.js'
-import { humanFileSize } from '../utils'
+import { humanFileSizeFromBits } from '../utils'
 const { onThemeChange, isDark } = useTheme()
 
 Chart.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend)
@@ -117,7 +117,7 @@ const chartOptions = computed<ChartOptions<any>>(() => {
           title: (context: any) => context.label,
           label: (context: any) => {
             const appName = context.dataset.label
-            return `${appName} : ` + humanFileSize(context.parsed.y) + props.labelSuffix
+            return `${appName} : ` + humanFileSizeFromBits(context.parsed.y) + props.labelSuffix
           }
         }
       }
@@ -140,7 +140,7 @@ const chartOptions = computed<ChartOptions<any>>(() => {
         },
         ticks: {
           callback: function (value: any) {
-            return humanFileSize(value) + props.labelSuffix
+            return humanFileSizeFromBits(value) + props.labelSuffix
           }
         },
         title: {

--- a/ui/src/components/Flows/LineChart.vue
+++ b/ui/src/components/Flows/LineChart.vue
@@ -54,6 +54,11 @@ const props = defineProps({
   getChartAreaWidthForDataPoints: {
     required: true,
     type: Function as PropType<(width: number) => void>
+  },
+  labelSuffix: {
+    required: false,
+    type: String,
+    default: ''
   }
 })
 const lineChart = ref()
@@ -112,7 +117,7 @@ const chartOptions = computed<ChartOptions<any>>(() => {
           title: (context: any) => context.label,
           label: (context: any) => {
             const appName = context.dataset.label
-            return `${appName} : ` + humanFileSize(context.parsed.y)
+            return `${appName} : ` + humanFileSize(context.parsed.y) + props.labelSuffix
           }
         }
       }

--- a/ui/src/components/Flows/TableChart.vue
+++ b/ui/src/components/Flows/TableChart.vue
@@ -15,9 +15,9 @@
         </thead>
         <tbody>
           <tr v-for="(data, index) in tableData" :key="index">
-            <td>{{ humanFileSize(Number(addValues(data.bytesIn, data.bytesOut))) }}</td>
-            <td>{{ humanFileSize(data.bytesIn) }}</td>
-            <td>{{ humanFileSize(data.bytesOut) }}</td>
+            <td>{{ humanFileSize(Number(addValues(data.bytesIn, data.bytesOut))) + labelSuffix }} </td>
+            <td>{{ humanFileSize(data.bytesIn) + labelSuffix }}</td>
+            <td>{{ humanFileSize(data.bytesOut) + labelSuffix }}</td>
           </tr>
         </tbody>
       </table>
@@ -53,6 +53,11 @@ const props = defineProps({
   selectedFilterRange: {
     required: true,
     type: String
+  },
+  labelSuffix: {
+    required: false,
+    type: String,
+    default: ''
   }
 })
 

--- a/ui/src/components/Flows/TableChart.vue
+++ b/ui/src/components/Flows/TableChart.vue
@@ -15,9 +15,9 @@
         </thead>
         <tbody>
           <tr v-for="(data, index) in tableData" :key="index">
-            <td>{{ humanFileSize(Number(addValues(data.bytesIn, data.bytesOut))) + labelSuffix }} </td>
-            <td>{{ humanFileSize(data.bytesIn) + labelSuffix }}</td>
-            <td>{{ humanFileSize(data.bytesOut) + labelSuffix }}</td>
+            <td>{{ humanFileSize(Number(addValues(data.bytesIn, data.bytesOut))) }} </td>
+            <td>{{ humanFileSize(data.bytesIn) }}</td>
+            <td>{{ humanFileSize(data.bytesOut) }}</td>
           </tr>
         </tbody>
       </table>
@@ -53,11 +53,6 @@ const props = defineProps({
   selectedFilterRange: {
     required: true,
     type: String
-  },
-  labelSuffix: {
-    required: false,
-    type: String,
-    default: ''
   }
 })
 
@@ -107,7 +102,7 @@ const chartOptions = computed<ChartOptions<any>>(() => {
             const value = context.dataset.data[context.dataIndex]
             const labelAbbrev = context.dataset.label.substring(0, 3).toLowerCase()
             const appName = context.label
-            return `${appName}(${labelAbbrev}): ` + humanFileSize(value) + props.labelSuffix
+            return `${appName}(${labelAbbrev}): ` + humanFileSize(value)
           }
         }
       }
@@ -121,7 +116,7 @@ const chartOptions = computed<ChartOptions<any>>(() => {
         },
         ticks: {
           callback: function (value: any) {
-            return humanFileSize(value) + props.labelSuffix
+            return humanFileSize(value)
           }
         }
       },

--- a/ui/src/components/Flows/TableChart.vue
+++ b/ui/src/components/Flows/TableChart.vue
@@ -107,7 +107,7 @@ const chartOptions = computed<ChartOptions<any>>(() => {
             const value = context.dataset.data[context.dataIndex]
             const labelAbbrev = context.dataset.label.substring(0, 3).toLowerCase()
             const appName = context.label
-            return `${appName}(${labelAbbrev}): ` + humanFileSize(value)
+            return `${appName}(${labelAbbrev}): ` + humanFileSize(value) + props.labelSuffix
           }
         }
       }
@@ -121,7 +121,7 @@ const chartOptions = computed<ChartOptions<any>>(() => {
         },
         ticks: {
           callback: function (value: any) {
-            return humanFileSize(value)
+            return humanFileSize(value) + props.labelSuffix
           }
         }
       },

--- a/ui/src/components/Flows/TableChart.vue
+++ b/ui/src/components/Flows/TableChart.vue
@@ -15,7 +15,7 @@
         </thead>
         <tbody>
           <tr v-for="(data, index) in tableData" :key="index">
-            <td>{{ humanFileSize(Number(addValues(data.bytesIn, data.bytesOut))) }} </td>
+            <td>{{ humanFileSize(Number(addValues(data.bytesIn, data.bytesOut))) }}</td>
             <td>{{ humanFileSize(data.bytesIn) }}</td>
             <td>{{ humanFileSize(data.bytesOut) }}</td>
           </tr>

--- a/ui/src/components/utils.ts
+++ b/ui/src/components/utils.ts
@@ -105,3 +105,12 @@ export const humanFileSize = (bytes: number, si = true, dp = 1) => {
 
   return bytes.toFixed(dp) + ' ' + units[u];
 }
+
+/**
+ * @param bits Bits as a number
+ * @returns a nicely formatted string
+ */
+export const humanFileSizeFromBits = (bits: number) => {
+  const bytes = bits / 8
+  return humanFileSize(bytes)
+}

--- a/ui/src/components/utils.ts
+++ b/ui/src/components/utils.ts
@@ -108,9 +108,25 @@ export const humanFileSize = (bytes: number, si = true, dp = 1) => {
 
 /**
  * @param bits Bits as a number
+ * @param dp Number of decimal places to show
  * @returns a nicely formatted string
  */
-export const humanFileSizeFromBits = (bits: number) => {
-  const bytes = bits / 8
-  return humanFileSize(bytes)
+export const humanFileSizeFromBits = (bits: number, dp = 1) => {
+  const thresh = 1000
+
+  if (Math.abs(bits) < thresh) {
+    return bits + ' b'
+  }
+
+  const units = ['kb', 'Mb', 'Gb', 'Tb', 'Pb']
+
+  let u = -1
+  const r = 10 ** dp
+
+  do {
+    bits /= thresh
+    ++u
+  } while (Math.round(Math.abs(bits) * r) / r >= thresh && u < units.length - 1)
+
+   return bits.toFixed(dp) + ' ' + units[u]
 }

--- a/ui/src/containers/Flows.vue
+++ b/ui/src/containers/Flows.vue
@@ -133,7 +133,6 @@
         ref="tableChartApplications"
         :selected-filter-range="flowsStore.filters.dateFilter"
         :chart-data="appStore.tableChartData"
-        labelSuffix=" /sec"
         :table-data="appStore.tableData"
       />
       <LineChart

--- a/ui/src/containers/Flows.vue
+++ b/ui/src/containers/Flows.vue
@@ -133,6 +133,7 @@
         ref="tableChartApplications"
         :selected-filter-range="flowsStore.filters.dateFilter"
         :chart-data="appStore.tableChartData"
+        labelSuffix=" /sec"
         :table-data="appStore.tableData"
       />
       <LineChart
@@ -142,6 +143,7 @@
         :selected-filter-range="flowsStore.filters.dateFilter"
         :chart-data="appStore.lineChartData"
         :table-data="appStore.tableData"
+        labelSuffix=" /sec"
         :format="flowsStore.convertToDate"
         :get-chart-area-width-for-data-points="setMaxDataPointsAndUpdateCharts"
       />

--- a/ui/src/containers/Flows.vue
+++ b/ui/src/containers/Flows.vue
@@ -142,7 +142,7 @@
         :selected-filter-range="flowsStore.filters.dateFilter"
         :chart-data="appStore.lineChartData"
         :table-data="appStore.tableData"
-        labelSuffix=" /sec"
+        labelSuffix="/sec"
         :format="flowsStore.convertToDate"
         :get-chart-area-width-for-data-points="setMaxDataPointsAndUpdateCharts"
       />

--- a/ui/tests/Utils/common.test.ts
+++ b/ui/tests/Utils/common.test.ts
@@ -1,4 +1,4 @@
-import { getHumanReadableDuration } from '@/components/utils'
+import { getHumanReadableDuration, humanFileSizeFromBits } from '@/components/utils'
 import { TimeUnit } from '@/types'
 
 test('The getHumanReadableDuration function', () => {
@@ -20,4 +20,13 @@ test('The getHumanReadableDuration function', () => {
   expect(getHumanReadableDuration(3661, TimeUnit.Secs)).toBe('1h1m1s')
   expect(getHumanReadableDuration(86461, TimeUnit.Secs)).toBe('1d1m1s')
   expect(getHumanReadableDuration(90061, TimeUnit.Secs)).toBe('1d1h1m1s')
+})
+
+test('The humanFileSizeFromBits function', () => {
+  expect(humanFileSizeFromBits(800)).toBe('800 b')
+  expect(humanFileSizeFromBits(5000)).toBe('5.0 kb')
+  expect(humanFileSizeFromBits(3957278)).toBe('4.0 Mb')
+  expect(humanFileSizeFromBits(9375836293)).toBe('9.4 Gb')
+  expect(humanFileSizeFromBits(9903456789099)).toBe('9.9 Tb')
+  expect(humanFileSizeFromBits(7000938277432849)).toBe('7.0 Pb')
 })


### PR DESCRIPTION
## Description
We had a request to add the string ` /sec` to the flows line chart to indicate the number is a rate, meaning data over time, versus just data. This is tied in with an additional PR to look into the data in the BE, to make sure the rate is actually per seconds.

This was a joint effort between Scott and Mike. Teamwork!

![screenshot-localhost_3009-2023 08 01-11_24_42](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/c379c27c-8f05-4752-a14b-4099926fd6a2)

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1861


## Checklist
* [X] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [X] Appropriate reviewer(s) have been selected.
* [X] Jira issue(s) have been updated to "In Review".
* ~~[ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)~~
* ~~[ ] Documentation has been updated as necessary.~~
* ~~[ ] Notify devops of changes to the Charts.~~
* [x] Notify documentation team of any changes to names of screens or features (affects URLs).
