### PR TITLE
LOK-2005: Add ability to delete rule from monitoring policy

### DIFF
--- a/ui/src/components/Common/TextRadioButtons.vue
+++ b/ui/src/components/Common/TextRadioButtons.vue
@@ -3,7 +3,7 @@
     v-model="radioModel"
     :label="''"
     class="text-radio"
-    @update:modelValue="(e) => onChecked && onChecked(e)"
+    @update:modelValue="(e: any) => onChecked && onChecked(e)"
     :data-test="`text-radio-group-${id}`"
   >
     <FeatherRadio

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
@@ -9,7 +9,7 @@
         @click="store.displayRuleForm()"
         data-test="new-rule-btn"
       >
-        <FeatherIcon :icon="addIcon" />
+        <FeatherIcon :icon="icons.addIcon" />
         New Rule
       </FeatherButton>
       <MonitoringPoliciesExistingItems
@@ -24,7 +24,16 @@
         class="rule-form"
         v-if="store.selectedRule"
       >
-        <div class="form-title">Create New Rule</div>
+        <div class="rule-form-title-container">
+          <div class="form-title">Create New Rule</div>
+          <FeatherButton
+            v-if="!store.selectedPolicy.isDefault"
+            icon="Delete Rule"
+            @click="store.removeRule"
+          >
+            <FeatherIcon :icon="icons.deleteIcon" />
+          </FeatherButton>
+        </div>
 
         <div class="row">
           <div class="col">
@@ -61,9 +70,7 @@
           </div>
           <div class="col">
             <template v-if="store.selectedRule?.detectionMethod === DetectionMethod.Threshold">
-              <div class="subtitle">
-                Metric
-              </div>
+              <div class="subtitle">Metric</div>
               <BasicSelect
                 :list="thresholdMetricsOptions"
                 @item-selected="selectThresholdMetric"
@@ -72,9 +79,7 @@
               />
             </template>
             <template v-else-if="store.selectedRule?.detectionMethod === DetectionMethod.Event">
-              <div class="subtitle">
-                Event Type
-              </div>
+              <div class="subtitle">Event Type</div>
               <BasicSelect
                 :list="eventTypeOptions"
                 @item-selected="selectEventType"
@@ -100,8 +105,10 @@
                 @deleteCondition="(id: string) => store.deleteCondition(id)"
               />
             </template>
-            <template v-else-if="store.selectedRule!.detectionMethod === DetectionMethod.Event
-                                 && store.selectedRule?.eventType">
+            <template
+              v-else-if="store.selectedRule!.detectionMethod === DetectionMethod.Event
+                                 && store.selectedRule?.eventType"
+            >
               <MonitoringPoliciesEventCondition
                 v-for="(cond, index) in store.selectedRule!.alertConditions"
                 :key="cond.id"
@@ -123,6 +130,15 @@
             </FeatherButton>
           </div>
         </div>
+        <FeatherButton
+          class="save-btn"
+          primary
+          @click="store.saveRule"
+          :disabled="disableSaveRuleBtn"
+          data-test="save-rule-btn"
+        >
+          Save Rule
+        </FeatherButton>
       </div>
     </transition>
   </div>
@@ -132,16 +148,20 @@
 import { useMonitoringPoliciesStore } from '@/store/Views/monitoringPoliciesStore'
 import { ThresholdCondition } from '@/types/policies'
 import Add from '@featherds/icon/action/Add'
+import Delete from '@featherds/icon/action/Delete'
 import { ThresholdMetrics } from './monitoringPolicies.constants'
 import { AlertCondition, DetectionMethod, EventType, ManagedObjectType, PolicyRule } from '@/types/graphql'
 
 const store = useMonitoringPoliciesStore()
-const addIcon = markRaw(Add)
+const icons = markRaw({
+  addIcon: Add,
+  deleteIcon: Delete
+})
 
 const componentTypeOptions = [
   { id: ManagedObjectType.Any, name: 'Any' },
   { id: ManagedObjectType.SnmpInterface, name: 'SNMP Interface' },
-  { id: ManagedObjectType.SnmpInterfaceLink, name: 'SNMP Interface Link'},
+  { id: ManagedObjectType.SnmpInterfaceLink, name: 'SNMP Interface Link' },
   { id: ManagedObjectType.Node, name: 'Node' }
 ]
 
@@ -171,6 +191,9 @@ const selectDetectionMethod = async (method: DetectionMethod) => {
   store.selectedRule!.detectionMethod = method
   await store.resetDefaultConditions()
 }
+const disableSaveRuleBtn = computed(
+  () => store.selectedPolicy?.isDefault || !store.selectedRule?.name || !store.selectedRule?.alertConditions?.length
+)
 </script>
 
 <style scoped lang="scss">
