### PR TITLE
BTO-870: gather per-user statistics from rest-server

### DIFF
--- a/rest-server/src/main/java/org/opennms/horizon/server/utils/JWTValidator.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/utils/JWTValidator.java
@@ -27,6 +27,12 @@
  *******************************************************************************/
 package org.opennms.horizon.server.utils;
 
+import java.net.URL;
+import java.text.ParseException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.source.RemoteJWKSet;
@@ -35,10 +41,8 @@ import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
-import java.net.URL;
-import java.text.ParseException;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+
+import io.opentelemetry.api.trace.Span;
 
 @Component
 public class JWTValidator {
@@ -56,6 +60,7 @@ public class JWTValidator {
     }
 
     public void validate(String jwt) throws BadJOSEException, ParseException, JOSEException {
-        jwtProcessor.process(jwt, null);
+        var claimSet = jwtProcessor.process(jwt, null);
+        Span.current().setAttribute("jwt.claim.sub", claimSet.getSubject());
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

Add the "sub" (subject) from the JWT claim as a span attribute, `jwt.claim.sub` (we kinda just guessed at what kind of a name might make sense).

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-870

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
