### PR TITLE
BTO-783: minion-gateway: flesh out traces for all connection types and streaming messages including identity attributes

### DIFF
--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/grpc/common/TenantIDGrpcServerInterceptor.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/grpc/common/TenantIDGrpcServerInterceptor.java
@@ -38,7 +38,6 @@ import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 
 import java.time.Duration;

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -49,7 +50,9 @@ import org.opennms.cloud.grpc.minion.RpcResponseProto;
 import org.opennms.cloud.grpc.minion.SinkMessage;
 import org.opennms.cloud.grpc.minion_gateway.GatewayRpcResponseProto;
 import org.opennms.cloud.grpc.minion_gateway.MinionIdentity;
+import org.opennms.horizon.grpc.heartbeat.contract.HeartbeatMessage;
 import org.opennms.horizon.shared.grpc.common.GrpcIpcServer;
+import org.opennms.horizon.shared.grpc.common.LocationServerInterceptor;
 import org.opennms.horizon.shared.grpc.common.TenantIDGrpcServerInterceptor;
 import org.opennms.horizon.shared.grpc.interceptor.InterceptorFactory;
 import org.opennms.horizon.shared.grpc.interceptor.MeteringInterceptorFactory;
@@ -72,6 +75,7 @@ import org.slf4j.MDC.MDCCloseable;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.Empty;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 
 import io.grpc.BindableService;
@@ -81,7 +85,9 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
@@ -124,6 +130,9 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
     private RpcRequestTimeoutManager rpcRequestTimeoutManager;
     private MinionManager minionManager;
     private TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor;
+    private LocationServerInterceptor locationServerInterceptor;
+    private final boolean debugSpanFullMessage;
+    private final boolean debugSpanContent;
 
     private final Map<String, Consumer<SinkMessage>> sinkDispatcherById = new ConcurrentHashMap<>();
 
@@ -140,13 +149,15 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
 // Constructor
 //----------------------------------------
 
