### PR TITLE
LOK-1929: fix graphql flaws

### DIFF
--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/grpc/TagGrpcService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/grpc/TagGrpcService.java
@@ -83,7 +83,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
-        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INTERNAL_VALUE, EMPTY_TENANT_ID_MSG)));
+        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INVALID_ARGUMENT_VALUE, EMPTY_TENANT_ID_MSG)));
     }
 
     @Override
@@ -108,7 +108,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
-        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INTERNAL_VALUE, EMPTY_TENANT_ID_MSG)));
+        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INVALID_ARGUMENT_VALUE, EMPTY_TENANT_ID_MSG)));
     }
 
     @Override
@@ -127,7 +127,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
-        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INTERNAL_VALUE, EMPTY_TENANT_ID_MSG)));
+        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INVALID_ARGUMENT_VALUE, EMPTY_TENANT_ID_MSG)));
     }
 
     @Override
@@ -147,7 +147,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
-        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INTERNAL_VALUE, EMPTY_TENANT_ID_MSG)));
+        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INVALID_ARGUMENT_VALUE, EMPTY_TENANT_ID_MSG)));
     }
 
     @Override
@@ -168,7 +168,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
-        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INTERNAL_VALUE, EMPTY_TENANT_ID_MSG)));
+        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INVALID_ARGUMENT_VALUE, EMPTY_TENANT_ID_MSG)));
     }
 
     private StatusRuntimeException getStatusRuntimeException(int code, String message){

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/grpc/TagGrpcService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/grpc/TagGrpcService.java
@@ -32,6 +32,7 @@ import com.google.protobuf.BoolValue;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import io.grpc.Context;
+import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
@@ -82,14 +83,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
-        }, () -> {
-
-            Status status = Status.newBuilder()
-                .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage(EMPTY_TENANT_ID_MSG)
-                .build();
-            responseObserver.onError(StatusProto.toStatusRuntimeException(status));
-        });
+        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INTERNAL_VALUE, EMPTY_TENANT_ID_MSG)));
     }
 
     @Override
@@ -114,13 +108,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
-        }, () -> {
-            Status status = Status.newBuilder()
-                .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage(EMPTY_TENANT_ID_MSG)
-                .build();
-            responseObserver.onError(StatusProto.toStatusRuntimeException(status));
-        });
+        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INTERNAL_VALUE, EMPTY_TENANT_ID_MSG)));
     }
 
     @Override
@@ -139,14 +127,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
-        }, () -> {
-
-            Status status = Status.newBuilder()
-                .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage(EMPTY_TENANT_ID_MSG)
-                .build();
-            responseObserver.onError(StatusProto.toStatusRuntimeException(status));
-        });
+        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INTERNAL_VALUE, EMPTY_TENANT_ID_MSG)));
     }
 
     @Override
@@ -166,14 +147,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
-        }, () -> {
-
-            Status status = Status.newBuilder()
-                .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage(EMPTY_TENANT_ID_MSG)
-                .build();
-            responseObserver.onError(StatusProto.toStatusRuntimeException(status));
-        });
+        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INTERNAL_VALUE, EMPTY_TENANT_ID_MSG)));
     }
 
     @Override
@@ -194,13 +168,14 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
-        }, () -> {
+        }, () -> responseObserver.onError(getStatusRuntimeException(Code.INTERNAL_VALUE, EMPTY_TENANT_ID_MSG)));
+    }
 
-            Status status = Status.newBuilder()
-                .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage(EMPTY_TENANT_ID_MSG)
-                .build();
-            responseObserver.onError(StatusProto.toStatusRuntimeException(status));
-        });
+    private StatusRuntimeException getStatusRuntimeException(int code, String message){
+        Status status = Status.newBuilder()
+            .setCode(code)
+            .setMessage(message)
+            .build();
+        return StatusProto.toStatusRuntimeException(status);
     }
 }

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/grpc/TagGrpcService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/grpc/TagGrpcService.java
@@ -55,6 +55,7 @@ import java.util.Optional;
 @Component
 @RequiredArgsConstructor
 public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
+    public static final String EMPTY_TENANT_ID_MSG = "Tenant Id can't be empty";
     private final TagService service;
     private final TenantLookup tenantLookup;
     private final NodeService nodeService;
