### PR TITLE
LOK-2094: Add confirmation modal for revoke/regen btn

### DIFF
--- a/ui/src/components/Common/DeleteConfirmationModal.vue
+++ b/ui/src/components/Common/DeleteConfirmationModal.vue
@@ -6,7 +6,7 @@
   >
     <template #content>
       <p v-if="customMsg">{{ customMsg }}</p>
-      <p v-else>Are you sure you wish to delete <strong>{{ name }}</strong>?</p>
+      <p v-else>Are you sure you wish to delete {{ name }}?</p>
     </template>
     <template #footer>
       <FeatherButton
@@ -22,7 +22,7 @@
         :click="deleteAndCloseModal"
         :isFetching="isDeleting"
       >
-        Delete
+        {{ actionBtnText || 'Delete' }}
       </ButtonWithSpinner>
     </template>
   </PrimaryModal>
@@ -36,6 +36,7 @@ const props = defineProps<{
   closeModal: () => void
   isDeleting?: boolean
   customMsg?: string
+  actionBtnText?: string
 }>()
 
 const deleteAndCloseModal = async () => {

--- a/ui/src/components/Locations/LocationsCertificateDownload.vue
+++ b/ui/src/components/Locations/LocationsCertificateDownload.vue
@@ -77,7 +77,7 @@
   </div>
   <DeleteConfirmationModal
     :isVisible="isVisible"
-    :customMsg="`Are you sure you want to regenerate the certificate for ${locationStore.selectedLocation.location}?`"
+    :customMsg="`Are you sure you want to regenerate the certificate for ${locationStore.selectedLocation?.location}?`"
     :closeModal="() => closeModal()"
     :deleteHandler="() => locationStore.revokeMinionCertificate()"
     actionBtnText="Continue"

--- a/ui/src/components/Locations/LocationsCertificateDownload.vue
+++ b/ui/src/components/Locations/LocationsCertificateDownload.vue
@@ -36,7 +36,7 @@
             <FeatherButton
               v-if="props.hasCert"
               secondary
-              @click="locationStore.revokeMinionCertificate"
+              @click="openModal"
               data-test="revoke-btn"
             >
               {{ props.secondaryButtonText }}
@@ -75,6 +75,13 @@
   <div class="row mt-m" v-if="locationStore.certificatePassword">
     <LocationsMinionCmd />
   </div>
+  <DeleteConfirmationModal
+    :isVisible="isVisible"
+    :customMsg="`Are you sure you want to regenerate the certificate for ${locationStore.selectedLocation.location}?`"
+    :closeModal="() => closeModal()"
+    :deleteHandler="() => locationStore.revokeMinionCertificate()"
+    actionBtnText="Continue"
+  />
 </template>
 
 <script lang="ts" setup>
@@ -83,10 +90,12 @@ import CopyIcon from '@featherds/icon/action/ContentCopy'
 import CheckIcon from '@featherds/icon/action/CheckCircle'
 import CalendarIcon from '@featherds/icon/action/CalendarEndDate'
 import { useLocationStore } from '@/store/Views/locationStore'
+import useModal from '@/composables/useModal'
 
 import useSnackbar from '@/composables/useSnackbar'
 const { showSnackbar } = useSnackbar()
 const locationStore = useLocationStore()
+const { openModal, closeModal, isVisible } = useModal()
 
 const props = defineProps({
   title: {

--- a/ui/src/store/Views/locationStore.ts
+++ b/ui/src/store/Views/locationStore.ts
@@ -5,6 +5,7 @@ import { DisplayType } from '@/types/locations.d'
 import { useLocationMutations } from '../Mutations/locationMutations'
 import { MonitoringLocation, MonitoringLocationCreateInput, MonitoringLocationUpdateInput } from '@/types/graphql'
 import useMinionCmd from '@/composables/useMinionCmd'
+import useSnackbar from '@/composables/useSnackbar'
 
 export const useLocationStore = defineStore('locationStore', () => {
   const locationsList = ref<MonitoringLocation[]>([])
@@ -124,10 +125,12 @@ export const useLocationStore = defineStore('locationStore', () => {
   }
 
   const revokeMinionCertificate = async () => {
+    const { showSnackbar } = useSnackbar()
     if (!selectedLocation.value) return
     const response = await locationMutations.revokeMinionCertificate(selectedLocation.value.id)
     if(!response.value){
       setCertificatePassword('')
+      showSnackbar({ msg: 'Certificate successfully regenerated.'})
     }
 
     return !response.value


### PR DESCRIPTION
## Description
Adds a confirmation for revoking/regenerating the cert.
Adds a minor tweak to repurpose the DeleteConfirmationModal for this.

[screencast-localhost_3009-2023.09.27-13_53_33.webm](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/25605d85-c0a5-431a-ab5f-18d42dba231b)


## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2094

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