@@ -185,6 +208,7 @@ const selectDetectionMethod = async (method: DetectionMethod) => {
   display: flex;
   flex-direction: column;
   gap: var(variables.$spacing-l);
+  margin-bottom: var(variables.$spacing-xl);
 
   .rule-form {
     @include elevation.elevation(2);
@@ -196,10 +220,15 @@ const selectDetectionMethod = async (method: DetectionMethod) => {
     border-radius: vars.$border-radius-s;
     overflow: hidden;
 
-    .form-title {
-      @include typography.headline3;
-      margin-bottom: var(variables.$spacing-m);
+    .rule-form-title-container {
+      display: flex;
+      justify-content: space-between;
+      .form-title {
+        @include typography.headline3;
+        margin-bottom: var(variables.$spacing-m);
+      }
     }
+
     .subtitle {
       @include typography.subtitle1;
     }
@@ -220,6 +249,11 @@ const selectDetectionMethod = async (method: DetectionMethod) => {
         flex: 1;
       }
     }
+  }
+
+  .save-btn {
+    width: 150px;
+    align-self: flex-end;
   }
 
   // for event / threshold child conditions

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesSaveButtons.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesSaveButtons.vue
@@ -1,17 +1,8 @@
 <template>
   <div
     class="btns"
-    v-if="store.selectedPolicy && store.selectedRule"
+    v-if="store.selectedPolicy && !store.selectedPolicy.isDefault"
   >
-    <FeatherButton
-      class="save-btn"
-      primary
-      @click="store.saveRule"
-      :disabled="disableSaveRuleBtn"
-      data-test="save-rule-btn"
-    >
-      Save Rule
-    </FeatherButton>
     <hr />
     <ButtonWithSpinner
       :isFetching="mutations.isFetching.value"
@@ -35,9 +26,6 @@ const mutations = useMonitoringPoliciesMutations()
 const disableSavePolicyBtn = computed(
   () => store.selectedPolicy?.isDefault || !store.selectedPolicy?.rules?.length || !store.selectedPolicy.name
 )
-const disableSaveRuleBtn = computed(
-  () => store.selectedPolicy?.isDefault || !store.selectedRule?.name || !store.selectedRule?.alertConditions?.length
-)
 </script>
 
 <style lang="scss" scoped>
@@ -45,10 +33,9 @@ const disableSaveRuleBtn = computed(
 .btns {
   display: flex;
   flex-direction: column;
-  margin: var(variables.$spacing-xl) 0;
+  margin-bottom: var(variables.$spacing-xl);
 
   .save-btn {
-    width: 150px;
     align-self: flex-end;
   }
 }

--- a/ui/src/store/Views/monitoringPoliciesStore.ts
+++ b/ui/src/store/Views/monitoringPoliciesStore.ts
@@ -4,16 +4,14 @@ import { Condition, Policy, ThresholdCondition } from '@/types/policies'
 import { useMonitoringPoliciesMutations } from '../Mutations/monitoringPoliciesMutations'
 import { useMonitoringPoliciesQueries } from '../Queries/monitoringPoliciesQueries'
 import useSnackbar from '@/composables/useSnackbar'
-import {
-  ThresholdLevels,
-  Unknowns
-} from '@/components/MonitoringPolicies/monitoringPolicies.constants'
+import { ThresholdLevels, Unknowns } from '@/components/MonitoringPolicies/monitoringPolicies.constants'
 import {
   AlertCondition,
   DetectionMethod,
   EventType,
   ManagedObjectType,
-  MonitorPolicy, PolicyRule,
+  MonitorPolicy,
+  PolicyRule,
   Severity,
   TimeRangeUnit
 } from '@/types/graphql'
@@ -52,8 +50,7 @@ function getDefaultThresholdCondition(): ThresholdCondition {
 
 async function getDefaultEventCondition(): Promise<AlertCondition> {
   const alertEventDefinitionQueries = useAlertEventDefinitionQueries()
-  const alertEventDefinitions =
-    await alertEventDefinitionQueries.listAlertEventDefinitions(EventType.SnmpTrap)
+  const alertEventDefinitions = await alertEventDefinitionQueries.listAlertEventDefinitions(EventType.SnmpTrap)
   if (alertEventDefinitions.value?.listAlertEventDefinitions?.length) {
     return {
       id: new Date().getTime(),
@@ -63,7 +60,7 @@ async function getDefaultEventCondition(): Promise<AlertCondition> {
       triggerEvent: alertEventDefinitions.value.listAlertEventDefinitions[0]
     }
   } else {
-    throw Error('Can\'t load alertEventDefinitions')
+    throw Error("Can't load alertEventDefinitions")
   }
 }
 
@@ -129,12 +126,14 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       })
     },
     deleteCondition(id: string) {
-      this.selectedRule!.alertConditions = this.selectedRule!.alertConditions?.filter((c: AlertCondition) => c.id !== id)
+      this.selectedRule!.alertConditions = this.selectedRule!.alertConditions?.filter(
+        (c: AlertCondition) => c.id !== id
+      )
     },
     async saveRule() {
       const existingItemIndex = findIndex(this.selectedPolicy!.rules, { id: this.selectedRule!.id })
 
-      if (existingItemIndex!== -1) {
+      if (existingItemIndex !== -1) {
         // replace existing rule
         this.selectedPolicy!.rules?.splice(existingItemIndex, 1, this.selectedRule!)
       } else {
@@ -176,6 +175,15 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       delete copiedPolicy.id
       delete copiedPolicy.name
       this.displayPolicyForm(copiedPolicy)
+    },
+    removeRule() {
+      const ruleIndex = findIndex(this.selectedPolicy!.rules, { id: this.selectedRule!.id })
+
+      if (ruleIndex !== -1) {
+        this.selectedPolicy!.rules?.splice(ruleIndex, 1)
+      }
+
+      this.selectedRule = undefined
     }
   }
 })


### PR DESCRIPTION
## Description
Let's a user click on a rule, then click on the delete icon to remove that rule from the policy. Because the user must also save the policy after updating the rules, I have made a small change to make sure the Save Policy button always shows (previously the user had to select a rule before it appeared).

[screencast-localhost_3009-2023.08.29-12_58_20.webm](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/9bf43eaf-f36d-44ac-a8ae-05abb53faf5f)


## Jira link(s)
- https://opennms.atlassian.net/browse/HS-2005

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
