### PR TITLE
LOK-1896: Populate new MP form with default tag

### DIFF
--- a/ui/src/store/Views/monitoringPoliciesStore.ts
+++ b/ui/src/store/Views/monitoringPoliciesStore.ts
@@ -33,7 +33,7 @@ const defaultPolicy: Policy = {
   notifyByEmail: false,
   notifyByPagerDuty: false,
   notifyByWebhooks: false,
-  tags: [],
+  tags: ['default'],
   rules: []
 }
 

--- a/ui/tests/MonitoringPolicies/monitoringPolicies.test.ts
+++ b/ui/tests/MonitoringPolicies/monitoringPolicies.test.ts
@@ -13,7 +13,7 @@ const testingPayload: MonitorPolicy = {
   notifyByEmail: false,
   notifyByPagerDuty: false,
   notifyByWebhooks: false,
-  tags: [],
+  tags: ['default'],
   rules: [
     {
       name: 'Rule1',


### PR DESCRIPTION
## Description
The Monitoring Policy form will be automatically populated with a `default` tag. The user may remove the `default` tag and/or add different tags.

[screencast-localhost_3009-2023.08.08-11_36_43.webm](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/81ec7e41-1a50-462b-8974-9784022a547d)

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1896

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
