### PR TITLE
LOK-1886: Inventory: Node: Display interface operator status name instead of ordinal

### DIFF
--- a/rest-server/src/main/java/org/opennms/horizon/server/model/inventory/SnmpInterface.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/model/inventory/SnmpInterface.java
@@ -42,8 +42,8 @@ public class SnmpInterface {
     private int ifType;
     private String ifName;
     private long ifSpeed;
-    private int ifAdminStatus;
-    private int ifOperatorStatus;
+    private String ifAdminStatus;
+    private String ifOperatorStatus;
     private String ifAlias;
     private String physicalAddr;
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/model/inventory/SnmpInterfaceAdminStatus.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/model/inventory/SnmpInterfaceAdminStatus.java
@@ -26,29 +26,35 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.horizon.server.mapper;
+package org.opennms.horizon.server.model.inventory;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
-import org.opennms.horizon.server.model.inventory.SnmpInterface;
-import org.opennms.horizon.inventory.dto.SnmpInterfaceDTO;
-import org.opennms.horizon.server.model.inventory.SnmpInterfaceAdminStatus;
-import org.opennms.horizon.server.model.inventory.SnmpInterfaceOperatorStatus;
+import java.util.HashMap;
+import java.util.Map;
 
-@Mapper(componentModel = "spring")
-public interface SnmpInterfaceMapper {
-    @Mapping(source = "ifAdminStatus", target = "ifAdminStatus", qualifiedByName = "mapAdminStatus")
-    @Mapping(source = "ifOperatorStatus", target = "ifOperatorStatus", qualifiedByName = "mapOperatorStatus")
-    SnmpInterface protobufToSnmpInterface(SnmpInterfaceDTO protoBuf);
+public enum SnmpInterfaceAdminStatus {
+    UP(1),
+    DOWN(2),
+    TESTING(3);
 
-    @Named("mapAdminStatus")
-    default String mapAdminStatus(int ifAdminStatus) {
-        return SnmpInterfaceAdminStatus.valueOf(ifAdminStatus).name();
+    public final int value;
+    private static final Map<Integer, SnmpInterfaceAdminStatus> MAP = new HashMap<>();
+
+    SnmpInterfaceAdminStatus(int value) {
+        this.value = value;
     }
 
-    @Named("mapOperatorStatus")
-    default String mapOperatorStatus(int ifOperatorStatus) {
-        return SnmpInterfaceOperatorStatus.valueOf(ifOperatorStatus).name();
+    static {
+        for (SnmpInterfaceAdminStatus status : SnmpInterfaceAdminStatus.values()) {
+            MAP.put(status.getValue(), status);
+        }
+    }
+
+    public static SnmpInterfaceAdminStatus valueOf(int value) {
+        return MAP.get(value);
+    }
+
+    public int getValue() {
+        return value;
     }
 }
+

--- a/rest-server/src/main/java/org/opennms/horizon/server/model/inventory/SnmpInterfaceOperatorStatus.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/model/inventory/SnmpInterfaceOperatorStatus.java
@@ -26,29 +26,38 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.horizon.server.mapper;
+package org.opennms.horizon.server.model.inventory;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
-import org.opennms.horizon.server.model.inventory.SnmpInterface;
-import org.opennms.horizon.inventory.dto.SnmpInterfaceDTO;
-import org.opennms.horizon.server.model.inventory.SnmpInterfaceAdminStatus;
-import org.opennms.horizon.server.model.inventory.SnmpInterfaceOperatorStatus;
+import java.util.HashMap;
+import java.util.Map;
 
-@Mapper(componentModel = "spring")
-public interface SnmpInterfaceMapper {
-    @Mapping(source = "ifAdminStatus", target = "ifAdminStatus", qualifiedByName = "mapAdminStatus")
-    @Mapping(source = "ifOperatorStatus", target = "ifOperatorStatus", qualifiedByName = "mapOperatorStatus")
-    SnmpInterface protobufToSnmpInterface(SnmpInterfaceDTO protoBuf);
+public enum SnmpInterfaceOperatorStatus {
+    UP(1),
+    DOWN(2),
+    TESTING(3),
+    UNKNOWN(4),
+    DORMANT(5),
+    NOT_PRESENT(6),
+    LOWER_LAYER_DOWN(7);
 
-    @Named("mapAdminStatus")
-    default String mapAdminStatus(int ifAdminStatus) {
-        return SnmpInterfaceAdminStatus.valueOf(ifAdminStatus).name();
+    public final int value;
+    private static final Map<Integer, SnmpInterfaceOperatorStatus> MAP = new HashMap<>();
+
+    SnmpInterfaceOperatorStatus(int value) {
+        this.value = value;
     }
 
-    @Named("mapOperatorStatus")
-    default String mapOperatorStatus(int ifOperatorStatus) {
-        return SnmpInterfaceOperatorStatus.valueOf(ifOperatorStatus).name();
+    static {
+        for (SnmpInterfaceOperatorStatus status : SnmpInterfaceOperatorStatus.values()) {
+            MAP.put(status.getValue(), status);
+        }
+    }
+
+    public static SnmpInterfaceOperatorStatus valueOf(int value) {
+        return MAP.get(value);
+    }
+
+    public int getValue() {
+        return value;
     }
 }

--- a/rest-server/src/test/java/org/opennms/horizon/server/service/flows/GrpcFlowServiceTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/service/flows/GrpcFlowServiceTest.java
@@ -87,8 +87,11 @@ class GrpcFlowServiceTest {
         .setId(1L).setNodeId(1L).setIpAddress("127.0.0.1").setHostname("localhost").setSnmpPrimary(true)
         .setSnmpInterfaceId(2).build();
     private NodeDTO nodeDTO = NodeDTO.newBuilder().setId(1L).setNodeLabel("label")
-        .addSnmpInterfaces(SnmpInterfaceDTO.newBuilder().setId(1).setIfIndex(1).setIfName("eth0"))
-        .addSnmpInterfaces(SnmpInterfaceDTO.newBuilder().setId(2).setIfIndex(2).setIfName("eth1")).build();
+        .addSnmpInterfaces(SnmpInterfaceDTO.newBuilder().setId(1).setIfIndex(1).setIfName("eth0").setIfAdminStatus(1)
+            .setIfOperatorStatus(1))
+        .addSnmpInterfaces(SnmpInterfaceDTO.newBuilder().setId(2).setIfIndex(2).setIfName("eth1").setIfAdminStatus(1)
+            .setIfOperatorStatus(1))
+        .build();
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
## Description
When displaying node interfaces, the admin and operator status will be the name (instead of the ordinal value).

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-1886

## Flagged for review
N/A

## Checklist
* [x] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] ~~Documentation has been updated as necessary.~~
* [ ] ~~Notify devops of changes to the Charts.~~
* [ ] ~~Notify documentation team of any changes to names of screens or features (affects URLs).~~

## Manual Testing

In this example, instead of displaying `1` the user will now see `UP`:

![Screenshot 2023-09-26 at 9 14 15 AM](https://github.com/OpenNMS-Cloud/lokahi/assets/39974723/0673c976-1a89-4459-8377-ba8a5f8daa90)

