### PR TITLE
LOK-2132: Fix azure call

### DIFF
--- a/ui/src/components/Discovery/DiscoveryMetaInformation.vue
+++ b/ui/src/components/Discovery/DiscoveryMetaInformation.vue
@@ -110,10 +110,10 @@
       <div class="azure-row">
         <FeatherInput
           label="Client Subscription ID"
-          :error="discoveryErrors?.clientSubscriptionId"
-          :modelValue="(discovery?.meta as DiscoveryAzureMeta).clientSubscriptionId"
+          :error="discoveryErrors?.subscriptionId"
+          :modelValue="(discovery?.meta as DiscoveryAzureMeta).subscriptionId"
           :disabled="isOverallDisabled"
-          @update:modelValue="(e?: string | number) => updateDiscoveryValue('clientSubscriptionId',String(e))"
+          @update:modelValue="(e?: string | number) => updateDiscoveryValue('subscriptionId',String(e))"
         />
         <FeatherInput
           label="Directory ID"

--- a/ui/src/dtos/discovery.dto.ts
+++ b/ui/src/dtos/discovery.dto.ts
@@ -36,7 +36,7 @@ export const discoveryFromAzureClientToServer = (discovery: NewOrUpdatedDiscover
     name: discovery.name,
     tags: discovery.tags?.map((t) => ({name:t.name})),
     clientId: meta.clientId,
-    clientSubscriptionId: meta.clientSubscriptionId,
+    subscriptionId: meta.subscriptionId,
     clientSecret: meta.clientSecret,
     directoryId: meta.directoryId
   }
@@ -77,7 +77,7 @@ export const discoveryFromServerToClient = (dataIn: ServerDiscoveries, locations
         udpPorts: d?.details?.snmpConfig?.ports.join(';') ?? '',
         clientId: d?.details?.clientId,
         clientSecret: d?.details?.clientSecret ?? '',
-        clientSubscriptionId: d?.details?.subscriptionId,
+        subscriptionId: d?.details?.subscriptionId,
         directoryId: d?.details?.directoryId
       }
     })
@@ -140,7 +140,7 @@ const azureDiscoveryValidation = yup.object().shape({
   name: yup.string().required('Please enter a name.'),
   locationId:yup.string().required('Location required.'),
   clientId: yup.string().required('Client ID is required.'),
-  clientSubscriptionId: yup.string().required('Client subscription ID is required.'),
+  subscriptionId: yup.string().required('Client subscription ID is required.'),
   directoryId: yup.string().required('Directory ID is required.'),
   clientSecret: yup.string().required('Client secret is required.')
 }).required()

--- a/ui/src/store/Views/discoveryStore.ts
+++ b/ui/src/store/Views/discoveryStore.ts
@@ -103,7 +103,7 @@ export const useDiscoveryStore = defineStore('discoveryStore', {
         meta:{
           clientId: '',
           clientSecret: '',
-          clientSubscriptionId: '',
+          subscriptionId: '',
           directoryId: '',
           communityStrings: 'public',
           udpPorts: '161'
@@ -232,6 +232,8 @@ export const useDiscoveryStore = defineStore('discoveryStore', {
       if (isValid){
         if (this.selectedDiscovery.type === DiscoveryType.SyslogSNMPTraps){
           await discoveryMutations.upsertPassiveDiscovery({passiveDiscovery:discoveryFromClientToServer(this.selectedDiscovery)})
+        } else if (this.selectedDiscovery.type === DiscoveryType.Azure) {
+          await discoveryMutations.addAzureCreds({ discovery: discoveryFromClientToServer(this.selectedDiscovery)})
         } else {
           await discoveryMutations.createOrUpdateDiscovery({request:discoveryFromClientToServer(this.selectedDiscovery)})
         }

--- a/ui/src/types/discovery.d.ts
+++ b/ui/src/types/discovery.d.ts
@@ -45,7 +45,7 @@ export interface DiscoverySNMPV3AuthPrivacy extends DiscoverySNMPV3Auth {
 export interface DiscoveryAzureMeta {
   clientId?: string;
   clientSecret?: string;
-  clientSubscriptionId?: string;
+  subscriptionId?: string;
   directoryId?: string;
 }
 


### PR DESCRIPTION
## Description
Since the discovery page refactor, the Azure payload was being sent to the wrong endpoint. This fixes the call, and also fixes the `subscriptionId` property.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2132

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
