### PR TITLE
LOK-1834: Fix liquibase update for alert definition

### DIFF
--- a/alert/src/main/resources/db/changelog/hs-0.1.0/data/system_tenant_default_policy.xml
+++ b/alert/src/main/resources/db/changelog/hs-0.1.0/data/system_tenant_default_policy.xml
@@ -79,34 +79,7 @@
             event_uei = 'uei.opennms.org/internal/node/serviceRestored')"/>
         </insert>
     </changeSet>
-
-    <changeSet id="hs-0.1.0-add-default-alert-definitions-for-system-tenant" author="cgorantla">
-        <insert tableName="alert_definition">
-            <column name="tenant_id" value="system-tenant"/>
-            <column name="uei" value="uei.opennms.org/generic/traps/SNMP_Cold_Start"/>
-            <column name="reduction_key" value="%s:%s:%d:%d"/>
-            <column name="type" value="PROBLEM_WITHOUT_CLEAR"/>
-            <column name="alert_condition_id" valueComputed="(SELECT ac.id FROM alert_condition ac INNER JOIN event_definition ed
-            ON ed.id = ac.trigger_event_definition_id WHERE ed.event_uei = 'uei.opennms.org/generic/traps/SNMP_Cold_Start')"/>
-        </insert>
-        <insert tableName="alert_definition">
-            <column name="tenant_id" value="system-tenant"/>
-            <column name="uei" value="uei.opennms.org/generic/traps/SNMP_Warm_Start"/>
-            <column name="reduction_key" value="%s:%s:%d:%d"/>
-            <column name="type" value="PROBLEM_WITHOUT_CLEAR"/>
-            <column name="alert_condition_id" valueComputed="(SELECT ac.id FROM alert_condition ac INNER JOIN event_definition ed
-            ON ed.id = ac.trigger_event_definition_id WHERE ed.event_uei = 'uei.opennms.org/generic/traps/SNMP_Warm_Start')"/>
-        </insert>
-        <insert tableName="alert_definition">
-            <column name="tenant_id" value="system-tenant"/>
-            <column name="uei" value="uei.opennms.org/internal/node/serviceUnreachable"/>
-            <column name="reduction_key" value="%s:%s:%d:%d"/>
-            <column name="type" value="PROBLEM_WITH_CLEAR"/>
-            <column name="alert_condition_id" valueComputed="(SELECT ac.id FROM alert_condition ac INNER JOIN event_definition ed
-            ON ed.id = ac.trigger_event_definition_id WHERE ed.event_uei = 'uei.opennms.org/internal/node/serviceUnreachable')"/>
-        </insert>
-    </changeSet>
-
+    
     <changeSet id="hs-0.1.0-add-default-tags-for-system-tenant" author="cgorantla">
         <insert tableName="tag">
             <column name="tenant_id" value="system-tenant"/>
@@ -120,6 +93,36 @@
             <column name="policy_id" valueComputed="(select id from monitoring_policy where tenant_id = 'system-tenant'
             and policy_name = 'default_policy')"/>
             <column name="tag_id" valueComputed="(select id from tag where tenant_id = 'system-tenant' and name = 'default')"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="hs-0.1.0-add-default-alert-definitions-for-system-tenant-update" author="cgorantla">
+        <delete tableName="alert_definition">
+            <where>tenant_id='system-tenant'</where>
+        </delete>
+        <insert tableName="alert_definition">
+            <column name="tenant_id" value="system-tenant"/>
+            <column name="uei" value="uei.opennms.org/generic/traps/SNMP_Cold_Start"/>
+            <column name="reduction_key" value="%s:%s:%d:%d"/>
+            <column name="type" value="PROBLEM_WITHOUT_CLEAR"/>
+            <column name="alert_condition_id" valueComputed="(SELECT ac.id FROM alert_condition ac INNER JOIN event_definition ed
+            ON ed.id = ac.trigger_event_definition_id WHERE tenant_id = 'system-tenant' AND ed.event_uei = 'uei.opennms.org/generic/traps/SNMP_Cold_Start')"/>
+        </insert>
+        <insert tableName="alert_definition">
+            <column name="tenant_id" value="system-tenant"/>
+            <column name="uei" value="uei.opennms.org/generic/traps/SNMP_Warm_Start"/>
+            <column name="reduction_key" value="%s:%s:%d:%d"/>
+            <column name="type" value="PROBLEM_WITHOUT_CLEAR"/>
+            <column name="alert_condition_id" valueComputed="(SELECT ac.id FROM alert_condition ac INNER JOIN event_definition ed
+            ON ed.id = ac.trigger_event_definition_id  WHERE tenant_id = 'system-tenant' AND ed.event_uei = 'uei.opennms.org/generic/traps/SNMP_Warm_Start')"/>
+        </insert>
+        <insert tableName="alert_definition">
+            <column name="tenant_id" value="system-tenant"/>
+            <column name="uei" value="uei.opennms.org/internal/node/serviceUnreachable"/>
+            <column name="reduction_key" value="%s:%s:%d:%d"/>
+            <column name="type" value="PROBLEM_WITH_CLEAR"/>
+            <column name="alert_condition_id" valueComputed="(SELECT ac.id FROM alert_condition ac INNER JOIN event_definition ed
+            ON ed.id = ac.trigger_event_definition_id  WHERE tenant_id = 'system-tenant' AND ed.event_uei = 'uei.opennms.org/internal/node/serviceUnreachable')"/>
         </insert>
     </changeSet>
 


### PR DESCRIPTION
Alert condition was not queried with tenant_id earlier which resulted in multiple rows.

Migration involves these steps.

1. Removes earlier changeset
2. Delete alert definitions that are already present.
3. Create new changeset with updated name and adding where clause for all alert conditions



## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-1834

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
