### PR TITLE
Tilt: ssl-check.sh at startup and improve context/namespace handling

### DIFF
--- a/.github/workflows/tilt.yaml
+++ b/.github/workflows/tilt.yaml
@@ -71,7 +71,7 @@ jobs:
         shell: bash
         run: |
           # Setup localhost DNS
-          sudo sh -c 'echo "127.0.0.1 onmshs" >> /etc/hosts'
+          sudo sh -c 'echo "127.0.0.1 onmshs.local minion.onmshs.local" >> /etc/hosts'
 
           ctlptl create cluster kind --registry=ctlptl-registry
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -191,6 +191,15 @@ def load_certificate_authority(secret_name, name, key_file_name, cert_file_name)
 def generate_certificate(secret_name, domain, ca_key_file_name, ca_cert_file_name):
     local('./install-local/generate-and-sign-certificate.sh "default" {} {} {} {}'.format(domain, secret_name, ca_key_file_name, ca_cert_file_name));
 
+def ssl_check(domain, port):
+    local([
+        './tools/ssl-check.sh',
+        '-t',
+        '5',
+        domain,
+        str(port),
+    ])
+
 # If you don't specify a resource, the button will be added to the global nav (location.NAV).
 def create_devmode_toggle_btn(devmode_key, resource=None):
     # we should not mutate new_config so we need to work with a copy
