### PR TITLE
BTO-788: Avoid Ignite Topology issues preferring IPv4

### DIFF
--- a/charts/lokahi/templates/opennms/minion-gateway/minion-gateway-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion-gateway/minion-gateway-deployment.yaml
@@ -60,7 +60,7 @@ spec:
           imagePullPolicy: {{ .Values.OpenNMS.MinionGateway.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y -XX:MaxDirectMemorySize=768m"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-Djava.net.preferIPv4Stack=true -XX:MaxRAMPercentage=40 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y -XX:MaxDirectMemorySize=768m"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
@@ -115,7 +115,7 @@ spec:
             - name: KUBERNETES_NAMESPACE
               value: "{{ .Release.Namespace }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # FIXME: Permanent debug port, enable only for dev mode
+              value: "-Djava.net.preferIPv4Stack=true -XX:MaxRAMPercentage=50 -javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # FIXME: Permanent debug port, enable only for dev mode
             - name: MINION_LOCATION
               value: "Default"
             - name: IGNITE_UPDATE_NOTIFIER # Disable Ignite version lookups

--- a/charts/lokahi/values.yaml
+++ b/charts/lokahi/values.yaml
@@ -112,7 +112,7 @@ OpenNMS:
     Resources:
       Limits:
         Cpu: "2"
-        Memory: 4Gi # MaxRAMPercentage=50,avg-usage=480MB
+        Memory: 4Gi # MaxRAMPercentage=40 for heap (avg-usage=480MB) plus up to 2GB off-heap (4 Ignite Data Regions)
       Requests:
         Cpu: "1"
         Memory: 2Gi

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -68,6 +68,7 @@ OpenNMS:
         Cpu: '0'
         Memory: '0'
   MinionGateway:
+    Replicas: 2
     Resources:
       Limits:
         Cpu: '0'


### PR DESCRIPTION
## Description
I discovered that the topology reconciliation on Ignite doesn't work well, and enforcing `-Djava.net.preferIPv4Stack=true` helps. I verified via Tilt that changes in the number of replicas are now taken adequately by Ignite (see the Jira issue for more details).

As a bonus, I reduced `-XX:MaxRAMPercentage=` from 50 to 40, as there are 4 Regions on Ignite that could take up to 2GB off-heap, so we reduce the actual heap to keep the current memory limit but be able to fulfill the worst case scenario.

<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-788

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
