### PR TITLE
Refresh initial page after login if it stays empty.

### DIFF
--- a/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/pages/WelcomePage.java
+++ b/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/pages/WelcomePage.java
@@ -75,6 +75,7 @@ public class WelcomePage {
     private static final SelenideElement minionDetectedCheck = $(By.xpath("//div[text()='Minion detected.']"));
     private static final SelenideElement nodeDetectedCheck = $(By.xpath("//div[@data-test='item-preview-status-id'][text()='UP']"));
     private static final SelenideElement discoveryResultLatencyCheck = $(By.xpath("//div[@data-test='item-preview-status-id'][.<=800]"));
+    private static final SelenideElement WELCOME_CHECK = $(By.xpath("//button[@data-test='welcome-slide-one-setup-button']|//div[@class='app-aside']"));
 
     public static void checkIsStartSetupButtonVisible() {
         startSetupBtn.shouldBe(enabled);
@@ -124,8 +125,8 @@ public class WelcomePage {
     }
 
     public static void waitOnWalkthroughOrMain() {
-        // First page to be opened. Seems to sometimes take a while to load under some test environments
-        $(By.xpath("//button[@data-test='welcome-slide-one-setup-button']|//div[@class='app-aside']")).should(exist, Duration.ofSeconds(60));
+        RefreshMonitor.waitForElement(WELCOME_CHECK, exist, 300, true);
+        WELCOME_CHECK.should(exist);
     }
 
     public static MinionContainer addMinionUsingWalkthrough(String minionName) {

--- a/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/pages/WelcomePage.java
+++ b/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/pages/WelcomePage.java
@@ -34,14 +34,10 @@ import org.junit.Assert;
 import org.opennms.horizon.systemtests.steps.LocationSteps;
 import org.opennms.horizon.systemtests.steps.MinionSteps;
 import org.opennms.horizon.systemtests.utils.FileDownloadManager;
-import org.opennms.horizon.systemtests.utils.MinionStarter;
 import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
-import testcontainers.DockerComposeMinionContainer;
 import testcontainers.MinionContainer;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -75,7 +71,7 @@ public class WelcomePage {
     private static final SelenideElement minionDetectedCheck = $(By.xpath("//div[text()='Minion detected.']"));
     private static final SelenideElement nodeDetectedCheck = $(By.xpath("//div[@data-test='item-preview-status-id'][text()='UP']"));
     private static final SelenideElement discoveryResultLatencyCheck = $(By.xpath("//div[@data-test='item-preview-status-id'][.<=800]"));
-    private static final SelenideElement WELCOME_CHECK = $(By.xpath("//button[@data-test='welcome-slide-one-setup-button']|//div[@class='app-aside']"));
+    private static final SelenideElement INITIAL_PAGE_CHECK = $(By.xpath("//button[@data-test='welcome-slide-one-setup-button']|//div[@class='app-aside']"));
 
     public static void checkIsStartSetupButtonVisible() {
         startSetupBtn.shouldBe(enabled);
@@ -125,8 +121,8 @@ public class WelcomePage {
     }
 
     public static void waitOnWalkthroughOrMain() {
-        RefreshMonitor.waitForElement(WELCOME_CHECK, exist, 300, true);
-        WELCOME_CHECK.should(exist);
+        RefreshMonitor.waitForElement(INITIAL_PAGE_CHECK, exist, 300, true);
+        INITIAL_PAGE_CHECK.should(exist);
     }
 
     public static MinionContainer addMinionUsingWalkthrough(String minionName) {


### PR DESCRIPTION
## Description
Sometimes the initial page will be empty in the test environment. This will try to force a refresh to attempt to get it to load.

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-844

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
