### PR TITLE
LOK-2082: Validate and allow lat/lon in location address input

### DIFF
--- a/ui/src/components/Common/AddressAutocomplete.vue
+++ b/ui/src/components/Common/AddressAutocomplete.vue
@@ -6,7 +6,6 @@
       type="single"
       :modelValue="addressModelValue"
       :minChar="1"
-      noResults=""
       :loading="loading"
       :results="results"
       @search="(e: any) => search(e)"
@@ -43,30 +42,17 @@ watch(
 
 const search = debounce(async (q: string) => {
   loading.value = true
-  q = q.trim()
   if (q.length == 0) {
     return
   }
   const addresses = await provider.search({ query: q })
   results.value = addresses
-    .filter((x) => matchQuery(q, x.label))
     .map((x) => ({
       _text: x.label,
       value: x
     }))
-
-  if (results.value.length == 0 || results.value[0]._text != q) {
-    results.value.unshift({ _text: q, value: { label: q, x: null, y: null } } as IAutocompleteItemType)
-  }
   loading.value = false
 }, 1000)
-
-const matchQuery = function (q: string, label: string) {
-  const words = q.split(/[\s.,;]/)
-  const lowerCase = label.toLowerCase()
-  const results = words.filter((w) => lowerCase.indexOf(w) == -1)
-  return results.length == 0
-}
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/Locations/LocationsAddForm.vue
+++ b/ui/src/components/Locations/LocationsAddForm.vue
@@ -85,7 +85,7 @@ const formInputs = reactive({
 })
 
 const onAddressChange = (newAddress: any) => {
-  if (newAddress != undefined) {
+  if (newAddress?.value.label && newAddress?.value.x && newAddress?.value.y) {
     formInputs.address = newAddress.value.label
     formInputs.longitude = newAddress.value.x
     formInputs.latitude = newAddress.value.y

--- a/ui/src/components/Locations/LocationsEditForm.vue
+++ b/ui/src/components/Locations/LocationsEditForm.vue
@@ -123,7 +123,7 @@ watchEffect(() => {
 })
 
 const onAddressChange = (newAddress: any) => {
-  if (newAddress != undefined) {
+  if (newAddress?.value.label && newAddress?.value.x && newAddress?.value.y) {
     formInputs.address = newAddress.value.label
     formInputs.longitude = newAddress.value.x
     formInputs.latitude = newAddress.value.y


### PR DESCRIPTION
## Description
- Validates input so that the user must click on an available address (no "allow new").
- Results should be more consistent with finding addresses
- Allows for input of coordinates

Note:
There is a bug in the feather Autocomplete component where the user cannot clear a selection. The bug for that is opened here: https://github.com/feather-design-system/feather-design-system/issues/186

[screencast-localhost_3009-2023.09.25-14_22_42.webm](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/1f876d42-7fb9-49ec-b28c-3634af64ca3d)


## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2082

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
