### PR TITLE
LOK-2051: Add initial discovery landing screen

### DIFF
--- a/ui/src/containers/Discovery.vue
+++ b/ui/src/containers/Discovery.vue
@@ -38,6 +38,28 @@
         </div>
       </section>
       <section
+        class="discovery landing"
+        v-if="
+          !discoveryStore.discoveryFormActive &&
+          !discoveryStore.discoveryTypePageActive &&
+          !discoveryStore.loading &&
+          discoveryStore.loadedDiscoveries.length === 0
+        "
+      >
+        <p class="landing-title">You have not configured any discoveries.</p>
+        <p class="landing-text">
+          You need to create a discovery to identify devices and entities on your network to monitor. After a <br />
+          discovery runs, these devices become part of your network inventory.
+        </p>
+        <FeatherButton
+          text
+          class="landing-btn"
+          @click="discoveryStore.startNewDiscovery"
+        >
+          Add Discovery
+        </FeatherButton>
+      </section>
+      <section
         class="discovery"
         v-if="!discoveryStore.discoveryFormActive && discoveryStore.discoveryTypePageActive"
       >
@@ -427,13 +449,24 @@ const activeDiscoveryTypes = [
   .type-selector {
     margin-bottom: var(variables.$spacing-l);
   }
-
   @include mediaQueriesMixins.screen-md {
     padding: var(variables.$spacing-l);
     height: fit-content;
     flex-grow: 1;
     min-width: auto;
     margin-bottom: 20px;
+  }
+}
+
+.landing {
+  text-align: center;
+  padding: 100px 50px;
+  .landing-title {
+    @include typography.headline2;
+  }
+  .landing-text {
+    margin: 40px 0px;
+    @include typography.body-small;
   }
 }
 

--- a/ui/src/store/Views/discoveryStore.ts
+++ b/ui/src/store/Views/discoveryStore.ts
@@ -30,6 +30,7 @@ export const useDiscoveryStore = defineStore('discoveryStore', {
   } as DiscoveryStore),
   actions: {
     async init(){
+      this.loading = true
       const discoveryQueries = useDiscoveryQueries()
       const latestDiscoveries = await discoveryQueries.getDiscoveries()
       await discoveryQueries.getLocations()
@@ -45,9 +46,6 @@ export const useDiscoveryStore = defineStore('discoveryStore', {
           await discoveryQueries.getTagsByPassiveDiscoveryId(loadedDiscovery.id)
           loadedDiscovery.tags = discoveryQueries.tagsByPassiveDiscoveryId
         }
-      }
-      if (this.loadedDiscoveries.length === 0){
-        this.startNewDiscovery()
       }
       this.loading = false
     },


### PR DESCRIPTION
## Description
Adds the initial discovery landing screen. Subsequent screen will require additional BE work.

![screenshot-localhost_3009-2023 10 23-11_36_41](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/abea04d7-10b0-40e5-9df6-f6b5eb7bf60b)


## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2051

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
