### PR TITLE
LOK-1699: Fix surface border & border-radius

### DIFF
--- a/ui/src/components/Alerts/AlertsSeverityCard.vue
+++ b/ui/src/components/Alerts/AlertsSeverityCard.vue
@@ -93,7 +93,7 @@ const isTypeAdded = computed(() => alertsStore.alertsFilter.severities?.includes
   flex-direction: column;
   background-color: var(variables.$surface);
   padding: var(variables.$spacing-s);
-  border-radius: vars.$border-radius-s;
+  border-radius: vars.$border-radius-surface;
   &.selected {
     background-color: var(variables.$shade-4);
     border-color: var(variables.$secondary-variant);

--- a/ui/src/components/Common/EmptyList.vue
+++ b/ui/src/components/Common/EmptyList.vue
@@ -55,6 +55,8 @@ const msg = computed(() => props.content.msg || '')
 }
 
 .bg {
-  background-color: var(--feather-surface);
+  background-color: var(variables.$surface);
+  border-radius: vars.$border-radius-surface;
+  border: 1px solid var(variables.$border-on-surface);
 }
 </style>

--- a/ui/src/components/Dashboard/DashboardCard.vue
+++ b/ui/src/components/Dashboard/DashboardCard.vue
@@ -30,6 +30,7 @@ defineProps<{
 @use '@featherds/styles/mixins/typography';
 @use '@featherds/styles/themes/variables';
 @use '@/styles/mediaQueriesMixins.scss';
+@use '@/styles/vars.scss';
 
 .card {
   display: flex;
@@ -38,6 +39,7 @@ defineProps<{
   background-color: var(variables.$surface);
   padding: var(variables.$spacing-l);
   border: 1px solid var(variables.$border-on-surface);
+  border-radius: vars.$border-radius-surface;
   @include mediaQueriesMixins.screen-lg {
     width: 49.5%;
   }

--- a/ui/src/components/Discovery/DiscoveryListCard.vue
+++ b/ui/src/components/Discovery/DiscoveryListCard.vue
@@ -75,7 +75,7 @@ defineProps<{
 .card-my-discoveries {
   background-color: var(variables.$surface);
   border: 1px solid var(variables.$border-on-surface);
-  border-radius: vars.$border-radius-s;
+  border-radius: vars.$border-radius-surface;
   min-height: 100px;
 }
 

--- a/ui/src/components/Locations/LocationsList.vue
+++ b/ui/src/components/Locations/LocationsList.vue
@@ -98,7 +98,8 @@ const icons = markRaw({
 .locations-list-wrapper {
   padding: var(variables.$spacing-m) var(variables.$spacing-s);
   background: var(variables.$surface);
-  border-radius: vars.$border-radius-s;
+  border-radius: vars.$border-radius-surface;
+  border: 1px solid var(variables.$border-on-surface);
 
   .header {
     display: flex;

--- a/ui/src/components/Locations/LocationsMinionsList.vue
+++ b/ui/src/components/Locations/LocationsMinionsList.vue
@@ -103,7 +103,8 @@ const icons = markRaw({
 .minions-list-wrapper {
   padding: var(variables.$spacing-m) var(variables.$spacing-s);
   background: var(variables.$surface);
-  border-radius: vars.$border-radius-s;
+  border-radius: vars.$border-radius-surface;
+  border: 1px solid var(variables.$border-on-surface);
 
   .search-minions-input {
     width: 100%;

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesCard.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesCard.vue
@@ -102,13 +102,13 @@ onMounted(() => (ruleStates[props.policy.rules?.[0].id] = true))
 <style scoped lang="scss">
 @use '@featherds/styles/themes/variables';
 @use '@featherds/styles/mixins/typography';
-@use '@featherds/styles/mixins/elevation';
 @use '@/styles/mediaQueriesMixins.scss';
 @use '@/styles/vars.scss';
 
 .mp-card {
-  @include elevation.elevation(1);
-  border-radius: vars.$border-radius-xs;
+  background: var(variables.$surface);
+  border-radius: vars.$border-radius-surface;
+  border: 1px solid var(variables.$border-on-surface);
   display: flex;
   gap: var(variables.$spacing-xl);
   flex-direction: column;

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesCardEventConditionTable.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesCardEventConditionTable.vue
@@ -46,7 +46,6 @@ defineProps<{
 <style scoped lang="scss">
 @use '@featherds/styles/themes/variables';
 @use '@featherds/styles/mixins/typography';
-@use '@featherds/styles/mixins/elevation';
 @use '@/styles/vars.scss';
 @use '@/styles/_severities.scss';
 

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesCardThresholdConditionTable.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesCardThresholdConditionTable.vue
@@ -29,7 +29,6 @@ defineProps<{
 <style scoped lang="scss">
 @use '@featherds/styles/themes/variables';
 @use '@featherds/styles/mixins/typography';
-@use '@featherds/styles/mixins/elevation';
 @use '@/styles/vars.scss';
 @use '@/styles/_severities.scss';
 

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesExistingItems.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesExistingItems.vue
@@ -31,18 +31,17 @@ defineProps<{
 <style lang="scss" scoped>
 @use '@featherds/styles/themes/variables';
 @use '@featherds/styles/mixins/typography';
-@use '@featherds/styles/mixins/elevation';
 @use '@/styles/vars.scss';
 
 .existing-items-container {
-  @include elevation.elevation(2);
   display: flex;
   flex-direction: column;
   background: var(variables.$surface);
   margin: var(variables.$spacing-l) 0;
   padding: var(variables.$spacing-l);
   width: 350px;
-  border-radius: vars.$border-radius-s;
+  border-radius: vars.$border-radius-surface;
+  border: 1px solid var(variables.$border-on-surface);
   border-left: 5px solid var(variables.$success);
 
   .title {

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesPolicyForm.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesPolicyForm.vue
@@ -115,7 +115,6 @@ const formattedTags = computed(() => store.selectedPolicy!.tags!.map((tag: strin
 </script>
 
 <style scoped lang="scss">
-@use '@featherds/styles/mixins/elevation';
 @use '@featherds/styles/themes/variables';
 @use '@featherds/styles/mixins/typography';
 @use '@/styles/mediaQueriesMixins';
@@ -128,13 +127,13 @@ const formattedTags = computed(() => store.selectedPolicy!.tags!.map((tag: strin
   gap: var(variables.$spacing-l);
 
   .policy-form {
-    @include elevation.elevation(2);
     display: flex;
     flex: 1;
     flex-direction: column;
     background: var(variables.$surface);
     padding: var(variables.$spacing-l);
-    border-radius: vars.$border-radius-s;
+    border-radius: vars.$border-radius-surface;
+    border: 1px solid var(variables.$border-on-surface);
 
     .policy-form-title-container {
       display: flex;

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
@@ -174,7 +174,6 @@ const selectDetectionMethod = async (method: DetectionMethod) => {
 </script>
 
 <style scoped lang="scss">
-@use '@featherds/styles/mixins/elevation';
 @use '@featherds/styles/themes/variables';
 @use '@featherds/styles/mixins/typography';
 @use '@/styles/mediaQueriesMixins';
@@ -187,13 +186,13 @@ const selectDetectionMethod = async (method: DetectionMethod) => {
   gap: var(variables.$spacing-l);
 
   .rule-form {
-    @include elevation.elevation(2);
     display: flex;
     flex: 1;
     flex-direction: column;
     background: var(variables.$surface);
     padding: var(variables.$spacing-l);
-    border-radius: vars.$border-radius-s;
+    border-radius: vars.$border-radius-surface;
+    border: 1px solid var(variables.$border-on-surface);
     overflow: hidden;
 
     .form-title {

--- a/ui/src/containers/Alerts.vue
+++ b/ui/src/containers/Alerts.vue
@@ -249,6 +249,8 @@ const searchAlertsListener: fncArgVoid = (val: string | null) => {
 .alerts-content {
   background: var(variables.$surface);
   padding: var(variables.$spacing-l);
+  border-radius: vars.$border-radius-surface;
+  border: 1px solid var(variables.$border-on-surface);
 }
 
 .alerts-list {

--- a/ui/src/containers/Discovery.vue
+++ b/ui/src/containers/Discovery.vue
@@ -334,7 +334,7 @@ onMounted(() => discoveryQueries.getDiscoveries())
   width: 100%;
   min-width: 400px;
   border: 1px solid var(variables.$border-on-surface);
-  border-radius: vars.$border-radius-s;
+  border-radius: vars.$border-radius-surface;
   padding: var(variables.$spacing-m);
   background-color: var(variables.$surface);
 

--- a/ui/src/containers/Flows.vue
+++ b/ui/src/containers/Flows.vue
@@ -264,7 +264,7 @@ onUnmounted(() => flowsStore.$reset)
   width: 100%;
   min-width: 400px;
   border: 1px solid var(variables.$border-on-surface);
-  border-radius: vars.$border-radius-s;
+  border-radius: vars.$border-radius-surface;
   padding: var(variables.$spacing-m) 40px;
   background-color: var(variables.$surface);
   display: flex;

--- a/ui/src/styles/mixins.scss
+++ b/ui/src/styles/mixins.scss
@@ -11,5 +11,6 @@
 @mixin wrapper-on-background(){
   padding: var(variables.$spacing-m) var(variables.$spacing-s);
   background: var(variables.$surface);
-  border-radius: vars.$border-radius-s;
+  border-radius: vars.$border-radius-surface;
+  border: 1px solid var(variables.$border-on-surface);
 }

--- a/ui/src/styles/vars.scss
+++ b/ui/src/styles/vars.scss
@@ -3,7 +3,8 @@ $border-radius: (
   s: 5px,
   sm: 8px,
   m: 10px,
-  round: 50%
+  round: 50%,
+  surface: 4px
 ) !default;
 
 @use "sass:map";
@@ -13,6 +14,7 @@ $border-radius-s: map.get($border-radius, 's');
 $border-radius-sm: map.get($border-radius, 'sm');
 $border-radius-m: map.get($border-radius, 'm');
 $border-radius-round: map.get($border-radius, 'round');
+$border-radius-surface: map.get($border-radius, 'surface');
 
 $min-width-smallest-screen: 480px;
 


### PR DESCRIPTION
## Description
There were inconsistencies with the border and border-radius for some of the major surface containers.
This PR makes things consistent by using a 4px border-radius and the `$border-on-surface` feather var.

ex:
![screenshot-localhost_3009-2023 08 28-13_26_51](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/19af8bb9-9147-45f8-a808-cb4a96f18e02)

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1699

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