@@ -75,7 +76,6 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                 responseObserver.onNext(TagListDTO.newBuilder().addAllTags(tags).build());
                 responseObserver.onCompleted();
             } catch (Exception e) {
-
                 Status status = Status.newBuilder()
                     .setCode(Code.INTERNAL_VALUE)
                     .setMessage(e.getMessage())
@@ -86,7 +86,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
 
             Status status = Status.newBuilder()
                 .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage("Tenant Id can't be empty")
+                .setMessage(EMPTY_TENANT_ID_MSG)
                 .build();
             responseObserver.onError(StatusProto.toStatusRuntimeException(status));
         });
@@ -108,7 +108,6 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                 responseObserver.onNext(BoolValue.of(true));
                 responseObserver.onCompleted();
             } catch (Exception e) {
-
                 Status status = Status.newBuilder()
                     .setCode(Code.INTERNAL_VALUE)
                     .setMessage(e.getMessage())
@@ -116,10 +115,9 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
         }, () -> {
-
             Status status = Status.newBuilder()
                 .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage("Tenant Id can't be empty")
+                .setMessage(EMPTY_TENANT_ID_MSG)
                 .build();
             responseObserver.onError(StatusProto.toStatusRuntimeException(status));
         });
@@ -135,7 +133,6 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
                 responseObserver.onNext(TagListDTO.newBuilder().addAllTags(tags).build());
                 responseObserver.onCompleted();
             } catch (Exception e) {
-
                 Status status = Status.newBuilder()
                     .setCode(Code.INTERNAL_VALUE)
                     .setMessage(e.getMessage())
@@ -146,7 +143,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
 
             Status status = Status.newBuilder()
                 .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage("Tenant Id can't be empty")
+                .setMessage(EMPTY_TENANT_ID_MSG)
                 .build();
             responseObserver.onError(StatusProto.toStatusRuntimeException(status));
         });
@@ -173,7 +170,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
 
             Status status = Status.newBuilder()
                 .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage("Tenant Id can't be empty")
+                .setMessage(EMPTY_TENANT_ID_MSG)
                 .build();
             responseObserver.onError(StatusProto.toStatusRuntimeException(status));
         });
@@ -201,7 +198,7 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
 
             Status status = Status.newBuilder()
                 .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage("Tenant Id can't be empty")
