### PR TITLE
LOK-2050: Fix active discovery cidr input

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -74,7 +74,7 @@
     "vue": "^3.3.4",
     "vue-chartjs": "^5.2.0",
     "vue-router": "4.1.6",
-    "yup": "^1.0.2"
+    "yup": "1.2.0"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "2.16.3",

--- a/ui/src/dtos/discovery.dto.ts
+++ b/ui/src/dtos/discovery.dto.ts
@@ -103,7 +103,24 @@ export const discoveryFromServerToClient = (dataIn: ServerDiscoveries, locations
 const activeDiscoveryValidation = yup.object().shape({
   name: yup.string().required('Please enter a name.'),
   locationId:yup.string().required('Location required.'),
-  ipAddresses: yup.array().min(1,'Please enter an ip address.').of(yup.string().required('Please enter an IP address.').matches(new RegExp(REGEX_EXPRESSIONS.IP[0]), 'Single IP address only. You cannot enter a range.')),
+  ipAddresses: yup.array().min(1,'Please enter an ip address.').of(yup.string().required('Please enter an IP address.')
+    .test('validate-ip',
+      (ip, ctx) => {
+        const matches = []
+        const testIp = ip.trim()
+
+        matches.push(REGEX_EXPRESSIONS.IP[0].test(testIp))
+        matches.push(REGEX_EXPRESSIONS.IP[1].test(testIp))
+        matches.push(REGEX_EXPRESSIONS.IP[2].test(testIp))
+
+        // ip must pass one of the reg exprs
+        if (!matches.some((val) => val === true)) {
+          return ctx.createError({ message: 'Contains input that is not supported.', path: 'ipAddresses' })
+        }
+
+        return true
+      })
+    ),
   snmpConfig: yup.object({
     communityStrings: yup.array().of(yup.string().required('Please enter a community string.')),
     udpPorts: yup.array().of(yup.number())

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6478,7 +6478,7 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-yup@^1.0.2:
+yup@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/yup/-/yup-1.2.0.tgz#9e51af0c63bdfc9be0fdc6c10aa0710899d8aff6"
   integrity sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==


### PR DESCRIPTION
## Description
Fixes the IP addresses input by testing against the same reg expressions previously used.

[screencast-localhost_3009-2023.09.13-14_51_05.webm](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/2b86da51-34e3-4edb-9c36-f17a1e19ca6a)


## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2050

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
