### PR TITLE
LOK-1874: Alerts: Alert Detail for SNMP Cold start contains <p> tags

### DIFF
--- a/alert/src/main/java/org/opennms/horizon/alertservice/service/AlertEventProcessor.java
+++ b/alert/src/main/java/org/opennms/horizon/alertservice/service/AlertEventProcessor.java
@@ -210,7 +210,7 @@ public class AlertEventProcessor {
 
             if (event.hasField(Event.getDescriptor().findFieldByNumber(Event.DESCRIPTION_FIELD_NUMBER))) {
                 String desc = event.getDescription().toLowerCase().contains("exception") ?
-                    event.getDescription() : "Monitoring error.";
+                    "Monitoring error." : event.getDescription();
                 event.getParametersList().stream().filter(p -> "serviceName".equals(p.getName())).findFirst()
                     .ifPresentOrElse(
                         p -> alert.setDescription(p.getValue() + " " + desc),

--- a/events/traps/src/main/java/org/opennms/horizon/events/traps/EventFactory.java
+++ b/events/traps/src/main/java/org/opennms/horizon/events/traps/EventFactory.java
@@ -145,8 +145,9 @@ public class EventFactory {
             }
 
             String description = econf.getDescr();
-            if (description != null) {
-                event.setDescr(description);
+            if (description != null && !description.isBlank()) {
+                // A quasi-temporary solution to clean up event descriptions inherited from Horizon.
+                event.setDescr(description.replace("<p>", "").replace("</p>", "").replace("&lt;p>", ""));
             }
 
             Logmsg econfLogMsg = econf.getLogmsg();


### PR DESCRIPTION
## Description
A quick fix to remove the `<p>` tags from alert details 

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-1874

## Flagged for review
N/A

## Checklist
* [x] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] ~~Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)~~
* [ ] ~~Documentation has been updated as necessary.~~
* [ ] ~~Notify devops of changes to the Charts.~~
* [ ] ~~Notify documentation team of any changes to names of screens or features (affects URLs).~~

## Manual Test Notes

A quick test showing what the alert description looks like for SNMP cold start:
![Screenshot 2023-09-25 at 11 07 26 AM](https://github.com/OpenNMS-Cloud/lokahi/assets/39974723/dbdede1d-ff7e-4065-b2eb-4a303d01e968)