+                .setMessage(EMPTY_TENANT_ID_MSG)
                 .build();
             responseObserver.onError(StatusProto.toStatusRuntimeException(status));
         });

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/grpc/discovery/AzureActiveDiscoveryGrpcService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/grpc/discovery/AzureActiveDiscoveryGrpcService.java
@@ -58,7 +58,6 @@ public class AzureActiveDiscoveryGrpcService extends AzureActiveDiscoveryService
         tenantIdOptional.ifPresentOrElse(tenantId -> {
             try {
                 AzureActiveDiscoveryDTO discovery = service.createActiveDiscovery(tenantId, request);
-
                 responseObserver.onNext(discovery);
                 responseObserver.onCompleted();
             } catch (LocationNotFoundException e){

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/MonitoringSystemService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/MonitoringSystemService.java
@@ -6,6 +6,7 @@ import org.opennms.cloud.grpc.minion.Identity;
 import org.opennms.horizon.grpc.heartbeat.contract.TenantLocationSpecificHeartbeatMessage;
 import org.opennms.horizon.inventory.dto.MonitoringSystemDTO;
 import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
+import org.opennms.horizon.inventory.exception.LocationNotFoundException;
 import org.opennms.horizon.inventory.mapper.MonitoringSystemMapper;
 import org.opennms.horizon.inventory.model.MonitoringSystem;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
@@ -35,7 +36,7 @@ public class MonitoringSystemService {
 
     public List<MonitoringSystemDTO> findByMonitoringLocationIdAndTenantId(long locationId, String tenantId) {
         if (locationRepository.findByIdAndTenantId(locationId, tenantId).isEmpty()) {
-            throw new InventoryRuntimeException("LocationId not found for id: " + locationId);
+            throw new LocationNotFoundException("Location not found for id: " + locationId);
         }
         List<MonitoringSystem> all = systemRepository.findByMonitoringLocationIdAndTenantId(locationId, tenantId);
         return all

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/MonitoringSystemService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/MonitoringSystemService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.opennms.cloud.grpc.minion.Identity;
 import org.opennms.horizon.grpc.heartbeat.contract.TenantLocationSpecificHeartbeatMessage;
 import org.opennms.horizon.inventory.dto.MonitoringSystemDTO;
+import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
 import org.opennms.horizon.inventory.mapper.MonitoringSystemMapper;
 import org.opennms.horizon.inventory.model.MonitoringSystem;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
@@ -33,6 +34,9 @@ public class MonitoringSystemService {
     }
 
     public List<MonitoringSystemDTO> findByMonitoringLocationIdAndTenantId(long locationId, String tenantId) {
+        if (locationRepository.findByIdAndTenantId(locationId, tenantId).isEmpty()) {
+            throw new InventoryRuntimeException("LocationId not found for id: " + locationId);
+        }
         List<MonitoringSystem> all = systemRepository.findByMonitoringLocationIdAndTenantId(locationId, tenantId);
         return all
             .stream()

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/NodeService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/NodeService.java
@@ -29,6 +29,7 @@
 package org.opennms.horizon.inventory.service;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -40,6 +41,7 @@ import org.opennms.horizon.inventory.dto.NodeDTO;
 import org.opennms.horizon.inventory.dto.TagCreateListDTO;
 import org.opennms.horizon.inventory.dto.TagEntityIdDTO;
 import org.opennms.horizon.inventory.exception.EntityExistException;
+import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
 import org.opennms.horizon.inventory.exception.LocationNotFoundException;
 import org.opennms.horizon.inventory.mapper.NodeMapper;
 import org.opennms.horizon.inventory.model.IpInterface;
@@ -82,8 +84,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class NodeService {
-
-    private final static String DEFAULT_TAG = "default";
+    private static final String DEFAULT_TAG = "default";
     private final ThreadFactory threadFactory = new ThreadFactoryBuilder()
         .setNameFormat("delete-node-task-publish-%d")
         .build();
@@ -246,8 +247,8 @@ public class NodeService {
             .anyMatch(tag -> !tag.getMonitorPolicyIds().isEmpty() || DEFAULT_TAG.equals(tag.getName()));
 
         var optional = nodeRepository.findById(nodeId);
-        if(optional.isEmpty()) {
-            return;
+        if (optional.isEmpty()) {
+            throw new InventoryRuntimeException("Node not found for id: " + nodeId);
         }
         var node = optional.get();
         final var monitoredState = monitored ? MonitoredState.MONITORED
@@ -285,7 +286,7 @@ public class NodeService {
 
     private Boolean isValidInetAddress(String ipAddress) {
         try {
-            var inetAddress = InetAddressUtils.addr(ipAddress);
+            InetAddressUtils.addr(ipAddress);
             return true;
         } catch (IllegalArgumentException  e) {
             return false;

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/NodeService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/NodeService.java
@@ -246,7 +246,7 @@ public class NodeService {
         final var monitored = tagRepository.findByTenantIdAndNodeId(tenantId, nodeId).stream()
             .anyMatch(tag -> !tag.getMonitorPolicyIds().isEmpty() || DEFAULT_TAG.equals(tag.getName()));
 
-        var optional = nodeRepository.findById(nodeId);
+        var optional = nodeRepository.findByIdAndTenantId(nodeId, tenantId);
         if (optional.isEmpty()) {
             throw new InventoryRuntimeException("Node not found for id: " + nodeId);
         }

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/TagService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/TagService.java
@@ -396,6 +396,9 @@ public class TagService {
         TagEntityIdDTO entityId = listParams.getEntityId();
 
         long nodeId = entityId.getNodeId();
+        if (nodeRepository.findByIdAndTenantId(nodeId, tenantId).isEmpty() ){
+            throw new InventoryRuntimeException("NodeId not found for id: " + nodeId);
+        }
         if (listParams.hasParams()) {
             TagListParamsDTO params = listParams.getParams();
             String searchTerm = params.getSearchTerm();
@@ -413,6 +416,10 @@ public class TagService {
         TagEntityIdDTO entityId = listParams.getEntityId();
 
         long activeDiscoveryId = entityId.getActiveDiscoveryId();
+        if (activeDiscoveryRepository.findByTenantIdAndId(tenantId, activeDiscoveryId).isEmpty()) {
+            throw new InventoryRuntimeException("ActiveDiscoveryId not found for id: " + activeDiscoveryId);
+        }
+
         if (listParams.hasParams()) {
             TagListParamsDTO params = listParams.getParams();
             String searchTerm = params.getSearchTerm();
@@ -430,6 +437,9 @@ public class TagService {
         TagEntityIdDTO entityId = listParams.getEntityId();
 
         long passiveDiscoveryId = entityId.getPassiveDiscoveryId();
+        if (passiveDiscoveryRepository.findByTenantIdAndId(tenantId, passiveDiscoveryId).isEmpty()) {
+            throw new InventoryRuntimeException("PassiveDiscovery not found for id: " + passiveDiscoveryId);
+        }
         if (listParams.hasParams()) {
             TagListParamsDTO params = listParams.getParams();
             String searchTerm = params.getSearchTerm();

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/TagService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/TagService.java
@@ -143,7 +143,7 @@ public class TagService {
                 .toList();
         } else if (entityId.hasMonitoringPolicyId()) {
             if (!policyExists(entityId.getMonitoringPolicyId(), tenantId)) {
-                throw new InventoryRuntimeException("MonitoringPolicyId not found for id: " + entityId.getMonitoringPolicyId());
+                throw new InventoryRuntimeException("MonitoringPolicy not found for id: " + entityId.getMonitoringPolicyId());
             }
             return tagCreateList.stream().map(tagCreateDTO ->
                     addTagsToMonitoringPolicy(tenantId, entityId.getMonitoringPolicyId(), tagCreateDTO))
@@ -199,7 +199,7 @@ public class TagService {
             return getTagsByPassiveDiscoveryId(tenantId, listParams);
         } else if (entityId.hasMonitoringPolicyId()) {
             if (!policyExists(entityId.getMonitoringPolicyId(), tenantId)) {
-                throw new InventoryRuntimeException("MonitoringPolicyId not found for id: " + entityId.getMonitoringPolicyId());
+                throw new InventoryRuntimeException("MonitoringPolicy not found for id: " + entityId.getMonitoringPolicyId());
             }
             return getTagsByMonitoryPolicyId(tenantId, listParams);
         } else {
@@ -397,7 +397,7 @@ public class TagService {
 
         long nodeId = entityId.getNodeId();
         if (nodeRepository.findByIdAndTenantId(nodeId, tenantId).isEmpty() ){
-            throw new InventoryRuntimeException("NodeId not found for id: " + nodeId);
+            throw new InventoryRuntimeException("Node not found for id: " + nodeId);
         }
         if (listParams.hasParams()) {
             TagListParamsDTO params = listParams.getParams();
@@ -417,7 +417,7 @@ public class TagService {
 
         long activeDiscoveryId = entityId.getActiveDiscoveryId();
         if (activeDiscoveryRepository.findByTenantIdAndId(tenantId, activeDiscoveryId).isEmpty()) {
-            throw new InventoryRuntimeException("ActiveDiscoveryId not found for id: " + activeDiscoveryId);
+            throw new InventoryRuntimeException("ActiveDiscovery not found for id: " + activeDiscoveryId);
         }
 
         if (listParams.hasParams()) {

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/service/MonitoringSystemServiceTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/service/MonitoringSystemServiceTest.java
@@ -28,6 +28,7 @@
 
 package org.opennms.horizon.inventory.service;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -117,6 +118,17 @@ class MonitoringSystemServiceTest {
         doReturn(Optional.of(new MonitoringLocation())).when(mockLocationRepo).findByIdAndTenantId(locationId, tenantId);
         service.findByMonitoringLocationIdAndTenantId(locationId, tenantId);
         verify(mockMonitoringSystemRepo).findByMonitoringLocationIdAndTenantId(locationId, tenantId);
+        verify(mockLocationRepo).findByIdAndTenantId(locationId, tenantId);
+    }
+
+    @Test
+    void testFindByMonitoringLocationIdAndTenantIdLocationNotFound() {
+        long locationId = 1L;
+        var exception = Assert.assertThrows(LocationNotFoundException.class, ()-> {
+            service.findByMonitoringLocationIdAndTenantId(locationId, tenantId);
+
+        });
+        assertThat(exception.getMessage()).isEqualTo("Location not found for id: " + locationId);
         verify(mockLocationRepo).findByIdAndTenantId(locationId, tenantId);
     }
 

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/service/MonitoringSystemServiceTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/service/MonitoringSystemServiceTest.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 class MonitoringSystemServiceTest {
     private MonitoringLocationRepository mockLocationRepo;
@@ -113,8 +114,10 @@ class MonitoringSystemServiceTest {
     void testFindByMonitoringLocationIdAndTenantId() {
         long locationId = 1L;
         doReturn(Collections.singletonList(testMonitoringSystem)).when(mockMonitoringSystemRepo).findByMonitoringLocationIdAndTenantId(locationId, tenantId);
+        doReturn(Optional.of(new MonitoringLocation())).when(mockLocationRepo).findByIdAndTenantId(locationId, tenantId);
         service.findByMonitoringLocationIdAndTenantId(locationId, tenantId);
         verify(mockMonitoringSystemRepo).findByMonitoringLocationIdAndTenantId(locationId, tenantId);
+        verify(mockLocationRepo).findByIdAndTenantId(locationId, tenantId);
     }
 
     @Test

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
@@ -30,6 +30,7 @@ package org.opennms.horizon.inventory.service;
 
 
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,7 @@ import org.opennms.horizon.inventory.dto.NodeCreateDTO;
 import org.opennms.horizon.inventory.dto.NodeDTO;
 import org.opennms.horizon.inventory.dto.TagCreateDTO;
 import org.opennms.horizon.inventory.exception.EntityExistException;
+import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
 import org.opennms.horizon.inventory.exception.LocationNotFoundException;
 import org.opennms.horizon.inventory.mapper.NodeMapper;
 import org.opennms.horizon.inventory.model.IpInterface;
@@ -502,5 +504,11 @@ public class NodeServiceTest {
         assertEquals(MonitoredState.MONITORED, testNode.getMonitoredState());
 
         Mockito.verify(mockNodeRepository, atLeastOnce()).save(testNode);
+
+        // test node not found
+        var exception = Assert.assertThrows(InventoryRuntimeException.class, () -> {
+            nodeService.updateNodeMonitoredState(9999L, testNode.getTenantId());
+        });
+        assertEquals("Node not found for id: 9999", exception.getMessage());
     }
 }

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
@@ -106,7 +106,6 @@ public class NodeServiceTest {
         tagRepository = mock(TagRepository.class);
         mockTagPublisher = mock(TagPublisher.class);
 
-
         nodeService = new NodeService(mockNodeRepository,
             mockMonitoringLocationRepository,
             mockIpInterfaceRepository,
@@ -477,6 +476,7 @@ public class NodeServiceTest {
         final var tagMonitoredWithDefaultTag = new Tag();
         tagMonitoredWithDefaultTag.setName("default");
 
+        when(this.mockNodeRepository.findByIdAndTenantId(testNode.getId(), testNode.getTenantId())).thenReturn(Optional.of(testNode));
         when(this.tagRepository.findByTenantIdAndNodeId(testNode.getTenantId(), testNode.getId())).thenReturn(List.of());
         nodeService.updateNodeMonitoredState(testNode.getId(), testNode.getTenantId());
         assertEquals(MonitoredState.DETECTED, testNode.getMonitoredState());


### PR DESCRIPTION
Flaws
Mutations
* discoveryByNodeIds: partial match will start scans silently — DONE in LOK-1925
* addTagsToNodes: No real node validation but likely throws NPEs when a node id does not exist  — DONE in LOK-1925
* removeTagsFromNodes: No real node validation but likely throws NPEs when a node id does not exist  — TagService getNode & getTag all have empty checking
* createMonitorPolicy: Downstream does not validate that there is no id in request, could potentially be set by the client
* createAzureActiveDiscovery:
    * Downstream does not validate that there are no ids in request, could potentially be set by the client — no id field in request
    * Does not validate that locationId exists  — DONE in LOK-1925
* revokeMinionCertificate: Downstream does not validate that location is valid — DONE in LOK-1925
* deleteMinion: Does not throw error when ID does not exist, fails silently — DONE in LOK-1925
Queries
* getMinionCertificate: Downstream does not validate that location is valid — DONE in LOK-1925
* findEventsByNodeId: does not validate that nodeId exists — DONE in LOK-1925
* tagsByActiveDiscoveryId: Does not validate that discovery exists
* findMinionsByLocationId: Does not validate that locationId exists
* tagsByNodeId: does not validate that nodeId exists
* tagsByPassiveDiscoveryId: does not validate that passiveDiscoveryId exists
* tagsByNodeIds: does not validate that nodeId exists


## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-1929

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
