### PR TITLE
LOK-2079: Re-add ability to make CORS requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # For local dev and sample envs, a place to put required dependencies, secrets,
 # or test data that we do not want to push to repo.
 tilt_config.json
+tilt-helm-values-local.yaml
 dev/tmp
 local-sample/tmp
 

--- a/charts/lokahi/templates/opennms/api/api-deployment.yaml
+++ b/charts/lokahi/templates/opennms/api/api-deployment.yaml
@@ -86,12 +86,16 @@ spec:
               value: "{{ .Values.OpenNMS.API.PackagedMinionFile }}"
             - name: MINION_ENDPOINT
               value: "{{ .Values.OpenNMS.API.MinionEndpoint }}"
+            {{- with .Values.OpenNMS.API.CorsAllowed }}
+            - name: LOKAHI_BFF_CORS_ALLOWED
+              value: "{{ . }}"
+            {{- end }}
             # Do not put any env variables below this. The lokahi.development.env include should be last
             # in the 'env' section so variables can be overridden with Helm chart values when needed.
             {{- include "lokahi.deployment.env" (dict "Values" .Values "thisService" .Values.OpenNMS.API) | nindent 12 }}
           envFrom:
-          - configMapRef:
-              name: spring-boot-env
+            - configMapRef:
+                name: spring-boot-env
           ports:
             - name: grpc
               containerPort: 9090

--- a/rest-server/src/main/java/org/opennms/horizon/server/config/WebFluxConfig.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/config/WebFluxConfig.java
@@ -28,16 +28,25 @@
 
 package org.opennms.horizon.server.config;
 
-import lombok.Data;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.config.CorsRegistry;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
 
-
+@Slf4j
 @Configuration
-@ConfigurationProperties(prefix = "lokahi.bff")
-@Data
-public class BffProperties {
+@RequiredArgsConstructor
+public class WebFluxConfig implements WebFluxConfigurer {
 
-    private boolean corsAllowed;
-    private int maxQueryDepth;
+    private final BffProperties bffProperties;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        if (!bffProperties.isCorsAllowed()) {
+            return;
+        }
+        log.info("Allowing all CORS requests");
+        registry.addMapping("/graphql");
+    }
 }

--- a/rest-server/src/main/resources/application.yml
+++ b/rest-server/src/main/resources/application.yml
@@ -25,8 +25,6 @@ graphql:
 
 logging:
   file.path: /var/log/restServer
-  level:
-    root: debug
 tsdb.url: http://localhost:59090/api/v1
 
 grpc:
@@ -50,3 +48,4 @@ management:
       probes:
         enabled: true
       show-details: always
+

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -39,6 +39,7 @@ OpenNMS:
       Requests:
         Cpu: '0'
         Memory: '0'
+    CorsAllowed: true
   UI:
     Resources:
       Limits:


### PR DESCRIPTION
## Description
Prior to https://github.com/OpenNMS-Cloud/lokahi/pull/1449, the graphql endpoint would allow CORS requests. When it was replaced, this behaviour was not carried over, causing an interruption in frontend development. Generally it is better to not allow CORS by default given that only our UI is making requests, and via the same origin. My fix here is to provide the configuration option to expose this option via configuration.

This is how you can provide helm chart values without having git tracking them:

In `tilt-config.json`:

```json
{
  "devmode": [],
  "values": ["./tilt-helm-values-local.yaml"]
}
```

In `tilt-helm-values-local.yaml`:

```yaml
OpenNMS:
  API:
    CorsAllowed: true
```

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2079

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