@@ -239,6 +248,7 @@ load_certificate_authority('root-ca-certificate', 'opennms-ca', 'target/tmp/serv
 generate_certificate('opennms-minion-gateway-certificate', 'minion.onmshs.local', 'target/tmp/server-ca.key', 'target/tmp/server-ca.crt')
 generate_certificate('opennms-ui-certificate', 'onmshs.local', 'target/tmp/server-ca.key', 'target/tmp/server-ca.crt')
 load_certificate_authority('client-root-ca-certificate', 'client-ca', 'target/tmp/client-ca.key', 'target/tmp/client-ca.crt')
+ssl_check('onmshs.local', 1443)
 
 
 # Deployment #

--- a/install-local/generate-and-sign-certificate.sh
+++ b/install-local/generate-and-sign-certificate.sh
@@ -10,12 +10,16 @@ else
     force=0
 fi
 
-namespace="$1"
-domain="$2"
+if [ $# -lt 4 ]; then
+    echo "$(basename "$0"): too few command-line arguments" >&2
+    echo "usage: $(basename "$0"): [-f] <domain> <secret> <keyFile> <crtFile> [<kubectl options>]" >&2
+    exit 1
+fi
 
-secret="$3"
-caKeyFile="$4"
-caCrtFile="$5"
+domain="$1"; shift
+secret="$1"; shift
+caKeyFile="$1"; shift
+caCrtFile="$1"; shift
 
 if [ ! -f $caKeyFile ]; then
   echo "Required file $caKeyFile does not exist!"
@@ -26,9 +30,9 @@ directory=$(dirname $caKeyFile)
 id=$(uuidgen)
 
 # see if the secret already exists
-if [ -n "$(kubectl -n $namespace get --ignore-not-found=true secret "$secret")" ]; then
+if [ -n "$(kubectl "$@" get --ignore-not-found=true secret "$secret")" ]; then
   if [ $force -gt 0 ]; then
-    kubectl -n $namespace delete "secrets/$secret"
+    kubectl "$@" delete "secrets/$secret"
   else
     echo "Secret '$secret' already exists, not adding. Use '-f' option to force recreation." >&2
     exit 0
@@ -38,6 +42,6 @@ fi
 openssl req -newkey rsa:2048 -nodes -keyout "$directory/$id.key" -subj "/CN=$domain/O=Test/C=US" -out "$directory/$id.csr"
 openssl x509 -req -extfile <(printf "subjectAltName=DNS:$domain") -days 14 -in  "$directory/$id.csr" \
   -CA $caCrtFile -CAkey $caKeyFile -CAcreateserial -out "$directory/$id.crt" || (echo "Certificate $id signing failed" && exit 1)
-kubectl -n $namespace create secret tls $secret --cert "$directory/$id.crt" --key "$directory/$id.key"
+kubectl "$@" create secret tls $secret --cert "$directory/$id.crt" --key "$directory/$id.key"
 
 rm "$directory/$id.crt" "$directory/$id.key" "$directory/$id.csr"

--- a/install-local/install-local.sh
+++ b/install-local/install-local.sh
@@ -66,12 +66,12 @@ cluster_install_kubelet_config() {
 
 create_ssl_cert_secret () {
   # generate CA and ingress certs
-  ./load-or-generate-secret.sh $NAMESPACE "opennms-ca" "root-ca-certificate" "tmp/ca.key" "tmp/ca.crt"
-  ./generate-and-sign-certificate.sh $NAMESPACE "minion.$DOMAIN" "opennms-minion-gateway-certificate" "tmp/ca.key" "tmp/ca.crt"
-  ./generate-and-sign-certificate.sh $NAMESPACE "$DOMAIN" "opennms-ui-certificate" "tmp/ca.key" "tmp/ca.crt"
+  ./load-or-generate-secret.sh "opennms-ca" "root-ca-certificate" "tmp/ca.key" "tmp/ca.crt" -n "$NAMESPACE"
+  ./generate-and-sign-certificate.sh "minion.$DOMAIN" "opennms-minion-gateway-certificate" "tmp/ca.key" "tmp/ca.crt" -n "$NAMESPACE"
+  ./generate-and-sign-certificate.sh "$DOMAIN" "opennms-ui-certificate" "tmp/ca.key" "tmp/ca.crt" -n "$NAMESPACE"
 
   # Generate client CA certificate
-  ./load-or-generate-secret.sh $NAMESPACE "client-ca" "client-root-ca-certificate" "tmp/client-ca.key" "tmp/client-ca.crt"
+  ./load-or-generate-secret.sh "client-ca" "client-root-ca-certificate" "tmp/client-ca.key" "tmp/client-ca.crt" -n "$NAMESPACE"
 }
 
 # WHEN kind fixes the bug, https://github.com/kubernetes-sigs/kind/issues/3063,

--- a/install-local/load-or-generate-secret.sh
+++ b/install-local/load-or-generate-secret.sh
@@ -10,12 +10,16 @@ else
     force=0
 fi
 
-namespace="$1"
-domain="$2"
+if [ $# -lt 4 ]; then
+    echo "$(basename "$0"): too few command-line arguments" >&2
+    echo "usage: $(basename "$0"): [-f] <domain> <secret> <keyFile> <crtFile> [<kubectl options>]" >&2
+    exit 1
+fi
 
-secret="$3"
-keyFile="$4"
-crtFile="$5"
+domain="$1"; shift
+secret="$1"; shift
+keyFile="$1"; shift
+crtFile="$1"; shift
 
 directory=$(dirname $keyFile)
 mkdir -p $directory
@@ -27,9 +31,9 @@ if [ ! -f $keyFile ]; then
 fi
 
 # see if the secret already exists
-if [ -n "$(kubectl -n "$namespace" get --ignore-not-found=true secret "$secret")" ]; then
+if [ -n "$(kubectl "$@" get --ignore-not-found=true secret "$secret")" ]; then
   if [ $force -gt 0 ]; then
-    kubectl -n "$namespace" delete "secrets/$secret"
+    kubectl "$@" delete "secrets/$secret"
   else
     echo "Secret '$secret' already exists, not adding. Use '-f' option to force recreation." >&2
     exit 0
@@ -38,8 +42,8 @@ fi
 
 # create secret which is tls, by default tls secrets have no "ca.crt" field which is mandatory in case if we wish to use
 # given secret at ingress for mtls. We append ca.crt in a patch call to keep secret as a tls, but also include ca.crt
-kubectl -n "$namespace" create secret tls "$secret" --key=$keyFile \
-  --cert=$crtFile || (echo "Could not create $secret in namespace $namespace" && exit 1)
-caContents=$(kubectl -n "$namespace" get secret "$secret" -o jsonpath="{.data['tls\.crt']}")
-kubectl -n "$namespace" patch secret "$secret" -p "{\"data\":{\"ca.crt\":\"${caContents}\"}}" \
-  || (echo "Could not supply 'ca.crt' field under secret $secret in namespace $namespace" && exit 2)
+kubectl "$@" create secret tls "$secret" --key=$keyFile \
+  --cert=$crtFile || (echo "Could not create $secret" && exit 1)
+caContents=$(kubectl "$@" get secret "$secret" -o jsonpath="{.data['tls\.crt']}")
+kubectl "$@" patch secret "$secret" -p "{\"data\":{\"ca.crt\":\"${caContents}\"}}" \
+  || (echo "Could not supply 'ca.crt' field under secret $secret" && exit 2)

--- a/tools/ssl-check.sh
+++ b/tools/ssl-check.sh
@@ -96,7 +96,7 @@ if [ $check_http -gt 0 ]; then
     # "openssl s_client" will get poll error and return non-zero, so we
     # temporarily disable pipefail here.
     set +o pipefail
-    if openssl s_client -CAfile target/tmp/server-ca.crt -connect minion.${domain}:${port} -servername minion.${domain} < /dev/null | openssl verify -CAfile target/tmp/server-ca.crt /dev/stdin; then
+    if openssl s_client -CAfile target/tmp/server-ca.crt -connect 127.0.0.1:${port} -servername minion.${domain} < /dev/null | openssl verify -CAfile target/tmp/server-ca.crt /dev/stdin; then
       set -o pipefail
       break
     else

--- a/tools/ssl-check.sh
+++ b/tools/ssl-check.sh
@@ -30,31 +30,31 @@ port="$1"; shift
 
 mkdir -p $DIR/target
 
-kubectl get secret client-root-ca-certificate > /dev/null || die "Kubernetes secret with 'Client CA' secret not found"
+kubectl "$@" get secret client-root-ca-certificate > /dev/null || die "Kubernetes secret with 'Client CA' secret not found"
 echo "'Client CA' secret found"
 
-kubectl get secret client-root-ca-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/client-ca.crt || die "'Client CA' certificate not found"
-kubectl get secret client-root-ca-certificate -ogo-template='{{index .data "tls.key" }}' | base64 --decode > $DIR/target/client-ca.key || die "'Client CA' private key not found"
+kubectl "$@" get secret client-root-ca-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/client-ca.crt || die "'Client CA' certificate not found"
+kubectl "$@" get secret client-root-ca-certificate -ogo-template='{{index .data "tls.key" }}' | base64 --decode > $DIR/target/client-ca.key || die "'Client CA' private key not found"
 echo "'Client CA' certificate and private key extracted fine"
 
-kubectl get secret root-ca-certificate > /dev/null || die "Kubernetes secret with 'Server CA' secret not found"
+kubectl "$@" get secret root-ca-certificate > /dev/null || die "Kubernetes secret with 'Server CA' secret not found"
 echo "'Server CA' secret found"
-kubectl get secret root-ca-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/server-ca.crt || die "'Server CA' certificate not found"
-kubectl get secret root-ca-certificate -ogo-template='{{index .data "tls.key" }}' | base64 --decode > $DIR/target/server-ca.key || die "'Server CA' private key not found"
+kubectl "$@" get secret root-ca-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/server-ca.crt || die "'Server CA' certificate not found"
+kubectl "$@" get secret root-ca-certificate -ogo-template='{{index .data "tls.key" }}' | base64 --decode > $DIR/target/server-ca.key || die "'Server CA' private key not found"
 echo "'Server CA' certificate and private key extracted fine"
 
 openssl verify -CAfile $DIR/target/server-ca.crt $DIR/target/server-ca.crt || die "'Server CA' certificate could not be verified"
 
-kubectl get secret opennms-ui-certificate > /dev/null || die "Kubernetes secret 'opennms-ui-certificate' not found"
+kubectl "$@" get secret opennms-ui-certificate > /dev/null || die "Kubernetes secret 'opennms-ui-certificate' not found"
 echo "'UI Ingress' secret found"
-kubectl get secret opennms-ui-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/ui.crt || die "'opennms-ui-certificate' certificate not found"
+kubectl "$@" get secret opennms-ui-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/ui.crt || die "'opennms-ui-certificate' certificate not found"
 echo "'UI Ingress'  certificate and private key extracted fine"
 
 openssl verify -CAfile $DIR/target/server-ca.crt $DIR/target/ui.crt || die "'UI Ingress' certificate could not be verified"
 
-kubectl get secret opennms-minion-gateway-certificate > /dev/null || die "Kubernetes secret 'opennms-minion-gateway-certificate' not found"
+kubectl "$@" get secret opennms-minion-gateway-certificate > /dev/null || die "Kubernetes secret 'opennms-minion-gateway-certificate' not found"
 echo "'Minion Gateway Ingress' secret found"
-kubectl get secret opennms-minion-gateway-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/mgw.crt || die "'opennms-minion-gateway-certificate' certificate not found"
+kubectl "$@" get secret opennms-minion-gateway-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/mgw.crt || die "'opennms-minion-gateway-certificate' certificate not found"
 echo "'Minion Gateway' certificate and private key extracted fine"
 
 openssl verify -CAfile $DIR/target/server-ca.crt $DIR/target/mgw.crt || die "'Minion Gateway' certificate could not be verified"

--- a/tools/ssl-check.sh
+++ b/tools/ssl-check.sh
@@ -30,14 +30,14 @@ port="$1"; shift
 
 mkdir -p $DIR/target
 
-kubectl get secret client-root-ca-certificate 2>&1 > /dev/null || die "Kubernetes secret with 'Client CA' secret not found"
+kubectl get secret client-root-ca-certificate > /dev/null || die "Kubernetes secret with 'Client CA' secret not found"
 echo "'Client CA' secret found"
 
 kubectl get secret client-root-ca-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/client-ca.crt || die "'Client CA' certificate not found"
 kubectl get secret client-root-ca-certificate -ogo-template='{{index .data "tls.key" }}' | base64 --decode > $DIR/target/client-ca.key || die "'Client CA' private key not found"
 echo "'Client CA' certificate and private key extracted fine"
 
-kubectl get secret root-ca-certificate 2>&1 > /dev/null || die "Kubernetes secret with 'Server CA' secret not found"
+kubectl get secret root-ca-certificate > /dev/null || die "Kubernetes secret with 'Server CA' secret not found"
 echo "'Server CA' secret found"
 kubectl get secret root-ca-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/server-ca.crt || die "'Server CA' certificate not found"
 kubectl get secret root-ca-certificate -ogo-template='{{index .data "tls.key" }}' | base64 --decode > $DIR/target/server-ca.key || die "'Server CA' private key not found"
@@ -45,14 +45,14 @@ echo "'Server CA' certificate and private key extracted fine"
 
 openssl verify -CAfile $DIR/target/server-ca.crt $DIR/target/server-ca.crt || die "'Server CA' certificate could not be verified"
 
-kubectl get secret opennms-ui-certificate 2>&1 > /dev/null || die "Kubernetes secret 'opennms-ui-certificate' not found"
+kubectl get secret opennms-ui-certificate > /dev/null || die "Kubernetes secret 'opennms-ui-certificate' not found"
 echo "'UI Ingress' secret found"
 kubectl get secret opennms-ui-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/ui.crt || die "'opennms-ui-certificate' certificate not found"
 echo "'UI Ingress'  certificate and private key extracted fine"
 
 openssl verify -CAfile $DIR/target/server-ca.crt $DIR/target/ui.crt || die "'UI Ingress' certificate could not be verified"
 
-kubectl get secret opennms-minion-gateway-certificate 2>&1 > /dev/null || die "Kubernetes secret 'opennms-minion-gateway-certificate' not found"
+kubectl get secret opennms-minion-gateway-certificate > /dev/null || die "Kubernetes secret 'opennms-minion-gateway-certificate' not found"
 echo "'Minion Gateway Ingress' secret found"
 kubectl get secret opennms-minion-gateway-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > $DIR/target/mgw.crt || die "'opennms-minion-gateway-certificate' certificate not found"
 echo "'Minion Gateway' certificate and private key extracted fine"
@@ -60,7 +60,7 @@ echo "'Minion Gateway' certificate and private key extracted fine"
 openssl verify -CAfile $DIR/target/server-ca.crt $DIR/target/mgw.crt || die "'Minion Gateway' certificate could not be verified"
 
 while true; do
-  if curl -sSf --cacert $DIR/target/server-ca.crt --resolve "${domain}:${port}:127.0.0.1" https://${domain}:${port}/ 2>&1 > /dev/null; then
+  if curl -sSf --cacert $DIR/target/server-ca.crt --resolve "${domain}:${port}:127.0.0.1" https://${domain}:${port}/ > /dev/null; then
     break
   fi
   tries=$(expr $tries - 1)
@@ -73,7 +73,7 @@ while true; do
 done
 
 # This doesn't work unless we provide a client certificate
-#curl -sSf --cacert $DIR/target/server-ca.crt --resolve "minion.${domain}:${port}:127.0.0.1" https://minion.${domain}:${port}/ 2>&1 > /dev/null || die "'Minion Gateway' failed to verify HTTPS connection using extracted CA certificate"
+#curl -sSf --cacert $DIR/target/server-ca.crt --resolve "minion.${domain}:${port}:127.0.0.1" https://minion.${domain}:${port}/ > /dev/null || die "'Minion Gateway' failed to verify HTTPS connection using extracted CA certificate"
 
 # "openssl s_client" will get poll error and return non-zero, so we
 # temporarily disable pipefail here.


### PR DESCRIPTION
- Run tools/ssl-check.sh in Tilt
- ssl-check.sh: remove effective no-op of '2>&1' before '> /dev/null'
- Allow specifying arbitrary kubectl options in SSL tools
- Tilt/ssl-check.sh: Run HTTP checks separately after ingress is up
- ssl-check.sh: also retry minion check
- tilt ci: Make sure necessary names are in /etc/hosts
- ssl-check.sh: connect to 127.0.0.1 to reach minion

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-784

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
