### PR TITLE
BTO-687-re-enable-minion-gateway-health-checks

### DIFF
--- a/charts/lokahi/templates/opennms/minion-gateway/minion-gateway-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion-gateway/minion-gateway-deployment.yaml
@@ -104,26 +104,26 @@ spec:
               mountPath: /ignite
             - name: spring-boot-app-config-volume
               mountPath: "/app/config"
-#          livenessProbe:
-#            httpGet:
-#              path: "/actuator/health/liveness"
-#              port: http
-#              scheme: HTTP
-#            initialDelaySeconds: 20
-#            timeoutSeconds: 1
-#            periodSeconds: 2
-#            successThreshold: 1
-#            failureThreshold: 150
-#          readinessProbe:
-#            httpGet:
-#              path: "/actuator/health/readiness"
-#              port: http
-#              scheme: HTTP
-#            initialDelaySeconds: 20
-#            timeoutSeconds: 1
-#            periodSeconds: 2
-#            successThreshold: 1
-#            failureThreshold: 250
+          livenessProbe:
+            httpGet:
+              path: "/actuator/health/liveness"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            timeoutSeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            failureThreshold: 150
+          readinessProbe:
+            httpGet:
+              path: "/actuator/health/readiness"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            timeoutSeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            failureThreshold: 250
           resources:
             limits:
               cpu: "{{ .Values.OpenNMS.MinionGateway.Resources.Limits.Cpu }}"


### PR DESCRIPTION
## Description

Re-enable minion gateway readiness and liveness probes.

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-687

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
