### PR TITLE
BTO-707: Set better defaults for CPU, Mem and MaxRAMPercentage

### DIFF
--- a/charts/lokahi/templates/opennms/alert/alert-deployment.yaml
+++ b/charts/lokahi/templates/opennms/alert/alert-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.Alert.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # Permanent debug port in `skaffold dev`
+              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # Permanent debug port in `skaffold dev`
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://{{ .Values.OpenNMS.Alert.DbHost }}:5432/{{ .Values.OpenNMS.Alert.DbName }}?currentSchema={{ .Values.OpenNMS.Alert.DbSchemaName }}"
             - name: SPRING_DATASOURCE_USERNAME

--- a/charts/lokahi/templates/opennms/api/api-deployment.yaml
+++ b/charts/lokahi/templates/opennms/api/api-deployment.yaml
@@ -56,7 +56,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.API.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_CACHE_CAFFEINE_SPEC
               value: "maximumSize=10000,expireAfterWrite=60s"
             - name: TSDB_URL

--- a/charts/lokahi/templates/opennms/datachoices/datachoices-deployment.yaml
+++ b/charts/lokahi/templates/opennms/datachoices/datachoices-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.DataChoices.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://{{ .Values.OpenNMS.DataChoices.DbHost }}:5432/{{ .Values.OpenNMS.DataChoices.DbName }}?currentSchema={{ .Values.OpenNMS.DataChoices.DbSchemaName }}"
             - name: SPRING_DATASOURCE_USERNAME

--- a/charts/lokahi/templates/opennms/events/events-deployment.yaml
+++ b/charts/lokahi/templates/opennms/events/events-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.Events.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://{{ .Values.OpenNMS.Events.DbHost }}:5432/{{ .Values.OpenNMS.Events.DbName }}?currentSchema={{ .Values.OpenNMS.Events.DbSchemaName }}"
             - name: SPRING_DATASOURCE_USERNAME

--- a/charts/lokahi/templates/opennms/inventory/inventory-deployment.yaml
+++ b/charts/lokahi/templates/opennms/inventory/inventory-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.Inventory.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://{{ .Values.OpenNMS.Inventory.DbHost }}:5432/{{ .Values.OpenNMS.Inventory.DbName }}?currentSchema={{ .Values.OpenNMS.Inventory.DbSchemaName }}"
             - name: SPRING_DATASOURCE_USERNAME

--- a/charts/lokahi/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
+++ b/charts/lokahi/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.MetricsProcessor.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "{{ .Values.OpenNMS.global.kafkaClient.bootstrapServers }}"
             - name: GRPC_FLOW_INGESTOR_URL

--- a/charts/lokahi/templates/opennms/minion-certificate-manager/minion-certificate-manager-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion-certificate-manager/minion-certificate-manager-deployment.yaml
@@ -61,7 +61,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.MinionCertificateManager.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: KEYCLOAK_BASE_URL
               value: "http://{{ .Values.Keycloak.ServiceName }}:8080/auth/"
             - name: KEYCLOAK_REALM

