### PR TITLE
LOK-2055: ignore node enrichment if ip lookup fail

### DIFF
--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/repository/IpInterfaceRepository.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/repository/IpInterfaceRepository.java
@@ -47,8 +47,9 @@ public interface IpInterfaceRepository extends JpaRepository<IpInterface, Long> 
         "FROM IpInterface ip " +
         "WHERE ip.ipAddress = :ipAddress " +
         "AND ip.node.monitoringLocationId = :locationId " +
-        "AND ip.tenantId = :tenantId ")
-    Optional<IpInterface> findByIpAddressAndLocationIdAndTenantId(@Param("ipAddress") InetAddress ipAddress,
+        "AND ip.tenantId = :tenantId " +
+        "ORDER BY ip.id")
+    List<IpInterface> findByIpAddressAndLocationIdAndTenantId(@Param("ipAddress") InetAddress ipAddress,
                                                                 @Param("locationId") Long locationId,
                                                                 @Param("tenantId") String tenantId);
 

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseService.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.util.Strings;
 import org.opennms.horizon.azure.api.AzureScanItem;
 import org.opennms.horizon.azure.api.AzureScanNetworkInterfaceItem;
 import org.opennms.horizon.azure.api.AzureScanResponse;
+import org.opennms.horizon.inventory.dto.IpInterfaceDTO;
 import org.opennms.horizon.inventory.dto.ListTagsByEntityIdParamsDTO;
 import org.opennms.horizon.inventory.dto.MonitoredServiceDTO;
 import org.opennms.horizon.inventory.dto.MonitoredServiceTypeDTO;
@@ -280,8 +281,8 @@ public class ScannerResponseService {
         log.info("Received Detector tenantId={}; locationId={}; response={}", serviceResult, tenantId, locationId);
 
         InetAddress ipAddress = InetAddressUtils.getInetAddress(serviceResult.getIpAddress());
-        Optional<IpInterface> ipInterfaceOpt = ipInterfaceRepository
-            .findByIpAddressAndLocationIdAndTenantId(ipAddress, locationId, tenantId);
+        Optional<IpInterface> ipInterfaceOpt = ipInterfaceService
+            .findByIpAddressAndLocationIdAndTenantIdModel(ipAddress, locationId, tenantId);
 
         if (ipInterfaceOpt.isPresent()) {
             IpInterface ipInterface = ipInterfaceOpt.get();

--- a/metrics-processor/flows/src/main/java/org/opennms/horizon/flows/processing/DocumentEnricherImpl.java
+++ b/metrics-processor/flows/src/main/java/org/opennms/horizon/flows/processing/DocumentEnricherImpl.java
@@ -96,11 +96,10 @@ public class DocumentEnricherImpl {
         try {
             iface = inventoryClient.getIpInterfaceFromQuery(tenantId, ipAddress, location);
         } catch (StatusRuntimeException e) {
-            if (Status.NOT_FOUND.getCode().equals(e.getStatus().getCode())) {
-                return null;
-            } else {
-                throw e;
+            if (!Status.NOT_FOUND.getCode().equals(e.getStatus().getCode())) {
+                LOG.warn("Fail to get NodeInfo ipAddress: {} location: {} unknown error: {}", ipAddress, location, e.getStatus());
             }
+            return null;
         }
 
         if (iface == null) {

--- a/metrics-processor/flows/src/test/java/org/opennms/horizon/flows/processing/DocumentEnricherTest.java
+++ b/metrics-processor/flows/src/test/java/org/opennms/horizon/flows/processing/DocumentEnricherTest.java
@@ -59,8 +59,7 @@ import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Disabled
-public class DocumentEnricherTest {
+class DocumentEnricherTest {
 
     private InventoryClient mockInventoryClient;
     private ClassificationEngine mockClassificationEngine;
@@ -310,18 +309,12 @@ public class DocumentEnricherTest {
         //
         // Execute
         //
-        Exception actual = null;
-        try {
-            List<FlowDocument> result = target.enrich(testDocumentLog);
-            fail("Missing expected exception");
-        } catch (Exception caught) {
-            actual = caught;
-        }
+        List<FlowDocument> result = target.enrich(testDocumentLog);
 
         //
         // Verify the Results
         //
-        assertSame(testException, actual);
+        assertFalse(result.get(0).hasSrcNode());
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR will skip node enrichment if anything happen during grpc call to inventory rather than lost that flow record.
It also make sure findByIpAddressAndLocationIdAndTenantId only return single record. Priority return snmpPrimary first then first record.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2055

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
