### PR TITLE
HS-1884: Enable Prometheus via Actuator on missing components.

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -339,7 +339,7 @@ jib_project(
     'opennms/lokahi-notification',
     'notifications',
     'opennms-notifications',
-    port_forwards=['15065:6565', '15050:5005'],
+    port_forwards=['15065:6565', '15050:5005', '15080:8080'],
     resource_deps=['shared-lib'],
 )
 

--- a/alert/pom.xml
+++ b/alert/pom.xml
@@ -182,6 +182,11 @@
             <artifactId>hypersistence-utils-hibernate-60</artifactId>
             <version>${io.hypersistence.verion}</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
         <!-- test -->
 
         <dependency>

--- a/alert/src/main/resources/application.yaml
+++ b/alert/src/main/resources/application.yaml
@@ -56,13 +56,9 @@ kafka:
 management:
   endpoints:
     web:
-      base-path: "/"
-      # The pipeline fails without this. 
-      path-mapping:
-        health: "actuator/health"
-        # With the basepath set to /, need to specify the path-mapping.
       exposure:
         include: "*"
+  endpoint:
     health:
       probes:
         enabled: true

--- a/alert/src/test/resources/org/opennms/horizon/alertservice/alert.feature
+++ b/alert/src/test/resources/org/opennms/horizon/alertservice/alert.feature
@@ -34,7 +34,7 @@ Feature: Alert Service Basic Functionality
 
   Scenario: When an event is received from Kafka, with no matching alert configuration, no new alert is created
     When An event is sent with UEI "uei.opennms.org/perspective/nodes/nodeLostService" on node 10
-    Then Send GET request to application at path "/metrics/events_without_alert_data_counter", with timeout 10000ms, until JSON response matches the following JSON path expressions
+    Then Send GET request to application at path "/actuator/metrics/events_without_alert_data_counter", with timeout 10000ms, until JSON response matches the following JSON path expressions
       | measurements[0].value == 1.0 |
     Then Verify alert topic has 0 messages for the tenant
 

--- a/charts/lokahi/templates/opennms/alert/alert-deployment.yaml
+++ b/charts/lokahi/templates/opennms/alert/alert-deployment.yaml
@@ -16,6 +16,9 @@ spec:
         appdomain: opennms
         app: {{ .Values.OpenNMS.Alert.ServiceName }}
       annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/actuator/prometheus"
         # roll the deployment when the Spring boot environment variable configmap changes
         checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: "{{ .Values.OpenNMS.Alert.ServiceName }}"

--- a/charts/lokahi/templates/opennms/api/api-deployment.yaml
+++ b/charts/lokahi/templates/opennms/api/api-deployment.yaml
@@ -19,6 +19,9 @@ spec:
         appdomain: opennms
         app: {{ .Values.OpenNMS.API.ServiceName }}
       annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/actuator/prometheus"
         # roll the deployment when the Spring boot environment variable configmap changes
         checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: "{{ .Values.OpenNMS.API.ServiceName }}"

--- a/charts/lokahi/templates/opennms/minion-certificate-verifier/minion-certificate-verifier-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion-certificate-verifier/minion-certificate-verifier-deployment.yaml
@@ -16,6 +16,9 @@ spec:
         appdomain: opennms
         app: {{ .Values.OpenNMS.MinionCertificateVerifier.ServiceName }}
       annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/actuator/prometheus"
         # roll the deployment when the Spring boot environment variable configmap changes
         checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: "{{ .Values.OpenNMS.MinionCertificateVerifier.ServiceName }}"

--- a/charts/lokahi/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/lokahi/templates/opennms/notification/notification-deployment.yaml
@@ -16,6 +16,9 @@ spec:
         appdomain: opennms
         app: {{ .Values.OpenNMS.Notification.ServiceName }}
       annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/actuator/prometheus"
         # roll the deployment when the Spring boot environment variable configmap changes
         checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: "{{ .Values.OpenNMS.Notification.ServiceName }}"

--- a/events/main/src/main/resources/application.yml
+++ b/events/main/src/main/resources/application.yml
@@ -40,6 +40,7 @@ management:
     web:
       exposure:
         include: "*"
+  endpoint:
     health:
       probes:
         enabled: true

--- a/inventory/main/src/main/resources/application.yml
+++ b/inventory/main/src/main/resources/application.yml
@@ -60,6 +60,7 @@ management:
     web:
       exposure:
         include: "*"
+  endpoint:
     health:
       probes:
         enabled: true

--- a/metrics-processor/main/src/main/resources/application.yml
+++ b/metrics-processor/main/src/main/resources/application.yml
@@ -42,3 +42,7 @@ management:
     web:
       exposure:
         include: "*"
+  endpoint:
+    health:
+      probes:
+        enabled: true

--- a/minion-certificate-verifier/main/pom.xml
+++ b/minion-certificate-verifier/main/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.lokahi.shared</groupId>
             <artifactId>minion-certificate-manager-api</artifactId>
             <version>${project.version}</version>

--- a/minion-certificate-verifier/main/src/main/resources/application.yaml
+++ b/minion-certificate-verifier/main/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ management:
     web:
       exposure:
         include: "*"
+  endpoing:
     health:
       probes:
         enabled: true

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -138,11 +138,6 @@
             <artifactId>notifications</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-            <version>${spring-boot.version}</version>
-        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -170,11 +165,6 @@
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-config</artifactId>
-            <version>${spring-security.version}</version>
-        </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
@@ -257,6 +247,10 @@
             <artifactId>azure-communication-email</artifactId>
             <version>${azure-communication-email.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
 
         <!-- test-->
 		<dependency>
@@ -271,12 +265,6 @@
                 </exclusion>
             </exclusions>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-test</artifactId>
-            <version>${spring-security.version}</version>
-            <scope>test</scope>
-        </dependency>
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka-test</artifactId>

--- a/notifications/src/main/resources/application.yml
+++ b/notifications/src/main/resources/application.yml
@@ -50,6 +50,10 @@ horizon:
     client-id: admin-cli
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
   endpoint:
     health:
       probes:

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -132,6 +132,10 @@
             <artifactId>flows-grpc</artifactId>
             <version>${flows.gateway.grpc.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
 
 		<!-- Test -->
 		<dependency>

--- a/rest-server/src/main/resources/application.yml
+++ b/rest-server/src/main/resources/application.yml
@@ -42,6 +42,7 @@ management:
     web:
       exposure:
         include: "*"
+  endpoint:
     health:
       probes:
         enabled: true


### PR DESCRIPTION
## Description
The main idea is to enable Prometheus via Actuator for all those components that don't have it enabled. The reason is to ensure we have basic metrics available, particularly JVM memory usage, as that would help estimate how much heap memory we would need when running Lokahi in Kubernetes.

There were some changes to ensure the Health Checks are enabled, and based on my research for Prometheus, I homologized the management configuration for all the services. We could remove some unnecessary content for the Alerts Component, and I verified that the solution still works as expected.

Also, the Security features for SpringBoot and SpringSecurity were enabled for the Notifications Component, although not used. I removed those dependencies to simplify things because the actuator already works without restrictions for all the other components.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1884

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
