### PR TITLE
Fixed the issue where monitoring policy tests failed intermittently.

### DIFF
--- a/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/MonitoringPolicyTestSteps.java
+++ b/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/MonitoringPolicyTestSteps.java
@@ -430,10 +430,8 @@ public class MonitoringPolicyTestSteps {
                 .atMost(20, TimeUnit.SECONDS)
                 .pollDelay(5, TimeUnit.SECONDS)
                 .ignoreExceptions()
-                .until(() -> waitForAlerts(triggerEventName, severity));
-    }
+                .until(() -> waitForAlerts(triggerEventName));
 
-    private boolean waitForAlerts(String triggerEventName, String severity) {
         String nodeLabel = getNodeLabel();
         JsonArray alerts = getAlerts(nodeLabel);
 
@@ -448,12 +446,23 @@ public class MonitoringPolicyTestSteps {
                 break;
             }
         }
-
-        if (!severity.equals(alertSeverity)) {
-            return false;
-        }
         assertEquals("Severity: " + severity + " was expected but got " + alertSeverity + " instead.", severity, alertSeverity);
-        return true;
+    }
+
+    private boolean waitForAlerts(String triggerEventName) {
+        String nodeLabel = getNodeLabel();
+        JsonArray alerts = getAlerts(nodeLabel);
+
+        for (JsonElement element : alerts) {
+            JsonObject alert = (JsonObject) element;
+            String nodeName = alert.get("nodeName").getAsString();
+            LOG.info(nodeName + " : " + nodeLabel);
+            String eventUei = alert.get("uei").getAsString();
+            if (nodeName.equals(nodeLabel) && eventUei.endsWith(triggerEventName.replaceAll(" ", "_"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public String getNodeLabel() {

--- a/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/MonitoringPolicyTestSteps.java
+++ b/test-automation/integration-tests/src/main/java/org/opennms/horizon/it/MonitoringPolicyTestSteps.java
@@ -60,7 +60,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 @CucumberOptions(monochrome = true,
-    features = "src/main/resources/org/opennms/horizon/it/monitoring-policy.feature")
+        features = "src/main/resources/org/opennms/horizon/it/monitoring-policy.feature")
 public class MonitoringPolicyTestSteps {
     private static final Logger LOG = LoggerFactory.getLogger(MonitoringPolicyTestSteps.class);
     private final TestsExecutionHelper helper;
@@ -180,7 +180,7 @@ public class MonitoringPolicyTestSteps {
 
         JsonObject policy = jsonObject.getAsJsonObject("data").getAsJsonObject("findMonitorPolicyById");
 
-        if(null != policy && name.equals(policy.get("name").getAsString())) {
+        if (null != policy && name.equals(policy.get("name").getAsString())) {
             JsonArray tags = policy.get("tags").getAsJsonArray();
             for (JsonElement element : tags) {
                 if (tag.equals(element.getAsString())) {
@@ -189,7 +189,7 @@ public class MonitoringPolicyTestSteps {
                 }
             }
         }
-        assertTrue("Monitoring policy with name " + name + " and tag " + tag + " does not exist.", false);
+        fail("Monitoring policy with name " + name + " and tag " + tag + " does not exist.");
     }
 
     @Given("Location {string} is created.")
@@ -207,8 +207,8 @@ public class MonitoringPolicyTestSteps {
     @Given("Location {string} is removed.")
     public void deleteLocation(String location) {
         LocationData locationData = commonQueryLocations().getData().getFindAllLocations().stream()
-            .filter(loc -> loc.getLocation().equals(location))
-            .findFirst().orElse(null);
+                .filter(loc -> loc.getLocation().equals(location))
+                .findFirst().orElse(null);
 
         if (locationData == null) {
             fail("Location " + location + " not found");
@@ -225,8 +225,8 @@ public class MonitoringPolicyTestSteps {
     @Then("Location {string} should exist")
     public void queryLocationDoExist(String location) {
         Optional<LocationData> locationData = commonQueryLocations().getData().getFindAllLocations().stream()
-            .filter(data -> data.getLocation().equals(location))
-            .findFirst();
+                .filter(data -> data.getLocation().equals(location))
+                .findFirst();
         assertTrue(locationData.isPresent());
     }
 
@@ -245,24 +245,24 @@ public class MonitoringPolicyTestSteps {
     public void waitForAtLeastOneMinionForTheGivenLocationReportedByInventoryWithTimeoutMs(int timeout) {
         try {
             Awaitility
-                .await()
-                .atMost(timeout, TimeUnit.MILLISECONDS)
-                .ignoreExceptions()
-                .until(this::checkAtLeastOneMinionAtGivenLocation);
+                    .await()
+                    .atMost(timeout, TimeUnit.MILLISECONDS)
+                    .ignoreExceptions()
+                    .until(this::checkAtLeastOneMinionAtGivenLocation);
         } finally {
             LOG.info("LAST CHECK MINION RESPONSE BODY: {}", lastMinionQueryResultBody);
         }
     }
 
     @Then("User can retrieve a certificate for location {string}")
-    public void requestCertificateForLocation(String location) throws MalformedURLException {
+    public void requestCertificateForLocation(String location) {
         LOG.info("Requesting certificate for location {}.", location);
 
         Long locationId = commonQueryLocations().getData().getFindAllLocations().stream()
-            .filter(loc -> location.equals(loc.getLocation()))
-            .findFirst()
-            .map(LocationData::getId)
-            .orElseThrow(() -> new IllegalArgumentException("Unknown location " + location));
+                .filter(loc -> location.equals(loc.getLocation()))
+                .findFirst()
+                .map(LocationData::getId)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown location " + location));
 
         GQLQuery gqlQuery = new GQLQuery();
         gqlQuery.setQuery(String.format(GQLQueryConstants.CREATE_MINION_CERTIFICATE, locationId));
@@ -289,18 +289,18 @@ public class MonitoringPolicyTestSteps {
                 existing.stop();
             }
             GenericContainer<?> minion = new GenericContainer<>(DockerImageName.parse(helper.getMinionImageNameSupplier().get()))
-                .withEnv("MINION_GATEWAY_HOST", helper.getMinionIngressSupplier().get())
-                .withEnv("MINION_GATEWAY_PORT", String.valueOf(helper.getMinionIngressPortSupplier().get()))
-                .withEnv("MINION_GATEWAY_TLS", String.valueOf(helper.getMinionIngressTlsEnabledSupplier().get()))
-                .withEnv("MINION_ID", systemId)
-                .withEnv("USE_KUBERNETES", "false")
-                .withEnv("GRPC_CLIENT_KEYSTORE", "/opt/karaf/minion.p12")
-                .withEnv("GRPC_CLIENT_KEYSTORE_PASSWORD", certificate.getKey())
-                .withEnv("GRPC_CLIENT_OVERRIDE_AUTHORITY", helper.getMinionIngressOverrideAuthority().get())
-                .withEnv("IGNITE_SERVER_ADDRESSES", "localhost")
-                .withNetworkAliases("minion")
-                .withNetwork(Network.SHARED)
-                .withLabel("label", key);
+                    .withEnv("MINION_GATEWAY_HOST", helper.getMinionIngressSupplier().get())
+                    .withEnv("MINION_GATEWAY_PORT", String.valueOf(helper.getMinionIngressPortSupplier().get()))
+                    .withEnv("MINION_GATEWAY_TLS", String.valueOf(helper.getMinionIngressTlsEnabledSupplier().get()))
+                    .withEnv("MINION_ID", systemId)
+                    .withEnv("USE_KUBERNETES", "false")
+                    .withEnv("GRPC_CLIENT_KEYSTORE", "/opt/karaf/minion.p12")
+                    .withEnv("GRPC_CLIENT_KEYSTORE_PASSWORD", certificate.getKey())
+                    .withEnv("GRPC_CLIENT_OVERRIDE_AUTHORITY", helper.getMinionIngressOverrideAuthority().get())
+                    .withEnv("IGNITE_SERVER_ADDRESSES", "localhost")
+                    .withNetworkAliases("minion")
+                    .withNetwork(Network.SHARED)
+                    .withLabel("label", key);
 
             File ca = helper.getMinionIngressCaCertificateSupplier().get();
             if (ca != null) {
@@ -321,17 +321,17 @@ public class MonitoringPolicyTestSteps {
     }
 
     @And("SNMP node {string} is started in the network of minion {string}")
-    public void startSNMPNode(String nodeLabel, String systemId) {
+    public void startSNMPNode(String nodeLabel, String systemId) throws InterruptedException {
 
         LOG.info("Starting node with systemId: " + systemId);
 
         GenericContainer<?> minion = minions.get(systemId);
 
         snmpContainer = new GenericContainer<>(DockerImageName.parse(helper.getNodeImageNameSupplier().get()))
-            .withNetworkAliases("nodes")
-            .withNetwork(minion.getNetwork())
-            .withCopyFileToContainer(MountableFile.forClasspathResource("BOOT-INF/classes/snmpd/snmpd.conf"), "/etc/snmp/snmpd.conf")
-            .withLabel("label", nodeLabel);
+                .withNetworkAliases("nodes")
+                .withNetwork(minion.getNetwork())
+                .withCopyFileToContainer(MountableFile.forClasspathResource("BOOT-INF/classes/snmpd/snmpd.conf"), "/etc/snmp/snmpd.conf")
+                .withLabel("label", nodeLabel);
 
         snmpContainer.waitingFor(Wait.forLogMessage(".*SNMPD Daemon started.*", 1).withStartupTimeout(Duration.ofMinutes(3)));
         snmpContainer.start();
@@ -340,6 +340,9 @@ public class MonitoringPolicyTestSteps {
         minionIpaddress = networksMap.values().iterator().next().getIpAddress();
 
         LOG.info("MINION ip={}", minionIpaddress);
+
+        LOG.info("Waiting for 20sec so both SNMP node and Minion are fully started ...");
+        Thread.sleep((20000));
 
     }
 
@@ -362,14 +365,14 @@ public class MonitoringPolicyTestSteps {
         LOG.info("SNMP node ip={}", snmpNodeIp);
 
         Long locationId = helper.commonQueryLocations().getData().getFindAllLocations().stream()
-            .filter(loc -> location.equals(loc.getLocation()))
-            .findFirst()
-            .map(LocationData::getId)
-            .orElseThrow(() -> new IllegalArgumentException("Unknown location " + location));
+                .filter(loc -> location.equals(loc.getLocation()))
+                .findFirst()
+                .map(LocationData::getId)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown location " + location));
 
         String ADD_DISCOVERY_QUERY_WITH_TAG =
-            "mutation { createIcmpActiveDiscovery( request: { name: \"%s\", locationId: \"%s\", ipAddresses: [\"%s\"], snmpConfig: { readCommunities: [\"%s\"], ports: [%d]\n" +
-                " }, tags: [ { name: \"%s\" } ] } ) {id, name, ipAddresses, locationId, snmpConfig { readCommunities, ports } } }";
+                "mutation { createIcmpActiveDiscovery( request: { name: \"%s\", locationId: \"%s\", ipAddresses: [\"%s\"], snmpConfig: { readCommunities: [\"%s\"], ports: [%d]\n" +
+                        " }, tags: [ { name: \"%s\" } ] } ) {id, name, ipAddresses, locationId, snmpConfig { readCommunities, ports } } }";
 
         String query = String.format(ADD_DISCOVERY_QUERY_WITH_TAG, discoveryName, locationId, snmpNodeIp, community, port, policyTag);
 
@@ -379,7 +382,7 @@ public class MonitoringPolicyTestSteps {
         Response response = helper.executePostQuery(gqlQuery);
 
         assertEquals("add-discovery query failed: status=" + response.getStatusCode() + "; body=" + response.getBody().asString(),
-            200, response.getStatusCode());
+                200, response.getStatusCode());
 
         AddDiscoveryResult discoveryResult = response.getBody().as(AddDiscoveryResult.class);
 
@@ -387,28 +390,33 @@ public class MonitoringPolicyTestSteps {
         LOG.info("SNMP node id={}", snmpNodeId);
 
         assertTrue("create-node errors: " + discoveryResult.getErrors(),
-            (discoveryResult.getErrors() == null) || (discoveryResult.getErrors().isEmpty()));
+                (discoveryResult.getErrors() == null) || (discoveryResult.getErrors().isEmpty()));
     }
 
-    @When("The snmp node sends a coldStart SNMP trap to Minion")
-    public void sendColdStartTrap() throws  Exception{
-        sendTrap("1.3.6.1.6.3.1.1.5.1");
-    }
-    @And("The snmp node sends a warmStart SNMP trap to Minion")
-    public void sendWarmStartTrap() throws  Exception{
-        sendTrap("1.3.6.1.6.3.1.1.5.2");
+    @When("The snmp node sends a {string} to Minion")
+    public void sendTrap(String triggerEventType) throws Exception {
+
+        switch (triggerEventType) {
+            case "SNMP Cold Start" -> sendTrapToMinion("1.3.6.1.6.3.1.1.5.1");
+            case "SNMP Warm Start" -> sendTrapToMinion("1.3.6.1.6.3.1.1.5.2");
+            case "SNMP Authen Failure" -> sendTrapToMinion("1.3.6.1.6.3.1.1.5.5");
+            case "SNMP Link Down" -> sendTrapToMinion("1.3.6.1.6.3.1.1.5.3");
+            case "SNMP Link Up" -> sendTrapToMinion("1.3.6.1.6.3.1.1.5.4");
+            case "SNMP EGP Down" -> sendTrapToMinion("1.3.6.1.6.3.1.1.5.6");
+            default -> LOG.error("trigger event type not supported: " + triggerEventType);
+        }
     }
 
-    public void sendTrap(String oid) throws Exception {
+    private void sendTrapToMinion(String oid) throws Exception {
         String community = "public";
         String trapReceiver = minionIpaddress + ":1162";
         String[] command = {
-            "snmptrap",
-            "-v", "2c",
-            "-c", community,
-            trapReceiver,
-            "", // empty string for the trap specific arguments
-            oid
+                "snmptrap",
+                "-v", "2c",
+                "-c", community,
+                trapReceiver,
+                "", // empty string for the trap specific arguments
+                oid
         };
 
         Container.ExecResult sendTrapResult = snmpContainer.execInContainer(command);
@@ -420,8 +428,8 @@ public class MonitoringPolicyTestSteps {
         Thread.sleep((2000));
     }
 
-    @Then("An alert should be triggered with severity {string}")
-    public void verifyAlertSeverity(String severity) throws Exception {
+    @Then("An alert with {string} should be triggered with severity {string}")
+    public void verifyAlertSeverity(String triggerEventName, String severity) throws Exception {
         LOG.info("Waiting 2 seconds for the new alert...");
         Thread.sleep(2000);
         String nodeLabel = getNodeLabel();
@@ -432,7 +440,8 @@ public class MonitoringPolicyTestSteps {
             JsonObject alert = (JsonObject) element;
             String nodeName = alert.get("nodeName").getAsString();
             LOG.info(nodeName + " : " + nodeLabel);
-            if (nodeName.equals(nodeLabel)) {
+            String eventUei = alert.get("uei").getAsString();
+            if (nodeName.equals(nodeLabel) && eventUei.endsWith(triggerEventName.replaceAll(" ", "_"))) {
                 alertSeverity = alert.get("severity").getAsString();
                 break;
             }
@@ -443,12 +452,12 @@ public class MonitoringPolicyTestSteps {
     public String getNodeLabel() {
 
         String request = """
-            query NodesTableParts { findAllNodes { id nodeLabel
-                  ipInterfaces {
-                    id
-                    ipAddress
-                  }
-                  }}""";
+                query NodesTableParts { findAllNodes { id nodeLabel
+                      ipInterfaces {
+                        id
+                        ipAddress
+                      }
+                      }}""";
 
         GQLQuery gqlQuery = new GQLQuery();
         gqlQuery.setQuery(request);
@@ -480,17 +489,18 @@ public class MonitoringPolicyTestSteps {
     public JsonArray getAlerts(String nodeLabel) {
 
         String request = """
-            query {
-              findAllAlerts(pageSize: 20, page: 0, timeRange: ALL, sortBy: "tenantId", sortAscending: true, nodeLabel:""" + " \"" + nodeLabel + "\"\n" + """
-                ) {
-                nextPage
-                alerts {
-                    severity
-                    label
-                    nodeName
-                }
-              }
-            }""";
+                query {
+                  findAllAlerts(pageSize: 20, page: 0, timeRange: ALL, sortBy: "tenantId", sortAscending: true, nodeLabel:""" + " \"" + nodeLabel + "\"\n" + """
+                    ) {
+                    nextPage
+                    alerts {
+                        severity
+                        label
+                        nodeName
+                        uei
+                    }
+                  }
+                }""";
 
         GQLQuery gqlQuery = new GQLQuery();
         gqlQuery.setQuery(request);
@@ -548,9 +558,9 @@ public class MonitoringPolicyTestSteps {
         List<MinionData> minionData = findAllMinionsQueryResult.getData().getFindAllMinions();
 
         List<MinionData> minionsAtLocation =
-            minionData.stream()
-                .filter((md) -> Objects.equals(md.getLocation().getLocation(), minionLocation))
-                .collect(Collectors.toList());
+                minionData.stream()
+                        .filter((md) -> Objects.equals(md.getLocation().getLocation(), minionLocation))
+                        .collect(Collectors.toList());
 
         LOG.debug("MINIONS for location: count={}; location={}", minionsAtLocation.size(), minionLocation);
 

--- a/test-automation/integration-tests/src/main/resources/org/opennms/horizon/it/monitoring-policy.feature
+++ b/test-automation/integration-tests/src/main/resources/org/opennms/horizon/it/monitoring-policy.feature
@@ -16,14 +16,22 @@ Feature: Monitoring Policy
     Given Minion ingress overridden authority is in variable "MINION_INGRESS_OVERRIDE_AUTHORITY"
     Then login to Keycloak with timeout 120000ms
 
-  Scenario Outline: Apply a custom monitoring policy to a node
+  Scenario Outline: Create monitoring policies
 
     Given Policy rule name "<policy-rule>", component type "NODE" and event type "SNMP_TRAP"
     Given Alert conditions data
-      | trigger event id   | trigger event name  | event type | count | overtime | overtime unit | severity   | clear event |
-      | <trigger-event-id> | <trigger-event-name> | SNMP_TRAP | 1     | 3        | MINUTE        | <severity> |             |
+      | trigger event id   | trigger event name   | event type | count | overtime | overtime unit | severity   | clear event |
+      | <trigger-event-id> | <trigger-event-name> | SNMP_TRAP  | 1     | 0        |               | <severity> |             |
     When The user saves the monitoring policy with name "test-monitoring-policy" and tag "<tag>"
     Then There is a monitoring policy with name "test-monitoring-policy" and tag "<tag>"
+
+    Examples:
+      | tag                     | trigger-event-id | trigger-event-name | severity | policy-rule   |
+      | monitoring-policy-tag01 | 1                | SNMP Cold Start    | MINOR    | policy-rule01 |
+      | monitoring-policy-tag01 | 2                | SNMP Warm Start    | MAJOR    | policy-rule02 |
+      | monitoring-policy-tag01 | 4                | SNMP Link Down     | CRITICAL | policy-rule04 |
+
+  Scenario: Send trap and verify alert severity
 
     Given No minion running with location "test-monitoring-policy-location"
     Given Location "test-monitoring-policy-location" does not exist
@@ -33,16 +41,18 @@ Feature: Monitoring Policy
 
     When Minion "test-monitoring-policy-system01" is started at location "test-monitoring-policy-location"
     And SNMP node "mp_snmp_node" is started in the network of minion "test-monitoring-policy-system01"
-    Then Discover "MPDiscovery" for snmp node "mp_snmp_node", location "test-monitoring-policy-location" is created to discover by IP with policy tag "<tag>"
-    When The snmp node sends a coldStart SNMP trap to Minion
-    And The snmp node sends a warmStart SNMP trap to Minion
-    Then An alert should be triggered with severity "<severity>"
+    Then Discover "test-monitoring-policy-discovery" for snmp node "mp_snmp_node", location "test-monitoring-policy-location" is created to discover by IP with policy tag "monitoring-policy-tag01"
+
+    When The snmp node sends a "SNMP Cold Start" to Minion
+    Then An alert with "SNMP Cold Start" should be triggered with severity "MINOR"
+
+    When The snmp node sends a "SNMP Warm Start" to Minion
+    Then An alert with "SNMP Warm Start" should be triggered with severity "MAJOR"
+
+    When The snmp node sends a "SNMP Link Down" to Minion
+    Then An alert with "SNMP Link Down" should be triggered with severity "CRITICAL"
 
     Given At least one Minion is running with location "test-monitoring-policy-location"
     Then Minion "test-monitoring-policy-system01" is stopped
     When Location "test-monitoring-policy-location" is removed
     Then Location "test-monitoring-policy-location" does not exist
-
-    Examples:
-      | tag | trigger-event-id | trigger-event-name | severity | policy-rule |
-      | monitoring-policy-tag-major | 1 | SNMP Event | MAJOR | policy-rule-major |


### PR DESCRIPTION
## Description
[<!-- Describe this Pull Request, what it changes, and why it's necessary. -->]() The issue has been caused by sending snmp traps from a snmp node before the node(a test container) is fully started. The fix is to insert a waiting period of 20 seconds after the node was started. The test scenarios have also been refactored as a result of the fix.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-1979

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
