### PR TITLE
LOK-2009: Fix the reset of flows store state

### DIFF
--- a/ui/src/components/Dashboard/DashboardApplications.vue
+++ b/ui/src/components/Dashboard/DashboardApplications.vue
@@ -123,7 +123,7 @@ onMounted(async () => {
   flowsStore.filters.selectedExporterTopApplication = undefined
 })
 
-onUnmounted(() => flowsStore.$reset)
+onUnmounted(() => flowsStore.$reset())
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/containers/Flows.vue
+++ b/ui/src/containers/Flows.vue
@@ -252,7 +252,7 @@ const setMaxDataPointsAndUpdateCharts = (width: number) => {
   }
 }
 
-onUnmounted(() => flowsStore.$reset)
+onUnmounted(() => flowsStore.$reset())
 </script>
 
 <style scoped lang="scss">

--- a/ui/tests/Dashboard/dashboardApplication.test.ts
+++ b/ui/tests/Dashboard/dashboardApplication.test.ts
@@ -42,3 +42,10 @@ test('The DashboardApplications should call querie with paramters', () => {
   expect(spy).toHaveBeenCalled()
   expect(spy).toHaveReturnedWith(filterValuesMock)
 })
+
+test('Resetting the flows date filter to Today', () => {
+  const store = useFlowsStore()
+  expect(store.filters.dateFilter).toBe(TimeRange.Last_24Hours)
+  wrapper.unmount()
+  expect(store.filters.dateFilter).toBe(TimeRange.Today)
+})


### PR DESCRIPTION
## Description
The initial flows date filter is set to `Today`. Loading the dashboard will change it to `24 hours`. Unmounting the dashboard was incorrectly attempting to reset it to `Today`. This change just fixes the reset.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-2009

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
