### PR TITLE
LOK-2043: Add version information to gRPC requests from the minion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,7 @@ jobs:
           docker buildx build --push \
             --tag opennms/lokahi-minion:latest \
             --tag opennms/lokahi-minion:${{ env.RELEASE_TAG }} \
+            --build-arg VERSION=${{ env.RELEASE_TAG }} \
             docker-assembly/target/docker/opennms/lokahi-minion/latest/build/ \
             -f docker-assembly/src/main/docker/app/Dockerfile \
             --platform linux/amd64,linux/arm64,linux/arm/v7

--- a/minion/docker-assembly/pom.xml
+++ b/minion/docker-assembly/pom.xml
@@ -31,6 +31,33 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>6.0.0</version>
+                <executions>
+                    <execution>
+                        <id>git-initialize</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.directory}/git/org.opennms.version.cfg</generateGitPropertiesFilename>
+                    <dateFormat>yyyy-MM-dd'T'HH:mm:ss'Z'</dateFormat>
+                    <dateFormatTimeZone>UTC</dateFormatTimeZone>
+                </configuration>
+            </plugin>
             <!--                                  -->
             <!-- COPY AND UNPACK THE TGZ ASSEMBLY -->
             <!--  FOR USE WITH THE DOCKERFILE     -->
@@ -110,6 +137,10 @@
                                                 <fileSet>
                                                     <directory>${application.jib.extra.root}/agent</directory>
                                                     <outputDirectory>agent</outputDirectory>
+                                                </fileSet>
+                                                <fileSet>
+                                                    <directory>${project.build.directory}/git</directory>
+                                                    <outputDirectory>karaf/etc</outputDirectory>
                                                 </fileSet>
                                             </fileSets>
                                         </inline>

--- a/minion/docker-assembly/src/main/docker/app/Dockerfile
+++ b/minion/docker-assembly/src/main/docker/app/Dockerfile
@@ -62,6 +62,9 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
       org.opennms.cicd.buildurl="${BUILD_URL}" \
       org.opennms.cicd.branch="${BUILD_BRANCH}"
 
+RUN echo "org.opencontainers.image.created=${BUILD_DATE}" >> /opt/karaf/etc/org.opennms.version.cfg
+RUN echo "org.opencontainers.image.version=${VERSION}" >> /opt/karaf/etc/org.opennms.version.cfg
+
 WORKDIR /opt/karaf
 
 USER 10001

