### PR TITLE
BTO-788: Restore Minion Gateway replicas to 1

### DIFF
--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -68,7 +68,6 @@ OpenNMS:
         Cpu: '0'
         Memory: '0'
   MinionGateway:
-    Replicas: 2
     Resources:
       Limits:
         Cpu: '0'


### PR DESCRIPTION
## Description
Unfortunately, `fb-dev` demonstrated that the Minion Gateway is not ready for multiple replicas (we need more time to understand how to configure and use Ignite), so I'm restoring the replicas to one for Tilt (as it was before).

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
