### PR TITLE
Revert "BTO-736: Enable JSON logging and upgrade Spring Boot to 3.1.1"

### DIFF
--- a/metrics-processor/main/pom.xml
+++ b/metrics-processor/main/pom.xml
@@ -103,6 +103,7 @@
         <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
+            <version>${spring-kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>org.awaitility</groupId>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -146,6 +146,7 @@
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
+            <version>${spring-kafka.version}</version>
 		</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -267,6 +268,7 @@
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka-test</artifactId>
+            <version>${spring-kafka.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -127,8 +127,9 @@
         <snmp4j.agent.version>2.5.3</snmp4j.agent.version>
         <spring.version>6.0.4</spring.version>
         <servicemix.spring.version>5.3.14_1</servicemix.spring.version>
-        <servicemix.spring.version>5.3.14_1</servicemix.spring.version>
-        <spring-boot.version>3.1.2</spring-boot.version>
+        <spring-boot.version>3.0.1</spring-boot.version>
+        <spring-security.version>6.0.1</spring-security.version>
+        <spring-kafka.version>3.0.1</spring-kafka.version>
         <sonar-maven.version>3.9.1.2184</sonar-maven.version>
         <swagger.version>2.1.1</swagger.version>
         <lombok.version>1.18.24</lombok.version>
@@ -479,57 +480,12 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-codec-dns</artifactId>
-                <version>${netty4.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http</artifactId>
-                <version>${netty4.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http2</artifactId>
-                <version>${netty4.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-socks</artifactId>
-                <version>${netty4.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver</artifactId>
-                <version>${netty4.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver-dns</artifactId>
-                <version>${netty4.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver-dns-native-macos</artifactId>
-                <version>${netty4.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
                 <version>${netty4.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
-                <version>${netty4.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>${netty4.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler-proxy</artifactId>
                 <version>${netty4.version}</version>
             </dependency>
             <dependency>
@@ -861,12 +817,6 @@
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope> <!-- TODO: do not specify scope in dependencyManagement in case a project wants to use a different scope -->
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -23,7 +23,7 @@
 	<properties>
         <application.docker.image.name>opennms/lokahi-rest-server</application.docker.image.name>
 		<java.version>17</java.version>
-		<graphql.spqr.version>1.0.0</graphql.spqr.version>
+		<graphql.spqr.version>0.0.6</graphql.spqr.version>
         <sonar.projectKey>opennms_lokahi_bff</sonar.projectKey>
 	</properties>
     <dependencyManagement>
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
+                <version>2.6.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -163,7 +163,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-standalone</artifactId>
+            <artifactId>wiremock</artifactId>
             <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Reverts OpenNMS-Cloud/lokahi#1348

This PR broke the GraphQL API. It seems like it was permissive with type checking (e.g. would accept an Integer for a String input) but more strict (throwing errors) with the PR.