--- a/minion/minion-grpc/grpc-client/src/main/java/org/opennms/horizon/minion/grpc/channel/OkHttpChannelBuilderFactory.java
+++ b/minion/minion-grpc/grpc-client/src/main/java/org/opennms/horizon/minion/grpc/channel/OkHttpChannelBuilderFactory.java
@@ -39,14 +39,45 @@ public class OkHttpChannelBuilderFactory implements ChannelBuilderFactory {
     @Setter
     private int maxInboundMessageSize = 0;
 
+    @Setter
+    private String imageCreated = "";
+
+    @Setter
+    private String imageVersion = "";
+
+    @Setter
+    private String gitDescribe = "";
+
+    @Setter
+    private String gitBranch = "";
+
+    public String getUserAgent() {
+        final var name = "OpenNMS_Lokahi_Minion";
+
+        final String version;
+        if (!imageVersion.isBlank()) {
+            version = String.format("%s/%s (%s)", name, imageVersion, gitDescribe);
+        } else {
+            version = String.format("%s/%s (built %s; branch %s)", name, gitDescribe, imageCreated, gitBranch);
+        }
+
+        return String.format("%s %s/%s (%s/%s; %s) %s/%s (%s)",
+            version,
+            "Java", System.getProperty("java.version"),
+            System.getProperty("java.vm.name"), System.getProperty("java.vm.version"), System.getProperty("java.vm.vendor"),
+            System.getProperty("os.name").replaceAll("\\s+", "_"), System.getProperty("os.version"), System.getProperty("os.arch")
+            );
+    }
+
     @Override
     public ManagedChannelBuilder<?> create(String host, int port, String authority, ChannelCredentials credentials) {
-        OkHttpChannelBuilder channelBuilder = null;
+        final OkHttpChannelBuilder channelBuilder;
         if (credentials == null) {
             channelBuilder = OkHttpChannelBuilder.forAddress(host, port);
         } else {
             channelBuilder = OkHttpChannelBuilder.forAddress(host, port, credentials);
         }
+        channelBuilder.userAgent(getUserAgent());
         channelBuilder.keepAliveWithoutCalls(true);
         if (maxInboundMessageSize != 0) {
             channelBuilder.maxInboundMessageSize(maxInboundMessageSize);
@@ -61,5 +92,4 @@ public class OkHttpChannelBuilderFactory implements ChannelBuilderFactory {
 
         return channelBuilder;
     }
-
 }

--- a/minion/minion-grpc/grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/minion/minion-grpc/grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,6 +36,16 @@
         </cm:default-properties>
     </cm:property-placeholder>
 
+    <cm:property-placeholder id="containerProperties" persistent-id="org.opennms.version" update-strategy="reload"
+                             placeholder-prefix="$(" placeholder-suffix=")">
+        <cm:default-properties>
+            <cm:property name="git.build.time" value=""/>
+            <cm:property name="git.branch" value=""/>
+            <cm:property name="git.commit.id.describe" value=""/>
+            <cm:property name="org.opencontainers.image.version" value=""/>
+        </cm:default-properties>
+    </cm:property-placeholder>
+
     <bean id="ipcIdentity" class="org.opennms.horizon.minion.grpc.MinionIpcIdentity">
         <argument value="$[id]" />
     </bean>
@@ -52,6 +62,10 @@
 
     <bean id="channelBuilderFactory" class="org.opennms.horizon.minion.grpc.channel.OkHttpChannelBuilderFactory">
         <property name="maxInboundMessageSize" value="${grpc.max.message.size}"/>
+        <property name="imageCreated" value="$(git.build.time)"/>
+        <property name="imageVersion" value="$(org.opencontainers.image.version)"/>
+        <property name="gitDescribe" value="$(git.commit.id.describe)"/>
+        <property name="gitBranch" value="$(git.branch)"/>
     </bean>
 
     <bean id="managedChannelFactory" class="org.opennms.horizon.minion.grpc.channel.SecuritySwitchedChannelFactory">

--- a/minion/minion-grpc/grpc-client/src/test/java/org/opennms/horizon/minion/grpc/channel/OkHttpChannelBuilderFactoryTest.java
+++ b/minion/minion-grpc/grpc-client/src/test/java/org/opennms/horizon/minion/grpc/channel/OkHttpChannelBuilderFactoryTest.java
@@ -1,9 +1,13 @@
 package org.opennms.horizon.minion.grpc.channel;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
 import io.grpc.ChannelCredentials;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.TlsChannelCredentials;
-import org.junit.jupiter.api.Test;
 
 class OkHttpChannelBuilderFactoryTest {
 
@@ -38,4 +42,31 @@ class OkHttpChannelBuilderFactoryTest {
         // no way to verify it
     }
 
+    @Test
+    public void verifyUserAgentNoVersion() {
+        OkHttpChannelBuilderFactory channelBuilderFactory = new OkHttpChannelBuilderFactory();
+        // no version set
+        channelBuilderFactory.setGitBranch("legislative");
+        channelBuilderFactory.setGitDescribe("excellent");
+        channelBuilderFactory.setImageCreated("1989-02-17");
+
+        String userAgent = channelBuilderFactory.getUserAgent();
+        assertTrue(userAgent.contains("/excellent "));
+        assertTrue(userAgent.contains("(built 1989-02-17;"));
+        assertTrue(userAgent.contains("; branch legislative"));
+    }
+    @Test
+    public void verifyUserAgentVersion() {
+        OkHttpChannelBuilderFactory channelBuilderFactory = new OkHttpChannelBuilderFactory();
+        channelBuilderFactory.setImageVersion("2");
+        channelBuilderFactory.setGitBranch("judicial");
+        channelBuilderFactory.setGitDescribe("bogus"); // won't show up in output
+        channelBuilderFactory.setImageCreated("1991-07-19"); // won't show up in output
+
+        String userAgent = channelBuilderFactory.getUserAgent();
+        assertTrue(userAgent.contains("/2 "));
+        assertTrue(userAgent.contains("bogus"));
+        assertFalse(userAgent.contains("judicial"));
+        assertFalse(userAgent.contains("1991-07-19"));
+    }
 }


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
* Adds a properties file containing version details from the build using https://github.com/git-commit-id/git-commit-id-maven-plugin (plus a few of our own that are added).
* Uses this properties file to add details to the User-agent header sent upstream by OkHttp.

Example user-agent:
```
OpenNMS_Lokahi_Minion/e02572f (built 2023-10-01T01:23:24Z; branch jira/LOK-2043) Java/17.0.8.1 (OpenJDK 64-Bit Server VM/17.0.8.1+1; Eclipse Adoptium) Linux/5.15.49-linuxkit-pr (amd64) grpc-java-okhttp/1.54.1
```

## TODO
* [x] Some of the names could stand to be tweaked.
* [x] Unit test?
* [x] Make sure it does the right thing on branches.
* ~~Update container labels (and remove anything we don't plan to support) -- see https://github.com/opencontainers/image-spec/blob/main/annotations.md~~ -- leaving this one for later, because I'm not sure what we'll want to have. Although this is related to the information we store inside the container, the labels on the container are unrelated to the version information that gets sent upstream in gRPC requests.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2043

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
