### PR TITLE
HS-1810: Events: Adjust fields displayed in UI

### DIFF
--- a/events/persistence/src/main/java/org/opennms/horizon/events/persistence/mapper/EventMapper.java
+++ b/events/persistence/src/main/java/org/opennms/horizon/events/persistence/mapper/EventMapper.java
@@ -3,7 +3,6 @@ package org.opennms.horizon.events.persistence.mapper;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
 import org.opennms.horizon.events.persistence.model.Event;
 import org.opennms.horizon.events.persistence.model.EventParameter;
 import org.opennms.horizon.events.persistence.model.EventParameters;
@@ -15,12 +14,10 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface EventMapper extends DateTimeMapper {
 
-    @Mappings({
-        @Mapping(source = "eventUei", target = "uei"),
-        @Mapping(source = "producedTime", target = "producedTimeMs"),
-        @Mapping(source = "eventInfo", target = "info"),
-        @Mapping(source = "id", target = "databaseId"),
-    })
+    @Mapping(source = "eventUei", target = "uei")
+    @Mapping(source = "producedTime", target = "producedTimeMs")
+    @Mapping(source = "eventInfo", target = "info")
+    @Mapping(source = "id", target = "databaseId")
     org.opennms.horizon.events.proto.Event modelToDTO(Event event);
 
     default org.opennms.horizon.events.proto.Event modelToDtoWithParams(Event event) {

--- a/events/persistence/src/main/java/org/opennms/horizon/events/persistence/mapper/EventMapper.java
+++ b/events/persistence/src/main/java/org/opennms/horizon/events/persistence/mapper/EventMapper.java
@@ -3,6 +3,7 @@ package org.opennms.horizon.events.persistence.mapper;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
 import org.opennms.horizon.events.persistence.model.Event;
 import org.opennms.horizon.events.persistence.model.EventParameter;
 import org.opennms.horizon.events.persistence.model.EventParameters;
@@ -14,9 +15,12 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface EventMapper extends DateTimeMapper {
 
-    @Mapping(source = "eventUei", target = "uei")
-    @Mapping(source = "producedTime", target = "producedTimeMs")
-    @Mapping(source = "eventInfo", target = "info")
+    @Mappings({
+        @Mapping(source = "eventUei", target = "uei"),
+        @Mapping(source = "producedTime", target = "producedTimeMs"),
+        @Mapping(source = "eventInfo", target = "info"),
+        @Mapping(source = "id", target = "databaseId"),
+    })
     org.opennms.horizon.events.proto.Event modelToDTO(Event event);
 
     default org.opennms.horizon.events.proto.Event modelToDtoWithParams(Event event) {

--- a/rest-server/src/main/java/org/opennms/horizon/server/mapper/EventMapper.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/mapper/EventMapper.java
@@ -30,17 +30,14 @@ package org.opennms.horizon.server.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
 import org.opennms.horizon.server.model.events.Event;
 
 
 @Mapper(componentModel = "spring")
 public interface EventMapper {
 
-    @Mappings({
-        @Mapping(source = "parametersList", target = "eventParams"),
-        @Mapping(source = "producedTimeMs", target = "producedTime"),
-        @Mapping(source = "databaseId", target = "id"),
-    })
+    @Mapping(source = "parametersList", target = "eventParams")
+    @Mapping(source = "producedTimeMs", target = "producedTime")
+    @Mapping(source = "databaseId", target = "id")
     Event protoToEvent(org.opennms.horizon.events.proto.Event eventProto);
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/mapper/EventMapper.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/mapper/EventMapper.java
@@ -30,12 +30,17 @@ package org.opennms.horizon.server.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
 import org.opennms.horizon.server.model.events.Event;
 
 
 @Mapper(componentModel = "spring")
 public interface EventMapper {
 
-    @Mapping(source = "parametersList", target = "eventParams")
+    @Mappings({
+        @Mapping(source = "parametersList", target = "eventParams"),
+        @Mapping(source = "producedTimeMs", target = "producedTime"),
+        @Mapping(source = "databaseId", target = "id"),
+    })
     Event protoToEvent(org.opennms.horizon.events.proto.Event eventProto);
 }

--- a/ui/src/components/NodeStatus/EventsTable.vue
+++ b/ui/src/components/NodeStatus/EventsTable.vue
@@ -11,19 +11,15 @@
       <table class="data-table" aria-label="Events Table" data-test="data-table">
         <thead>
           <tr>
-            <th scope="col">ID</th>
             <th scope="col">Time</th>
             <th scope="col">UEI</th>
-            <th scope="col">Node Id</th>
             <th scope="col">IP Address</th>
           </tr>
         </thead>
         <TransitionGroup name="data-table" tag="tbody">
           <tr v-for="event in nodeData.events" :key="event.id as number" data-test="data-item">
-            <td>{{ event.id }}</td>
-            <td>{{ event.producedTime }}</td>
+            <td>{{ fnsFormat(event.producedTime, 'M/dd/yyyy HH:mm:ssxxx') }}</td>
             <td>{{ event.uei }}</td>
-            <td>{{ event.nodeId }}</td>
             <td>{{ event.ipAddress }}</td>
           </tr>
         </TransitionGroup>
@@ -42,6 +38,7 @@
 
 <script lang="ts" setup>
 import { useNodeStatusStore } from '@/store/Views/nodeStatusStore'
+import {format as fnsFormat} from 'date-fns'
 
 const nodeStatusStore = useNodeStatusStore()
 


### PR DESCRIPTION
## Description
A node's associated events didn't have values populated for `id` and `time` in the UI.  These now work.

EDIT: In a team discussion, we decided on removing `id` and `node id` fields.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1810

## Flagged for review
No special remarks.

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).


## Manual Testing

![Screenshot 2023-07-27 at 11 51 38 AM](https://github.com/OpenNMS-Cloud/lokahi/assets/39974723/297d3cf5-267f-4f7d-869e-e191416add4a)
