### PR TITLE
LOK-1691: Use logout from latest vue-keycloak package

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
     "generate": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 graphql-codegen --config codegen.yml"
   },
   "dependencies": {
-    "@dsb-norge/vue-keycloak-js": "^2.2.0",
+    "@dsb-norge/vue-keycloak-js": "2.4.0",
     "@featherds/app-bar": "0.12.16",
     "@featherds/app-layout": "0.12.16",
     "@featherds/app-rail": "0.12.16",

--- a/ui/src/components/Layout/Menubar.vue
+++ b/ui/src/components/Layout/Menubar.vue
@@ -13,7 +13,7 @@
         <FeatherIcon
           :icon="LogOut"
           class="pointer menu-icon"
-          @click="logout()"
+          @click="keycloak.logout()"
         />
       </div>
     </template>
@@ -25,7 +25,6 @@ import LightDarkMode from '@featherds/icon/action/LightDarkMode'
 import LogOut from '@featherds/icon/action/LogOut'
 import useKeycloak from '@/composables/useKeycloak'
 import useTheme from '@/composables/useTheme'
-import { logout } from '@/services/authService'
 
 const { keycloak } = useKeycloak()
 const { toggleDark } = useTheme()

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -524,7 +524,7 @@
   resolved "https://registry.yarnpkg.com/@dash14/svg-pan-zoom/-/svg-pan-zoom-3.6.9.tgz#e73b5a71f73ce00f20ab3484260f45e6c6512ed7"
   integrity sha512-6u+KTQec+9+3bRdk2mReix8AGsp2mB40cw0iYfQQzo22QBkeCNpXl2amnfwQzK7xB9oH/62Wvf2z7l6l2w+csA==
 
-"@dsb-norge/vue-keycloak-js@^2.2.0":
+"@dsb-norge/vue-keycloak-js@2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@dsb-norge/vue-keycloak-js/-/vue-keycloak-js-2.4.0.tgz#46e81a57a07a0ef720b73c3cb1df1b53d23d90e2"
   integrity sha512-hpzFJkBzCk8ttFBLUAUH0CQpuTBIDU8b4N1xWJYAjF9Em9apGHeXI3IqJXwqVOfaPwki3KiXQTBW8kdHA06v1w==


### PR DESCRIPTION
## Description
Updates the vue-keycloak package and uses the logout function that it offers.

## Jira link(s)
- https://opennms.atlassian.net/browse/HS-1691

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