--- a/charts/lokahi/templates/opennms/minion-certificate-verifier/minion-certificate-verifier-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion-certificate-verifier/minion-certificate-verifier-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.MinionCertificateVerifier.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             {{- include "deployment.env" .Values.OpenNMS.MinionCertificateVerifier | nindent 12 }}
             - name: GRPC_URL_MINION_CERTIFICATE_MANAGER
               value: {{ if or (eq .Values.OpenNMS.MinionCertificateVerifier.CertificateManagerUrl "") (eq .Values.OpenNMS.MinionCertificateVerifier.CertificateManagerUrl "dev")

--- a/charts/lokahi/templates/opennms/minion-gateway/minion-gateway-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion-gateway/minion-gateway-deployment.yaml
@@ -60,7 +60,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.MinionGateway.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y -XX:MaxDirectMemorySize=768m"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y -XX:MaxDirectMemorySize=768m"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
@@ -115,7 +115,7 @@ spec:
             - name: KUBERNETES_NAMESPACE
               value: "{{ .Release.Namespace }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # FIXME: Permanent debug port, enable only for dev mode
+              value: "-XX:MaxRAMPercentage=50 -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # FIXME: Permanent debug port, enable only for dev mode
             - name: MINION_LOCATION
               value: "Default"
             - name: IGNITE_UPDATE_NOTIFIER # Disable Ignite version lookups

--- a/charts/lokahi/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/lokahi/templates/opennms/notification/notification-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.Notification.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "{{ .Values.OpenNMS.global.kafkaClient.bootstrapServers }}"
             - name: SPRING_DATASOURCE_URL

--- a/charts/lokahi/values.yaml
+++ b/charts/lokahi/values.yaml
@@ -21,11 +21,11 @@ OpenNMS:
     Replicas: 1
     Resources:
       Limits:
-        Cpu: "2"
-        Memory: 2Gi
+        Cpu: "1"
+        Memory: 2Gi # MaxRAMPercentage=50,avg-usage=245MB
       Requests:
         Cpu: "1"
-        Memory: 1Gi
+        Memory: 2Gi
     PrivateRepoEnabled: false
     FlowsUrl: SOME-EXTERNAL-FLOW-SERVER:80
     FlowsTlsEnabled: false
@@ -37,11 +37,11 @@ OpenNMS:
     Replicas: 1
     Resources:
       Limits:
-        Cpu: "1"
-        Memory: 512Mi
+        Cpu: "2"
+        Memory: 4Gi # MaxRAMPercentage=50,avg-usage=400MB
       Requests:
-        Cpu: 250m
-        Memory: 256Mi
+        Cpu: "1"
+        Memory: 2Gi
     PrivateRepoEnabled: false
     FlowIngestorUrl: SOME-EXTERNAL-FLOW-SERVER:80
     FlowTlsEnabled: false
@@ -57,10 +57,10 @@ OpenNMS:
     Resources:
       Limits:
         Cpu: "1"
-        Memory: 500Mi
+        Memory: 512Mi
       Requests:
         Cpu: 100m
-        Memory: 250Mi
+        Memory: 256Mi
     PrivateRepoEnabled: false
     IngressAnnotations:
       nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -86,11 +86,11 @@ OpenNMS:
     NetflowListenerPort: 9999
     Resources:
       Limits:
-        Cpu: "1"
-        Memory: 500Mi
+        Cpu: "2"
+        Memory: 4Gi
       Requests:
-        Cpu: 100m
-        Memory: 250Mi
+        Cpu: "1"
+        Memory: 2Gi
     ExtraVolumes: []
     ExtraMounts: []
     ExtraInitContainers: []
@@ -110,7 +110,7 @@ OpenNMS:
     Resources:
       Limits:
         Cpu: "2"
-        Memory: 4Gi
+        Memory: 4Gi # MaxRAMPercentage=50,avg-usage=480MB
       Requests:
         Cpu: "1"
         Memory: 2Gi
@@ -139,11 +139,11 @@ OpenNMS:
     DbHost: "postgres"
     Resources:
       Limits:
-        Cpu: "1"
-        Memory: 500Mi
+        Cpu: "2"
+        Memory: 4Gi # MaxRAMPercentage=50,avg-usage=620MB
       Requests:
-        Cpu: 100m
-        Memory: 250Mi
+        Cpu: "1"
+        Memory: 2Gi
     EncryptionKey: ~
     PrivateRepoEnabled: false
     kafkaSecretName: ~
@@ -157,11 +157,11 @@ OpenNMS:
     DbHost: "postgres"
     Resources:
       Limits:
-        Cpu: "1"
-        Memory: 500Mi
+        Cpu: "2"
+        Memory: 4Gi # MaxRAMPercentage=50,avg-usage=480MB
       Requests:
-        Cpu: 100m
-        Memory: 250Mi
+        Cpu: "1"
+        Memory: 2Gi
     PrivateRepoEnabled: false
     kafkaSecretName: ~
   Notification:
@@ -174,11 +174,11 @@ OpenNMS:
     DbHost: "postgres"
     Resources:
       Limits:
-        Cpu: "1"
-        Memory: 500Mi
+        Cpu: "2"
+        Memory: 4Gi # MaxRAMPercentage=50,avg-usage=450MB
       Requests:
-        Cpu: 100m
-        Memory: 250Mi
+        Cpu: "1"
+        Memory: 2Gi
     PrivateRepoEnabled: false
     kafkaSecretName: ~
     retry:
@@ -198,11 +198,11 @@ OpenNMS:
     DbHost: "postgres"
     Resources:
       Limits:
-        Cpu: "1"
-        Memory: 500Mi
+        Cpu: "2"
+        Memory: 4Gi # MaxRAMPercentage=50,avg-usage=550MB
       Requests:
-        Cpu: 100m
-        Memory: 250Mi
+        Cpu: "1"
+        Memory: 2Gi
     PrivateRepoEnabled: false
   DataChoices:
     ServiceName: opennms-datachoices
@@ -215,10 +215,10 @@ OpenNMS:
     Resources:
       Limits:
         Cpu: "1"
-        Memory: 500Mi
+        Memory: 1Gi
       Requests:
-        Cpu: 100m
-        Memory: 250Mi
+        Cpu: "1"
+        Memory: 1Gi
     PrivateRepoEnabled: false
   MinionCertificateManager:
     Enabled: false
@@ -232,10 +232,10 @@ OpenNMS:
     Resources:
       Limits:
         Cpu: "1"
-        Memory: 500Mi
+        Memory: 1Gi
       Requests:
-        Cpu: 100m
-        Memory: 250Mi
+        Cpu: "1"
+        Memory: 1Gi
     PrivateRepoEnabled: false
   MinionCertificateVerifier:
     ServiceName: opennms-minion-certificate-verifier
@@ -245,10 +245,10 @@ OpenNMS:
     Resources:
       Limits:
         Cpu: "1"
-        Memory: 500Mi
+        Memory: 1Gi # MaxRAMPercentage=50,avg-usage=245MB
       Requests:
-        Cpu: 100m
-        Memory: 250Mi
+        Cpu: "1"
+        Memory: 1Gi
     PrivateRepoEnabled: false
     CertificateManagerUrl: ""
 Postgres:
@@ -286,12 +286,12 @@ Keycloak:
   DbName: "horizon_stream"
   DbHost: "postgres"
   Resources:
-    Limits:
-      Cpu: "1"
-      Memory: 1000Mi
-    Requests:
-      Cpu: 100m
-      Memory: 500Mi
+      Limits:
+        Cpu: "1"
+        Memory: 2Gi
+      Requests:
+        Cpu: "1"
+        Memory: 1Gi
   AdminUsername: admin
   AdminPassword: notset
   RealmName: opennms


### PR DESCRIPTION
## Description

As described on the Jira issue, when there are no resource limits for Memory, the JVM will use 25% of the total RAM available on the K8s Worker Node, which could lead to resource starvation. Based on current usage on Fabric-Dev (for over 60 hours), this PR sets better defaults with enough room for more usage compared to the measured baseline. Also, it sets the RAM Ratio to 50 (from 25%, which is the JVM default).

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-707

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
