### PR TITLE
Small minion cleanups and some other small improvements

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -49,10 +49,8 @@ load('ext://uibutton', 'cmd_button', 'location')
 load('ext://helm_remote', 'helm_remote') # for simple charts like jaeger and cert-manager
 load('ext://helm_resource', 'helm_resource', 'helm_repo') # for charts that we want to have resources for
 
-context = k8s_context()
-
 cmd_button(name='reload-certificates',
-           argv=['sh', '-c', 'find target/tmp/ -type f -exec rm {} \\; ; kubectl --context ' + context + ' -n ' + k8s_namespace() + ' delete secret root-ca-certificate opennms-minion-gateway-certificate opennms-ui-certificate client-root-ca-certificate ; kubectl --context ' + context + ' -n ' + k8s_namespace() + ' rollout restart deployment opennms-minion'],
+           argv=['sh', '-c', 'find target/tmp/ -type f -exec rm {} \\; ; kubectl --context ' + k8s_context() + ' -n ' + k8s_namespace() + ' delete secret root-ca-certificate opennms-minion-gateway-certificate opennms-ui-certificate client-root-ca-certificate ; kubectl --context ' + k8s_context() + ' -n ' + k8s_namespace() + ' rollout restart deployment opennms-minion'],
            text='Remove & reissue certificates',
            location=location.NAV,
            icon_name='sync')

--- a/Tiltfile
+++ b/Tiltfile
@@ -518,6 +518,18 @@ k8s_resource(
     trigger_mode=TRIGGER_MODE_MANUAL,
     resource_deps=['shared-lib'],
 )
+cmd_button(
+    name='button-opennms-minion',
+    text='Rollout restart minion',
+    resource='minion',
+    argv=[
+        'kubectl',
+        '--context', k8s_context(),
+        '-n', k8s_namespace(),
+        'rollout', 'restart', 'deployment', 'opennms-minion',
+    ],
+    icon_name='sync',
+)
 
 ### Minion Certificate Manager ###
 jib_project(

--- a/alert/src/main/resources/application.yaml
+++ b/alert/src/main/resources/application.yaml
@@ -62,3 +62,4 @@ management:
     health:
       probes:
         enabled: true
+      show-details: always

--- a/charts/lokahi/templates/_helpers.tpl
+++ b/charts/lokahi/templates/_helpers.tpl
@@ -53,8 +53,8 @@ by adding them as key/value pairs under <ServiceName>.env.
 - name: OTEL_RESOURCE_ATTRIBUTES
   value: {{ printf "service.version=%s" (regexReplaceAllLiteral ".*:" (include "lokahi.image" .) "") | quote }}
   {{- /* Other environment variables */ -}}
-  {{- if .env }}
-    {{- range $key, $val := .env }}
+  {{- if .thisService.env }}
+    {{- range $key, $val := .thisService.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
     {{- end }}

--- a/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
@@ -120,6 +120,10 @@ spec:
               value: "Default"
             - name: IGNITE_UPDATE_NOTIFIER # Disable Ignite version lookups
               value: "false"
+            {{- if .Values.OpenNMS.Minion.logLevel }}
+            - name: KARAF_OPTS
+              value: -Dkaraf.log.console={{ .Values.OpenNMS.Minion.logLevel }}
+            {{- end }}
             {{- if .Values.OpenNMS.Minion.addDefaultLocation }}
             - name: GRPC_CLIENT_KEYSTORE
               value: "/opt/karaf/certs/minion.p12"

--- a/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
+++ b/charts/lokahi/templates/opennms/minion/minion-deployment.yaml
@@ -206,4 +206,5 @@ spec:
               - unset JAVA_TOOL_OPTIONS; echo "opennms:task-set-print" | bin/client -b | grep -q taskDefinition
             initialDelaySeconds: 25
             periodSeconds: 5
+            failureThreshold: 10
 {{- end }}

--- a/datachoices/src/main/resources/application.yml
+++ b/datachoices/src/main/resources/application.yml
@@ -66,3 +66,4 @@ management:
     health:
       probes:
         enabled: true
+      show-details: always

--- a/events/main/src/main/resources/application.yml
+++ b/events/main/src/main/resources/application.yml
@@ -44,3 +44,4 @@ management:
     health:
       probes:
         enabled: true
+      show-details: always

--- a/inventory/main/src/main/resources/application.yml
+++ b/inventory/main/src/main/resources/application.yml
@@ -64,3 +64,4 @@ management:
     health:
       probes:
         enabled: true
+      show-details: always

--- a/metrics-processor/main/src/main/resources/application.yml
+++ b/metrics-processor/main/src/main/resources/application.yml
@@ -46,3 +46,4 @@ management:
     health:
       probes:
         enabled: true
+      show-details: always

--- a/minion-certificate-verifier/main/src/main/resources/application.yaml
+++ b/minion-certificate-verifier/main/src/main/resources/application.yaml
@@ -17,3 +17,4 @@ management:
     health:
       probes:
         enabled: true
+      show-details: always

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
@@ -346,7 +346,7 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
 
             @Override
             public void onCompleted() {
-
+                LOG.info("sink streaming stream completed");
             }
         };
     }

--- a/minion-gateway/main/src/main/resources/application.yaml
+++ b/minion-gateway/main/src/main/resources/application.yaml
@@ -23,3 +23,4 @@ management:
     health:
       probes:
         enabled: true
+      show-details: always

--- a/minion/assembly/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/minion/assembly/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -31,7 +31,7 @@ log4j2.out.pattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{F
 
 
 # Root logger
-log4j2.rootLogger.level = INFO
+log4j2.rootLogger.level = ${karaf.log.console:-INFO}
 # uncomment to use asynchronous loggers, which require mvn:com.lmax/disruptor/3.3.2 and mvn:org.ops4j.pax.logging/pax-logging-log4j2-extra/1.11.4 libraries
 #log4j2.rootLogger.type = asyncRoot
 #log4j2.rootLogger.includeLocation = false

--- a/notifications/src/main/resources/application.yml
+++ b/notifications/src/main/resources/application.yml
@@ -58,4 +58,4 @@ management:
     health:
       probes:
         enabled: true
-
+      show-details: always

--- a/rest-server/src/main/resources/application.yml
+++ b/rest-server/src/main/resources/application.yml
@@ -46,3 +46,4 @@ management:
     health:
       probes:
         enabled: true
+      show-details: always

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -91,6 +91,8 @@ OpenNMS:
         add_header x-location "$authHeader1" always;
         set $dummy_val "$opentelemetry_context_traceparent"; # workaround for https://github.com/kubernetes/ingress-nginx/issues/9811
         grpc_set_header 'traceparent' $opentelemetry_context_traceparent; # This doesn't get sent downstream normally. :(
+        opentelemetry_attribute "user" "$authHeader0";
+        opentelemetry_attribute "location" "$authHeader1";
   MinionCertificateManager:
     Enabled: true
     CaSecretName: root-ca-certificate


### PR DESCRIPTION
- Allow setting the Minion log level in the Lokahi chart
- Tilt: otel: add user and location attributes for minion-gateway ingress
- Log when the sink streaming stream is completed
- Tilt: cleanup suggested by Gerald that I missed on a previous PR
- Tilt: add a button to restart the Minion
- Helm: Minion: give 10 attempts at status check
- Configure health checks to always return health details
- Fix 'env' values on individual services

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