-    public OpennmsGrpcServer(GrpcIpcServer grpcIpcServer, final MeterRegistry meterRegistry) {
+    public OpennmsGrpcServer(GrpcIpcServer grpcIpcServer, final MeterRegistry meterRegistry, boolean debugSpanFullMessage, boolean debugSpanContent) {
         this.grpcIpcServer = grpcIpcServer;
         this.interceptors = List.of(
             new MeteringInterceptorFactory(meterRegistry)
         );
 
         this.meterRegistry = Objects.requireNonNull(meterRegistry);
+        this.debugSpanFullMessage = debugSpanFullMessage;
+        this.debugSpanContent = debugSpanContent;
     }
 
 //========================================
@@ -243,6 +254,13 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
     public void setTenantIDGrpcServerInterceptor(TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor) {
         this.tenantIDGrpcServerInterceptor = tenantIDGrpcServerInterceptor;
     }
+    public LocationServerInterceptor getLocationServerInterceptor() {
+        return locationServerInterceptor;
+    }
+
+    public void setLocationServerInterceptor(LocationServerInterceptor locationServerInterceptor) {
+        this.locationServerInterceptor = locationServerInterceptor;
+    }
 
 //========================================
 // Operations
@@ -263,14 +281,10 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
         sinkDispatcherById.computeIfAbsent(module.getId(), id -> sinkMessage -> {
             final T message = module.unmarshal(sinkMessage.getContent().toByteArray());
             final var span = tracer.spanBuilder("dispatch " + module.getId())
-                .setNoParent()
-                .addLink(Span.current().getSpanContext())
                 .setAttribute(SemanticAttributes.CODE_NAMESPACE, module.getClass().getName())
                 .startSpan();
 
             try (var ss = span.makeCurrent()) {
-                // we might want to do this in the future in a debugging mode
-                //span.setAttribute("message", message.toString());
                 dispatch(module, message);
             } catch (Throwable throwable) {
                 span.setStatus(StatusCode.ERROR, "Received exception during dispatch: " + throwable);
@@ -304,33 +318,99 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
 //----------------------------------------
 
     private StreamObserver<MinionToCloudMessage> processSinkStreamingCall(StreamObserver<Empty> responseObserver) {
-        return new StreamObserver<>() {
+        final var streamSpan = Span.current(); // stash for linking future messages back to the stream
+        final AtomicReference<Attributes> attributes = new AtomicReference<>(Attributes.builder()
+            .put("user", tenantIDGrpcServerInterceptor.readCurrentContextTenantId())
+            .put("location", locationServerInterceptor.readCurrentContextLocationId())
+            // we don't have systemId yet -- we grab this from the first heartbeat message we see
+            .build());
+        final var haveSystemId = new AtomicBoolean(false);
 
+        streamSpan.setAllAttributes(attributes.get()); // Add attributes to the stream span now
+
+        return new StreamObserver<MinionToCloudMessage>() {
             @Override
             public void onNext(MinionToCloudMessage message) {
-                if (message.hasSinkMessage()) {
-                    SinkMessage sinkMessage = message.getSinkMessage();
-                    if (!Strings.isNullOrEmpty(sinkMessage.getModuleId())) {
-                        ExecutorService sinkModuleExecutor = sinkConsumersByModuleId.get(sinkMessage.getModuleId());
-                        if (sinkModuleExecutor != null) {
-                            // Schedule execution with the ExecutorService, with the current GRPC context active
-                            Context.currentContextExecutor(sinkModuleExecutor)
-                                .execute(() -> dispatchSinkMessage(sinkMessage));
+                // We don't know the message type yet, but will update later if we can
+                final var span = tracer.spanBuilder("MinionToCloudMessage receive unknown")
+                    .setSpanKind(SpanKind.CONSUMER)
+                    .setAllAttributes(attributes.get())
+                    .setAttribute("size", message.getSerializedSize())
+                    .setNoParent() // we don't want each message to be lost in the long-running streaming trace
+                    .addLink(Span.current().getSpanContext()) // but we do want to link to the long-running trace
+                    .startSpan();
+
+                try (var ss = span.makeCurrent()) {
+                    if (message.hasSinkMessage()) {
+                        SinkMessage sinkMessage = message.getSinkMessage();
+                        span.updateName("MinionToCloudMessages receive " + sinkMessage.getModuleId());
+                        span.setAttribute("moduleId", sinkMessage.getModuleId());
+                        span.setAttribute("messageId", sinkMessage.getMessageId());
+                        if (sinkMessage.hasIdentity()) {
+                            span.setAttribute("identity", sinkMessage.getIdentity().toString());
+                        }
+
+                        if (debugSpanFullMessage) {
+                            span.setAttribute("message", sinkMessage.toString());
+                        }
+                        if (debugSpanContent) {
+                            span.setAttribute("content", sinkMessage.getContent().toString());
+                        }
+
+                        // We won't have the system ID until we receive the first heartbeat message, so
+                        // once we get it, (1) we stash it with a full set of identity attributes for
+                        // future message spans, (2) we set it on the long-running stream span, and
+                        // (3) we set it on our current span. And we make sure to only do this once.
+                        if (!haveSystemId.get() && "heartbeat".equals(sinkMessage.getModuleId())) {
+                            try {
+                                var heartbeatMessage = HeartbeatMessage.parseFrom(sinkMessage.getContent());
+                                if (heartbeatMessage.getIdentity() != null) {
+                                    var systemId = heartbeatMessage.getIdentity().getSystemId();
+                                    attributes.set(Attributes.builder()
+                                        .putAll(attributes.get())
+                                        .put("systemId", systemId)
+                                        .build());
+                                    streamSpan.setAttribute("systemId", systemId);
+                                    span.setAttribute("systemId", systemId);
+                                    haveSystemId.set(true);
+                                }
+                            } catch (InvalidProtocolBufferException e) {
+                                // ignore
+                            }
+                        }
+
+                        if (!Strings.isNullOrEmpty(sinkMessage.getModuleId())) {
+                            ExecutorService sinkModuleExecutor = sinkConsumersByModuleId.get(sinkMessage.getModuleId());
+                            if (sinkModuleExecutor != null) {
+                                // Schedule execution with the ExecutorService, with the current GRPC context active
+                                Context.currentContextExecutor(sinkModuleExecutor)
+                                    .execute(() -> dispatchSinkMessage(sinkMessage));
+                            } else {
+                                LOG.error("Ignoring sink message; no module executor registered: module-id={}; identity={}; message-id={}",
+                                    sinkMessage.getModuleId(),
+                                    sinkMessage.getIdentity(),
+                                    sinkMessage.getMessageId()
+                                );
+                                span.setStatus(StatusCode.ERROR, "Ignoring sink message; no module executor registered");
+                            }
                         } else {
-                            LOG.error("Ignoring sink message; no module executor registered: module-id={}; identity={}; message-id={}",
-                                sinkMessage.getModuleId(),
+                            LOG.error("Ignoring sink message with null or empty module-id: identity={}; message-id={}",
                                 sinkMessage.getIdentity(),
                                 sinkMessage.getMessageId()
                             );
+                            span.setStatus(StatusCode.ERROR, "Ignoring sink message with null or empty module-id");
                         }
                     } else {
-                        LOG.error("Ignoring sink message with null or empty module-id: identity={}; message-id={}",
-                            sinkMessage.getIdentity(),
-                            sinkMessage.getMessageId()
-                        );
+                        LOG.error("Unsupported message {}", message);
+                        span.setStatus(StatusCode.ERROR, "Unsupported message (expecting SinkMessage)");
+                        span.setAttribute("message", message.toString());
                     }
-                } else {
-                    LOG.error("Unsupported message {}", message);
+                } catch (Throwable throwable) {
+                    span.setStatus(StatusCode.ERROR, "Received exception during dispatch: " + throwable);
+                    span.recordException(throwable);
+                    throw new UndeclaredThrowableException(throwable);
+                } finally {
+                    span.end();
                 }
             }
 

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
@@ -84,7 +84,6 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
@@ -141,7 +140,7 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
     private BiConsumer<RpcRequestProto, StreamObserver<RpcResponseProto>> incomingRpcHandler;
     private OutgoingMessageHandler outgoingMessageHandler;
 
-    private Tracer tracer = GlobalOpenTelemetry.get().getTracer(getClass().getName());
+    private final Tracer tracer;
 
     private MeterRegistry meterRegistry;
 
@@ -149,13 +148,14 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
 // Constructor
 //----------------------------------------
 
-    public OpennmsGrpcServer(GrpcIpcServer grpcIpcServer, final MeterRegistry meterRegistry, boolean debugSpanFullMessage, boolean debugSpanContent) {
+    public OpennmsGrpcServer(GrpcIpcServer grpcIpcServer, final MeterRegistry meterRegistry, final Tracer tracer, boolean debugSpanFullMessage, boolean debugSpanContent) {
         this.grpcIpcServer = grpcIpcServer;
         this.interceptors = List.of(
             new MeteringInterceptorFactory(meterRegistry)
         );
 
         this.meterRegistry = Objects.requireNonNull(meterRegistry);
+        this.tracer = tracer;
         this.debugSpanFullMessage = debugSpanFullMessage;
         this.debugSpanContent = debugSpanContent;
     }

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/OutgoingMessageFactory.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/OutgoingMessageFactory.java
@@ -28,11 +28,13 @@
 
 package org.opennms.horizon.shared.ipc.grpc.server.manager;
 
-import io.grpc.stub.StreamObserver;
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
+
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.trace.SpanContext;
 
 public interface OutgoingMessageFactory {
 
-    void create(String systemId, String tenantId, String location, StreamObserver<CloudToMinionMessage> streamObserver);
+    void create(String systemId, String tenantId, String location, SpanContext streamSpan, StreamObserver<CloudToMinionMessage> streamObserver);
 
 }

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/OutgoingMessageHandler.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/OutgoingMessageHandler.java
@@ -28,12 +28,14 @@
 
 package org.opennms.horizon.shared.ipc.grpc.server.manager;
 
-import io.grpc.stub.StreamObserver;
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
 import org.opennms.cloud.grpc.minion.Identity;
 
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.trace.Span;
+
 public interface OutgoingMessageHandler {
 
-    void handleOutgoingStream(Identity request, StreamObserver<CloudToMinionMessage> responseObserver);
+    void handleOutgoingStream(Identity request, StreamObserver<CloudToMinionMessage> responseObserver, Span streamSpan);
 
 }

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/RpcConnectionTracker.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/RpcConnectionTracker.java
@@ -1,9 +1,12 @@
 package org.opennms.horizon.shared.ipc.grpc.server.manager;
 
-import io.grpc.stub.StreamObserver;
 import java.util.concurrent.Semaphore;
+
 import org.opennms.cloud.grpc.minion.RpcRequestProto;
-import org.opennms.cloud.grpc.minion.RpcResponseProto;
+
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
 
 public interface RpcConnectionTracker {
     boolean addConnection(String tenantId, String location, String minionId, StreamObserver<RpcRequestProto> connection);
@@ -11,6 +14,8 @@ public interface RpcConnectionTracker {
     StreamObserver<RpcRequestProto> lookupByLocationRoundRobin(String tenantId, String locationId);
     MinionInfo removeConnection(StreamObserver<RpcRequestProto> connection);
     Semaphore getConnectionSemaphore(StreamObserver<RpcRequestProto> connection);
+    SpanContext getConnectionSpanContext(StreamObserver<RpcRequestProto> connection);
+    Attributes getConnectionSpanAttributes(StreamObserver<RpcRequestProto> connection);
 
     void clear();
 }

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/adapter/MinionRSTransportAdapter.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/adapter/MinionRSTransportAdapter.java
@@ -1,9 +1,8 @@
 package org.opennms.horizon.shared.ipc.grpc.server.manager.adapter;
 
-import com.google.protobuf.Empty;
-import io.grpc.stub.StreamObserver;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+
 import org.opennms.cloud.grpc.minion.CloudServiceGrpc.CloudServiceImplBase;
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
 import org.opennms.cloud.grpc.minion.Identity;
@@ -11,6 +10,11 @@ import org.opennms.cloud.grpc.minion.MinionToCloudMessage;
 import org.opennms.cloud.grpc.minion.RpcRequestProto;
 import org.opennms.cloud.grpc.minion.RpcResponseProto;
 import org.opennms.horizon.shared.ipc.grpc.server.manager.OutgoingMessageHandler;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.trace.Span;
 
 public class MinionRSTransportAdapter extends CloudServiceImplBase {
 
@@ -36,7 +40,7 @@ public class MinionRSTransportAdapter extends CloudServiceImplBase {
 
     @Override
     public void cloudToMinionMessages(Identity request, StreamObserver<CloudToMinionMessage> responseObserver) {
-        cloudToMinionMessages.handleOutgoingStream(request, responseObserver);
+        cloudToMinionMessages.handleOutgoingStream(request, responseObserver, Span.current());
     }
 
     @Override

--- a/minion-gateway/main/pom.xml
+++ b/minion-gateway/main/pom.xml
@@ -150,6 +150,10 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+        </dependency>
         <!-- test -->
         <dependency>
             <groupId>junit</groupId>

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/MinionGatewayMain.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/MinionGatewayMain.java
@@ -8,6 +8,9 @@ import org.springframework.context.annotation.ImportResource;
 
 import com.codahale.metrics.MetricRegistry;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+
 @SpringBootConfiguration
 @SpringBootApplication
 @ImportResource("classpath:/ignite-cache-config.xml")
@@ -20,5 +23,10 @@ public class MinionGatewayMain {
     @Bean
     public MetricRegistry metricRegistry(){
         return new MetricRegistry();
+    }
+
+    @Bean
+    public OpenTelemetry openTelemetry() {
+        return GlobalOpenTelemetry.get(); // this gets the SDK that was configured by the Java agent
     }
 }

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
@@ -90,7 +90,7 @@ public class GrpcServerConfig {
         TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor,
         LocationServerInterceptor locationServerInterceptor,
         List<OutgoingMessageFactory> outgoingMessageFactoryList) {
-        return new TaskSetTwinMessageProcessor(tenantIDGrpcServerInterceptor, locationServerInterceptor, outgoingMessageFactoryList);
+        return new TaskSetTwinMessageProcessor(tenantIDGrpcServerInterceptor, locationServerInterceptor, outgoingMessageFactoryList, debugSpanFullMessage, debugSpanContent);
     }
 
     @Bean

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Configuration;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.OpenTelemetry;
 
 @Configuration
 public class GrpcServerConfig {
@@ -125,10 +126,11 @@ public class GrpcServerConfig {
         @Autowired RpcRequestTimeoutManager rpcRequestTimeoutManager,
         @Autowired TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor,
         @Autowired LocationServerInterceptor locationServerInterceptor,
-        @Autowired MeterRegistry meterRegistry
+        @Autowired MeterRegistry meterRegistry,
+        @Autowired OpenTelemetry openTelemetry
         ) throws Exception {
 
-        OpennmsGrpcServer server = new OpennmsGrpcServer(serverBuilder, meterRegistry, debugSpanFullMessage, debugSpanContent);
+        OpennmsGrpcServer server = new OpennmsGrpcServer(serverBuilder, meterRegistry, openTelemetry.getTracer(getClass().getName()), debugSpanFullMessage, debugSpanContent);
 
         server.setRpcConnectionTracker(rpcConnectionTracker);
         server.setRpcRequestTracker(rpcRequestTracker);

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcTwinPublisherConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcTwinPublisherConfig.java
@@ -5,11 +5,18 @@ import org.opennms.horizon.shared.grpc.common.LocationServerInterceptor;
 import org.opennms.horizon.shared.grpc.common.TenantIDGrpcServerInterceptor;
 import org.opennms.miniongateway.grpc.twin.GrpcTwinPublisher;
 import org.opennms.miniongateway.grpc.twin.TwinRpcHandler;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class GrpcTwinPublisherConfig {
+
+    @Value("${debug.span.full.message:false}")
+    private boolean debugSpanFullMessage;
+
+    @Value("${debug.span.content:false}")
+    private boolean debugSpanContent;
 
     @Bean
     public ServerHandler serverHandler(
@@ -22,7 +29,7 @@ public class GrpcTwinPublisherConfig {
 
     @Bean(initMethod = "start", destroyMethod = "close")
     public GrpcTwinPublisher grpcTwinPublisher(Ignite ignite) {
-        return new GrpcTwinPublisher(ignite);
+        return new GrpcTwinPublisher(ignite, debugSpanFullMessage, debugSpanContent);
     }
 
 }

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcTwinPublisherConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcTwinPublisherConfig.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.opentelemetry.api.OpenTelemetry;
+
 @Configuration
 public class GrpcTwinPublisherConfig {
 
@@ -22,14 +24,15 @@ public class GrpcTwinPublisherConfig {
     public ServerHandler serverHandler(
         GrpcTwinPublisher grpcTwinPublisher,
         TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor,
-        LocationServerInterceptor locationServerInterceptor
+        LocationServerInterceptor locationServerInterceptor,
+        OpenTelemetry openTelemetry
     ) {
-        return new TwinRpcHandler(grpcTwinPublisher, tenantIDGrpcServerInterceptor, locationServerInterceptor, debugSpanFullMessage, debugSpanContent);
+        return new TwinRpcHandler(grpcTwinPublisher, tenantIDGrpcServerInterceptor, locationServerInterceptor, openTelemetry.getTracer(getClass().getName()), debugSpanFullMessage, debugSpanContent);
     }
 
     @Bean(initMethod = "start", destroyMethod = "close")
-    public GrpcTwinPublisher grpcTwinPublisher(Ignite ignite) {
-        return new GrpcTwinPublisher(ignite, debugSpanFullMessage, debugSpanContent);
+    public GrpcTwinPublisher grpcTwinPublisher(Ignite ignite, OpenTelemetry openTelemetry) {
+        return new GrpcTwinPublisher(ignite, openTelemetry.getTracer(getClass().getName()), debugSpanFullMessage, debugSpanContent);
     }
 
 }

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcTwinPublisherConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcTwinPublisherConfig.java
@@ -24,7 +24,7 @@ public class GrpcTwinPublisherConfig {
         TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor,
         LocationServerInterceptor locationServerInterceptor
     ) {
-        return new TwinRpcHandler(grpcTwinPublisher, tenantIDGrpcServerInterceptor, locationServerInterceptor);
+        return new TwinRpcHandler(grpcTwinPublisher, tenantIDGrpcServerInterceptor, locationServerInterceptor, debugSpanFullMessage, debugSpanContent);
     }
 
     @Bean(initMethod = "start", destroyMethod = "close")

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/twin/GrpcTwinPublisher.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/twin/GrpcTwinPublisher.java
@@ -58,7 +58,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -77,12 +76,13 @@ public class GrpcTwinPublisher extends AbstractTwinPublisher implements Outgoing
             .build();
     private final ExecutorService twinRpcExecutor = Executors.newCachedThreadPool(twinRpcThreadFactory);
 
-    private Tracer tracer = GlobalOpenTelemetry.get().getTracer(getClass().getName());
+    private final Tracer tracer;
     private final boolean debugSpanFullMessage;
     private final boolean debugSpanContent;
 
-    public GrpcTwinPublisher(Ignite ignite, boolean debugSpanFullMessage, boolean debugSpanContent) {
+    public GrpcTwinPublisher(Ignite ignite, final Tracer tracer, boolean debugSpanFullMessage, boolean debugSpanContent) {
         super(ignite);
+        this.tracer = tracer;
         this.debugSpanFullMessage = debugSpanFullMessage;
         this.debugSpanContent = debugSpanContent;
     }

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/twin/TaskSetTwinMessageProcessor.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/twin/TaskSetTwinMessageProcessor.java
@@ -1,7 +1,7 @@
 package org.opennms.miniongateway.grpc.twin;
 
-import io.grpc.stub.StreamObserver;
 import java.util.List;
+
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
 import org.opennms.cloud.grpc.minion.Identity;
 import org.opennms.horizon.shared.grpc.common.LocationServerInterceptor;
@@ -11,6 +11,12 @@ import org.opennms.horizon.shared.ipc.grpc.server.manager.OutgoingMessageHandler
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+
 public class TaskSetTwinMessageProcessor implements OutgoingMessageHandler {
     private static final Logger DEFAULT_LOGGER = LoggerFactory.getLogger(TaskSetTwinMessageProcessor.class);
 
@@ -18,31 +24,63 @@ public class TaskSetTwinMessageProcessor implements OutgoingMessageHandler {
     private final LocationServerInterceptor locationServerInterceptor;
 
     private final List<OutgoingMessageFactory> outgoingMessageFactoryList;
+    private final boolean debugSpanFullMessage;
+    private final boolean debugSpanContent;
 
     private Logger log = DEFAULT_LOGGER;
 
     public TaskSetTwinMessageProcessor(TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor, LocationServerInterceptor locationServerInterceptor,
-        List<OutgoingMessageFactory> outgoingMessageFactoryList) {
+                                       List<OutgoingMessageFactory> outgoingMessageFactoryList, boolean debugSpanFullMessage, boolean debugSpanContent) {
         this.outgoingMessageFactoryList = outgoingMessageFactoryList;
         this.tenantIDGrpcServerInterceptor = tenantIDGrpcServerInterceptor;
         this.locationServerInterceptor = locationServerInterceptor;
+        this.debugSpanFullMessage = debugSpanFullMessage;
+        this.debugSpanContent = debugSpanContent;
     }
 
+    /**
+     *
+     * @param minionHeader Identity message received from the Minion as the first (and only) message after it connects.
+     * @param cloudToMinionMessageStreamObserver observer that handles this stream
+     * @param streamSpan the Span for the parent stream for this message, used relate later cloud message Spans back
+     *                   to the stream Span and to add identity attributes to the stream Span.
+     *                   This needs to be passed into this method because a new span is started for this
+     *                   method using @WithSpan and at that point we lose visibility to the stream Span.
+     */
     @Override
-    public void handleOutgoingStream(Identity minionHeader, StreamObserver<CloudToMinionMessage> cloudToMinionMessageStreamObserver) {
+    @WithSpan(value="CloudToMinionMessage Minion identity received", kind=SpanKind.CONSUMER)
+    public void handleOutgoingStream(Identity minionHeader, StreamObserver<CloudToMinionMessage> cloudToMinionMessageStreamObserver, Span streamSpan) {
         String tenantId = tenantIDGrpcServerInterceptor.readCurrentContextTenantId();
         String location = locationServerInterceptor.readCurrentContextLocationId();
-        log.info("Have Message to send to Minion: tenant-id: {}; system-id={}, location={}",
+        String systemId = minionHeader.getSystemId();
+
+        var attributes = Attributes.builder()
+            .put("user", tenantId)
+            .put("location", location)
+            .put("systemId", systemId)
+            .build();
+
+        var span = Span.current();
+
+        // We make sure the identity attributes are set both on the streamSpanContext and our current span.
+        streamSpan.setAllAttributes(attributes);
+        span.setAllAttributes(attributes);
+
+        span.setAttribute("size", minionHeader.getSerializedSize());
+        if (debugSpanFullMessage) {
+            span.setAttribute("message", minionHeader.toByteString().toStringUtf8());
+        }
+        // No debugSpanContent because it's just the systemId.
+
+        log.info("Received initial CloudToMinionMessages Identity message for Minion: tenant-id: {}; location={}; system-id={}",
             tenantId,
-            minionHeader.getSystemId(),
-            location
+            location,
+            systemId
         );
 
         for (OutgoingMessageFactory outgoingMessageFactory : outgoingMessageFactoryList) {
             // streamObserver.accept(identity, cloudToMinionMessageStreamObserver);
-            outgoingMessageFactory.create(minionHeader.getSystemId(), tenantId, location, cloudToMinionMessageStreamObserver);
+            outgoingMessageFactory.create(systemId, tenantId, location, streamSpan.getSpanContext(), cloudToMinionMessageStreamObserver);
         }
-
     }
-
 }

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/twin/TwinRpcHandler.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/twin/TwinRpcHandler.java
@@ -1,6 +1,5 @@
 package org.opennms.miniongateway.grpc.twin;
 
-import com.google.protobuf.Any;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -15,21 +14,34 @@ import org.opennms.miniongateway.grpc.server.ServerHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.protobuf.Any;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+
 public class TwinRpcHandler implements ServerHandler {
 
     private final Logger logger = LoggerFactory.getLogger(TwinRpcHandler.class);
+
     private final TwinProvider twinProvider;
     private final TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor;
     private final LocationServerInterceptor locationServerInterceptor;
+    private final boolean debugSpanFullMessage;
+    private final boolean debugSpanContent;
     private Executor twinRpcExecutor = Executors.newSingleThreadScheduledExecutor((runnable) -> new Thread(runnable, "twin-rpc"));
+    private Tracer tracer = GlobalOpenTelemetry.get().getTracer(getClass().getName());
 
     public TwinRpcHandler(
         TwinProvider twinProvider,
         TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor,
-        LocationServerInterceptor locationServerInterceptor) {
+        LocationServerInterceptor locationServerInterceptor, boolean debugSpanFullMessage, boolean debugSpanContent) {
         this.twinProvider = twinProvider;
         this.tenantIDGrpcServerInterceptor = tenantIDGrpcServerInterceptor;
         this.locationServerInterceptor = locationServerInterceptor;
+        this.debugSpanFullMessage = debugSpanFullMessage;
+        this.debugSpanContent = debugSpanContent;
     }
 
     @Override
@@ -42,11 +54,38 @@ public class TwinRpcHandler implements ServerHandler {
         String tenantId = tenantIDGrpcServerInterceptor.readCurrentContextTenantId();
         String locationId = locationServerInterceptor.readCurrentContextLocationId();
 
+        var attributesBuilder = Attributes.builder()
+            .put("user", tenantId)
+            .put("location", locationId);
+        if (request.hasIdentity()) {
+            attributesBuilder.put("systemId", request.getIdentity().getSystemId());
+        }
+        var attributes = attributesBuilder.build();
+
+        var span = Span.current();
+        span.updateName("minion.CloudService/MinionToCloudRPC " + request.getModuleId());
+        span
+            .setAllAttributes(attributes)
+            .setAttribute("request_size", request.getSerializedSize())
+            .setAttribute("rpcId", request.getRpcId())
+            .setAttribute("expiration", request.getExpirationTime())
+            .setAttribute("moduleId", request.getModuleId());
+
+        if (debugSpanFullMessage) {
+            span.setAttribute("request", request.toString());
+        }
+
         return CompletableFuture.supplyAsync(() -> {
             try {
                 TwinRequestProto twinRequest = request.getPayload().unpack(TwinRequestProto.class);
-                TwinResponseProto twinResponseProto = twinProvider.getTwinResponse(tenantId, locationId, twinRequest);
-                logger.debug("Sent Twin response for key {} at location {}", twinRequest.getConsumerKey(), locationId);
+
+                span.updateName("minion.CloudService/MinionToCloudRPC " + request.getModuleId() + " " + twinRequest.getConsumerKey());
+                span.setAttribute("consumerKey", twinRequest.getConsumerKey());
+                if (debugSpanContent) {
+                    span.setAttribute("request_payload", twinRequest.toString());
+                }
+
+                final TwinResponseProto twinResponseProto = twinProvider.getTwinResponse(tenantId, locationId, twinRequest);
 
                 RpcResponseProto response = RpcResponseProto.newBuilder()
                     .setModuleId("twin")
@@ -55,6 +94,15 @@ public class TwinRpcHandler implements ServerHandler {
                     .setPayload(Any.pack(twinResponseProto))
                     .build();
 
+                span.setAttribute("response_size", response.getSerializedSize());
+                if (debugSpanFullMessage) {
+                    span.setAttribute("response", response.toString());
+                }
+                if (debugSpanContent && response.hasPayload()) {
+                    span.setAttribute("response_payload", response.getPayload().toString());
+                }
+
+                logger.debug("Sending Twin response for key {} at location {}", twinRequest.getConsumerKey(), locationId);
                 return response;
             } catch (Exception e) {
                 throw new IllegalArgumentException("Exception while processing request", e);

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/twin/TwinRpcHandler.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/twin/TwinRpcHandler.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.protobuf.Any;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -28,18 +27,20 @@ public class TwinRpcHandler implements ServerHandler {
     private final TwinProvider twinProvider;
     private final TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor;
     private final LocationServerInterceptor locationServerInterceptor;
+    private final Tracer tracer;
     private final boolean debugSpanFullMessage;
     private final boolean debugSpanContent;
     private Executor twinRpcExecutor = Executors.newSingleThreadScheduledExecutor((runnable) -> new Thread(runnable, "twin-rpc"));
-    private Tracer tracer = GlobalOpenTelemetry.get().getTracer(getClass().getName());
 
     public TwinRpcHandler(
         TwinProvider twinProvider,
         TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor,
-        LocationServerInterceptor locationServerInterceptor, boolean debugSpanFullMessage, boolean debugSpanContent) {
+        LocationServerInterceptor locationServerInterceptor,
+        final Tracer tracer, boolean debugSpanFullMessage, boolean debugSpanContent) {
         this.twinProvider = twinProvider;
         this.tenantIDGrpcServerInterceptor = tenantIDGrpcServerInterceptor;
         this.locationServerInterceptor = locationServerInterceptor;
+        this.tracer = tracer;
         this.debugSpanFullMessage = debugSpanFullMessage;
         this.debugSpanContent = debugSpanContent;
     }

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -96,6 +96,9 @@ OpenNMS:
         grpc_set_header 'traceparent' $opentelemetry_context_traceparent; # This doesn't get sent downstream normally. :(
         opentelemetry_attribute "user" "$authHeader0";
         opentelemetry_attribute "location" "$authHeader1";
+    env:
+      DEBUG_SPAN_FULL_MESSAGE: "true"
+      DEBUG_SPAN_CONTENT: "true"
   MinionCertificateManager:
     Enabled: true
     CaSecretName: root-ca-certificate


### PR DESCRIPTION
- BTO-783: Add identity attributes to MinionToCloudMessage streaming and message spans
- BTO-783: Add tracing details for CloudToMinionRPC dispatch calls
- BTO-783: Add tracing for CloudToMinionMessage
- BTO-783: Add tracing for MinionToCloudRPC
- Tilt: include minion-gateway messages in tracing spans by default
- Don't use GlobalOpenTelemetry.get().getTracer anymore
- remove unused import

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
We should now have tracing spans created for **all** Minion<->Minion-gateway communications:
* CloudToMinionMessage
* MinionToCloudMessage
* CloudToMinionRPC
* MinionToCloudRPC

Streaming gRPC calls (the first two in the list above) are a little interesting, because by default, the OpenTelemetry gRPC instrumentation only adds spans at the *connection* level. These are both long-lived streams, and that can result in massive traces with a wide variety of messages intermingled. These changes now create a new trace for each message in a gRPC stream, and that new trace is linked to the connection-level trace (note: the top-level connection-level span won't be recorded *until the connection is closed*, so even though there is a linkage, you might not see the connection-level trace immediately).

This adds a few key attributes to the spans that seemed useful based on perusing the messages. Also, useful for development debugging: it can record the gRPC message payloads in the span. This is turned off by default, but can be enabled by setting environment variables, which are enabled by default in Tilt:
* DEBUG_SPAN_CONTENT -- show the decoded gRPC inner content for the message (in whatever form makes sense for the message)
* DEBUG_SPAN_FULL_MESSAGE -- show the full gRPC message (including metadata that is included in other attributes--like the identity of the minion, message ID, RPC moduleId, twin consumerKey, etc.)

Here is an example of a heartbeat trace (interestingly, you'll see about 2/3 of the way down, the *incoming* heartbeat from the Minion ends up triggering an echo RPC back to the Minion):
<img width="1550" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/4461073/50970ae6-2244-45ec-ab01-6a5db779bf2c">

Here are the attributes on the incoming heartbeat message:
<img width="829" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/4461073/2ffbd3e8-e1c2-45a5-9bb2-26f366ca3e1c">

And here's the same for the RPC echo call:
<img width="829" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/4461073/ae146f84-4c71-42b6-ad1f-fc44078c8677">
<img width="829" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/4461073/55a65478-eb14-430b-9ac0-0a47069d8e0b">
...
<img width="829" alt="image" src="https://github.com/OpenNMS-Cloud/lokahi/assets/4461073/3f1455c6-9f37-4791-87ca-b4aa8f731871">

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-783

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

This will unfortunately fail the SonarCloud coverage check because there is no test coverage on the new code. I started doing some refactoring to write some tests to exercise the tracing code I added, however I discovered that the classes I touched are completely untested today (at least from SonarCloud's perspective).

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
