### PR TITLE
LOK-2042: In CI/CD, use current timestamp for Jib docker images

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -1187,6 +1187,7 @@
             <properties>
                 <!-- Build AND push the built image -->
                 <application.jib.defaultGoal>build</application.jib.defaultGoal>
+                <jib.container.creationTime>USE_CURRENT_TIMESTAMP</jib.container.creationTime>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2042

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
