### PR TITLE
BTO-753: Collect Prometheus stats from Keycloak.

### DIFF
--- a/charts/lokahi/templates/keycloak/keycloak-deployment.yaml
+++ b/charts/lokahi/templates/keycloak/keycloak-deployment.yaml
@@ -17,6 +17,9 @@ spec:
         app: {{ .Values.Keycloak.ServiceName }}
       annotations:
         kubectl.kubernetes.io/default-container: "keycloak"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/auth/metrics"
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}
       nodeSelector:


### PR DESCRIPTION
## Description

Keycloak has the metrics engine enabled, but we're not collecting stats by default. This PR enables that via Prometheus annotations (like the rest of the services).

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-753

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
