### PR TITLE
Jira/bto 884 full reload when no main page

### DIFF
--- a/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/CucumberHooks.java
+++ b/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/CucumberHooks.java
@@ -66,6 +66,7 @@ public class CucumberHooks {
         Configuration.fileDownload = FileDownloadMode.FOLDER;
         Configuration.headless = true;
         Configuration.timeout = 20000;
+        Configuration.reopenBrowserOnFail = true;
 
         ChromeOptions options = new ChromeOptions();
 

--- a/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/pages/RefreshMonitor.java
+++ b/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/pages/RefreshMonitor.java
@@ -59,33 +59,4 @@ public class RefreshMonitor {
             }
         }
     }
-
-    public static void waitForElementAndReload(SelenideElement element, Condition condition, int totalWaitTime,
-                                               boolean isPositiveCheck, String page) {
-        int individualWaitTime=30;
-        if (totalWaitTime <= 0) {
-            throw new RuntimeException("Invalid wait time of " + totalWaitTime);
-        }
-
-        // Need to have the duration/wait as part of the refresh since redrawing everything can take some time
-        // The duration isn't supported as part of the regular 'find' methods and only the 'should' methods
-        while (totalWaitTime > 0) {
-            try {
-                if (isPositiveCheck) {
-                    element.shouldBe(condition, Duration.ofSeconds(individualWaitTime));
-                } else {
-                    // Negative check may need to wait for the refresh to complete, so wait separately then check
-                    // if the element is showing up
-                    Selenide.sleep(individualWaitTime * 1000);
-                    element.shouldNotBe(condition, Duration.ofSeconds(0));
-                }
-                return;
-            } catch (com.codeborne.selenide.ex.ElementNotFound | com.codeborne.selenide.ex.ElementShouldNot e) {
-                totalWaitTime -= individualWaitTime;
-                Selenide.open(page);
-            }
-        }
-
-    }
-
 }

--- a/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/pages/WelcomePage.java
+++ b/test-automation/ui-tests/src/test/java/org/opennms/horizon/systemtests/pages/WelcomePage.java
@@ -122,7 +122,6 @@ public class WelcomePage {
     }
 
     public static void waitOnWalkthroughOrMain() {
-        RefreshMonitor.waitForElementAndReload(INITIAL_PAGE_CHECK, exist, 300, true, CucumberHooks.instanceUrl);
         INITIAL_PAGE_CHECK.should(exist);
     }
 


### PR DESCRIPTION
## Description
During the UI tests, close the browser window and re-open when either the login or initial page doesn't load.

## Jira link(s)
- https://opennms.atlassian.net/browse/BTO-884

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
