### PR TITLE
LOK-1891: Enable/Fine Tune Validations

### DIFF
--- a/charts/lokahi/templates/opennms/api/api-deployment.yaml
+++ b/charts/lokahi/templates/opennms/api/api-deployment.yaml
@@ -65,6 +65,10 @@ spec:
               value: /api
             - name: GRAPHQL_SPQR_GUI_TARGET_ENDPOINT
               value: /api/graphql
+            {{- with .Values.OpenNMS.API.PlaygroundGuiEnabled }}
+            - name: GRAPHQL_SPQR_GUI_ENABLED
+              value: "{{ . }}"
+            {{- end }}
             - name: GRPC_URL_INVENTORY
               value: "{{ .Values.OpenNMS.Inventory.ServiceName }}:6565"
             - name: GRPC_URL_EVENTS

--- a/charts/lokahi/templates/opennms/api/api-deployment.yaml
+++ b/charts/lokahi/templates/opennms/api/api-deployment.yaml
@@ -65,9 +65,12 @@ spec:
               value: /api
             - name: GRAPHQL_SPQR_GUI_TARGET_ENDPOINT
               value: /api/graphql
-            {{- with .Values.OpenNMS.API.PlaygroundGuiEnabled }}
+            {{- if .Values.OpenNMS.API.PlaygroundGuiEnabled }}
             - name: GRAPHQL_SPQR_GUI_ENABLED
-              value: "{{ . }}"
+              value: "true"
+            {{- else }}
+            - name: GRAPHQL_SPQR_GUI_ENABLED
+              value: "false"
             {{- end }}
             - name: GRPC_URL_INVENTORY
               value: "{{ .Values.OpenNMS.Inventory.ServiceName }}:6565"
@@ -94,9 +97,12 @@ spec:
             - name: LOKAHI_BFF_CORS_ALLOWED
               value: "{{ . }}"
             {{- end }}
-            {{- with .Values.OpenNMS.API.IntrospectionEnabled }}
+            {{- if .Values.OpenNMS.API.IntrospectionEnabled }}
             - name: LOKAHI_BFF_INTROSPECTION_ENABLED
-              value: "{{ . }}"
+              value: "true"
+            {{- else }}
+            - name: LOKAHI_BFF_INTROSPECTION_ENABLED
+              value: "false"
             {{- end }}
             {{- with .Values.OpenNMS.API.MaxAliasOccurrence }}
             - name: LOKAHI_BFF_MAX_ALIAS_OCCURRENCE

--- a/charts/lokahi/values.yaml
+++ b/charts/lokahi/values.yaml
@@ -35,7 +35,13 @@ OpenNMS:
     CertificateManagerUrl: ""
     PackagedMinionFile: run-minion-docker-compose.yaml
     MinionEndpoint: host.docker.internal
-    # TODO: Default values here
+    IntrospectionEnabled: false
+    MaxAliasOccurrence: 5
+    MaxComplexity: 50
+    MaxDirectiveOccurrence: 5
+    MaxFieldOccurrence: 5
+    MaxQueryDepth: 5
+    PlaygroundGuiEnabled: false
   MetricsProcessor:
     ServiceName: opennms-metrics-processor
     ImageShortName: lokahi-metrics-processor

--- a/charts/lokahi/values.yaml
+++ b/charts/lokahi/values.yaml
@@ -35,6 +35,7 @@ OpenNMS:
     CertificateManagerUrl: ""
     PackagedMinionFile: run-minion-docker-compose.yaml
     MinionEndpoint: host.docker.internal
+    # TODO: Default values here
   MetricsProcessor:
     ServiceName: opennms-metrics-processor
     ImageShortName: lokahi-metrics-processor

--- a/charts/lokahi/values.yaml
+++ b/charts/lokahi/values.yaml
@@ -37,7 +37,7 @@ OpenNMS:
     MinionEndpoint: host.docker.internal
     IntrospectionEnabled: false
     MaxAliasOccurrence: 5
-    MaxComplexity: 50
+    MaxComplexity: 60
     MaxDirectiveOccurrence: 5
     MaxFieldOccurrence: 5
     MaxQueryDepth: 5

--- a/rest-server/src/main/java/org/opennms/horizon/server/config/BffProperties.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/config/BffProperties.java
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.Configuration;
 public class BffProperties {
 
     private boolean corsAllowed = false;
-    private boolean introspectionEnabled = true;
+    private boolean introspectionEnabled = false;
     private int maxAliasOccurrence = -1;
     private int maxComplexity = -1;
     private int maxDirectiveOccurrence = -1;

--- a/rest-server/src/main/java/org/opennms/horizon/server/config/GraphqlConfig.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/config/GraphqlConfig.java
@@ -29,7 +29,6 @@
 package org.opennms.horizon.server.config;
 
 import graphql.GraphQL;
-import graphql.analysis.MaxQueryDepthInstrumentation;
 import graphql.execution.DataFetcherExceptionHandler;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationInstrumentation;
@@ -45,6 +44,7 @@ import org.opennms.horizon.server.service.graphql.DuplicateFieldValidation;
 import org.opennms.horizon.server.service.graphql.ExecutionTimingInstrumentation;
 import org.opennms.horizon.server.service.graphql.MaxAliasOccurrenceValidation;
 import org.opennms.horizon.server.service.graphql.MaxComplexityInstrumentation;
+import org.opennms.horizon.server.service.graphql.MaxDepthInstrumentation;
 import org.opennms.horizon.server.service.graphql.MaxDirectiveOccurrenceInstrumentation;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -80,7 +80,7 @@ public class GraphqlConfig {
         BffProperties properties
     ) {
         log.info("Limiting max query depth to {}", properties.getMaxQueryDepth());
-        return new MaxQueryDepthInstrumentation(properties.getMaxQueryDepth());
+        return new MaxDepthInstrumentation(properties.getMaxQueryDepth());
     }
 
     @Bean

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/DuplicateFieldValidation.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/DuplicateFieldValidation.java
@@ -54,6 +54,16 @@ public class DuplicateFieldValidation implements FieldValidation {
             .queryTraverser(environment)
             .reducePreOrder(this::reduceField, new LinkedHashMap<>());
 
+        if (log.isDebugEnabled()) {
+            occurrences.forEach((field, count) -> log.debug(
+                "Field: {}, Occurrences: {} > {}, Over Limit: {}",
+                field,
+                count,
+                maxFieldOccurrence,
+                count > maxFieldOccurrence
+            ));
+        }
+
         return occurrences
             .entrySet().stream()
             .filter(entry -> entry.getValue() > maxFieldOccurrence)

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/ExecutionTimingInstrumentation.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/ExecutionTimingInstrumentation.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ */
+
+package org.opennms.horizon.server.service.graphql;
+
+import graphql.ExecutionResult;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.SimpleInstrumentationContext;
+import graphql.execution.instrumentation.SimplePerformantInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ExecutionTimingInstrumentation extends SimplePerformantInstrumentation {
+
+    @Getter
+    public static class EventTimes implements InstrumentationState {
+        private Long beginExecution = null;
+        private Long executionDuration = null;
+
+        public void recordBegin() {
+            beginExecution = System.currentTimeMillis();
+        }
+
+        public void recordEnd() {
+            executionDuration = System.currentTimeMillis() - beginExecution;
+        }
+    }
+
+    @Override
+    public InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
+        return new EventTimes();
+    }
+
+    @Override
+    public InstrumentationContext<ExecutionResult> beginExecution(
+        InstrumentationExecutionParameters parameters, InstrumentationState state
+    ) {
+        EventTimes times = InstrumentationState.ofState(state);
+        times.recordBegin();
+        return new SimpleInstrumentationContext<>() {
+            @Override
+            public void onCompleted(ExecutionResult result, Throwable t) {
+                times.recordEnd();
+                log.info("Execution performed in {} ms", times.getExecutionDuration());
+            }
+        };
+    }
+}

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/IntrospectionDisabler.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/IntrospectionDisabler.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ */
+
+package org.opennms.horizon.server.service.graphql;
+
+import graphql.schema.GraphQLSchema;
+import graphql.schema.visibility.NoIntrospectionGraphqlFieldVisibility;
+import io.leangen.graphql.GraphQLSchemaGenerator;
+import io.leangen.graphql.generator.BuildContext;
+import io.leangen.graphql.spqr.spring.autoconfigure.BaseAutoConfiguration;
+import io.leangen.graphql.spqr.spring.autoconfigure.SpqrProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+/**
+ * Takes the previously auto-configured {@link GraphQLSchemaGenerator}
+ * instance and additionally configures it to disable introspection. This is
+ * done to re-use the relatively complex original autoconfiguration instead
+ * of replacing it.
+ *
+ * @see BaseAutoConfiguration#graphQLSchemaGenerator(SpqrProperties)
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class IntrospectionDisabler implements BeanPostProcessor {
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof GraphQLSchemaGenerator schemaGenerator) {
+            log.info("Updating GraphQLSchemaGenerator to disable introspection");
+            schemaGenerator.withSchemaProcessors(this::disableIntrospection);
+        }
+
+        return bean;
+    }
+
+    private GraphQLSchema.Builder disableIntrospection(GraphQLSchema.Builder schemaBuilder, BuildContext buildContext) {
+        buildContext.codeRegistry.fieldVisibility(
+            NoIntrospectionGraphqlFieldVisibility.NO_INTROSPECTION_FIELD_VISIBILITY);
+        schemaBuilder.codeRegistry(buildContext.codeRegistry.build());
+        return schemaBuilder;
+    }
+}

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/MaxAliasOccurrenceValidation.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/MaxAliasOccurrenceValidation.java
@@ -34,6 +34,7 @@ import graphql.analysis.QueryVisitorFieldEnvironment;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidation;
 import graphql.execution.instrumentation.fieldvalidation.FieldValidationEnvironment;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
+@Slf4j
 public class MaxAliasOccurrenceValidation implements FieldValidation {
 
     private final int maxFieldOccurrence;
@@ -49,6 +51,16 @@ public class MaxAliasOccurrenceValidation implements FieldValidation {
     public List<GraphQLError> validateFields(FieldValidationEnvironment environment) {
         QueryTraverser queryTraverser = Traversers.queryTraverser(environment);
         var occurrences = queryTraverser.reducePreOrder(this::reduceField, new LinkedHashMap<>());
+
+        if (log.isDebugEnabled()) {
+            occurrences.forEach((field, count) -> log.debug(
+                "Field: {}, Occurrences: {} > {}, Over Limit: {}",
+                field,
+                count,
+                maxFieldOccurrence,
+                count > maxFieldOccurrence
+            ));
+        }
 
         return occurrences
             .entrySet().stream()

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/MaxComplexityInstrumentation.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/MaxComplexityInstrumentation.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ */
+
+package org.opennms.horizon.server.service.graphql;
+
+import graphql.analysis.FieldComplexityCalculator;
+import graphql.analysis.MaxQueryComplexityInstrumentation;
+import graphql.analysis.QueryComplexityInfo;
+import graphql.execution.AbortExecutionException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.function.Function;
+
+@Slf4j
+public class MaxComplexityInstrumentation extends MaxQueryComplexityInstrumentation {
+    public MaxComplexityInstrumentation(int maxComplexity) {
+        super(maxComplexity);
+    }
+
+    public MaxComplexityInstrumentation(
+        int maxComplexity, Function<QueryComplexityInfo, Boolean> complexityExceededFunction
+    ) {
+        super(maxComplexity, complexityExceededFunction);
+    }
+
+    public MaxComplexityInstrumentation(int maxComplexity, FieldComplexityCalculator calculator) {
+        super(maxComplexity, calculator);
+    }
+
+    public MaxComplexityInstrumentation(
+        int maxComplexity,
+        FieldComplexityCalculator calculator,
+        Function<QueryComplexityInfo, Boolean> complexityExceededFunction
+    ) {
+        super(maxComplexity, calculator, complexityExceededFunction);
+    }
+
+    @Override
+    protected AbortExecutionException mkAbortException(int totalComplexity, int maxComplexity) {
+        log.debug("maximum query complexity exceeded {} > {}", totalComplexity, maxComplexity);
+        return new AbortExecutionException("maximum query complexity exceeded");
+    }
+}

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/MaxDepthInstrumentation.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/MaxDepthInstrumentation.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ */
+
+package org.opennms.horizon.server.service.graphql;
+
+import graphql.analysis.MaxQueryDepthInstrumentation;
+import graphql.analysis.QueryDepthInfo;
+import graphql.execution.AbortExecutionException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.function.Function;
+
+@Slf4j
+public class MaxDepthInstrumentation extends MaxQueryDepthInstrumentation {
+    public MaxDepthInstrumentation(int maxDepth) {
+        super(maxDepth);
+    }
+
+    public MaxDepthInstrumentation(int maxDepth, Function<QueryDepthInfo, Boolean> maxQueryDepthExceededFunction) {
+        super(maxDepth, maxQueryDepthExceededFunction);
+    }
+
+    @Override
+    protected AbortExecutionException mkAbortException(int depth, int maxDepth) {
+        log.debug("maximum query depth exceeded {} > {}", depth, maxDepth);
+        return new AbortExecutionException("maximum query depth exceeded");
+    }
+}

--- a/rest-server/src/main/java/org/opennms/horizon/server/web/WebExceptionHandler.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/web/WebExceptionHandler.java
@@ -28,6 +28,7 @@
 
 package org.opennms.horizon.server.web;
 
+import lombok.extern.slf4j.Slf4j;
 import org.opennms.horizon.server.service.graphql.BffDataFetchExceptionHandler;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.reactive.error.ErrorAttributes;
@@ -57,6 +58,7 @@ import java.util.Map;
  * @see org.springframework.boot.autoconfigure.web.reactive.error.ErrorWebFluxAutoConfiguration#errorWebExceptionHandler
  */
 @RestControllerAdvice
+@Slf4j
 public class WebExceptionHandler {
 
     private final ErrorAttributes errorAttributes;
@@ -107,6 +109,9 @@ public class WebExceptionHandler {
         HttpStatus status,
         String message
     ) {
+        if (status.is5xxServerError()) {
+            log.error("Exception occurred during request processing", t);
+        }
         errorAttributes.storeErrorInformation(t, exchange);
         var request = ServerRequest.create(exchange, messageReaders);
         Map<String, Object> attributes = errorAttributes.getErrorAttributes(

--- a/rest-server/src/main/resources/application.yml
+++ b/rest-server/src/main/resources/application.yml
@@ -19,6 +19,7 @@ graphql:
   spqr:
     gui:
       enabled: true
+    # See https://github.com/leangen/graphql-spqr/issues/320
     base-packages:
       - org.opennms.horizon.server.model
 

--- a/rest-server/src/main/resources/application.yml
+++ b/rest-server/src/main/resources/application.yml
@@ -17,8 +17,6 @@ keycloak:
 
 graphql:
   spqr:
-    gui:
-      enabled: true
     # See https://github.com/leangen/graphql-spqr/issues/320
     base-packages:
       - org.opennms.horizon.server.model

--- a/rest-server/src/test/java/org/opennms/horizon/server/GraphQLQueryValidationConfig.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/GraphQLQueryValidationConfig.java
@@ -1,0 +1,157 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ */
+
+package org.opennms.horizon.server;
+
+import lombok.extern.slf4j.Slf4j;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.opennms.horizon.server.service.GrpcAlertService;
+import org.opennms.horizon.server.service.GrpcEventService;
+import org.opennms.horizon.server.service.GrpcLocationService;
+import org.opennms.horizon.server.service.GrpcMinionCertificateManager;
+import org.opennms.horizon.server.service.GrpcMinionService;
+import org.opennms.horizon.server.service.GrpcNodeService;
+import org.opennms.horizon.server.service.GrpcTagService;
+import org.opennms.horizon.server.service.NotificationService;
+import org.opennms.horizon.server.service.discovery.GrpcActiveDiscoveryService;
+import org.opennms.horizon.server.service.discovery.GrpcAzureActiveDiscoveryService;
+import org.opennms.horizon.server.service.discovery.GrpcIcmpActiveDiscoveryService;
+import org.opennms.horizon.server.service.discovery.GrpcPassiveDiscoveryService;
+import org.opennms.horizon.server.service.flows.GrpcFlowService;
+import org.opennms.horizon.server.service.metrics.TSDBMetricsService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@TestConfiguration
+@Slf4j
+public class GraphQLQueryValidationConfig {
+
+    @Bean
+    @Primary
+    public GrpcAlertService grpcAlertService() {
+        return Mockito.mock(GrpcAlertService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcEventService grpcEventService() {
+        return Mockito.mock(GrpcEventService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcLocationService grpcLocationService() {
+        return Mockito.mock(GrpcLocationService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcMinionCertificateManager grpcMinionCertificateManager() {
+        return Mockito.mock(GrpcMinionCertificateManager.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcMinionService grpcMinionService() {
+        return Mockito.mock(GrpcMinionService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcNodeService grpcNodeService() {
+        return Mockito.mock(GrpcNodeService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcTagService grpcTagService() {
+        return Mockito.mock(GrpcTagService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public NotificationService notificationService() {
+        return Mockito.mock(NotificationService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcActiveDiscoveryService grpcActiveDiscoveryService() {
+        return Mockito.mock(GrpcActiveDiscoveryService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcAzureActiveDiscoveryService grpcAzureActiveDiscoveryService() {
+        return Mockito.mock(GrpcAzureActiveDiscoveryService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcIcmpActiveDiscoveryService grpcIcmpActiveDiscoveryService() {
+        return Mockito.mock(GrpcIcmpActiveDiscoveryService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcPassiveDiscoveryService grpcPassiveDiscoveryService() {
+        return Mockito.mock(GrpcPassiveDiscoveryService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public GrpcFlowService grpcFlowService() {
+        return Mockito.mock(GrpcFlowService.class, new GraphQLAnswer());
+    }
+
+    @Bean
+    @Primary
+    public TSDBMetricsService TSDBMetricsService() {
+        return Mockito.mock(TSDBMetricsService.class, new GraphQLAnswer());
+    }
+
+    static class GraphQLAnswer implements Answer<Object> {
+
+        @Override
+        @SuppressWarnings("ReactiveStreamsUnusedPublisher")
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+            Class<?> returnType = invocation.getMethod().getReturnType();
+            if (returnType.isAssignableFrom(Mono.class)) {
+                return Mono.empty();
+            } else if (returnType.isAssignableFrom(Flux.class)) {
+                return Flux.empty();
+            }
+            throw new RuntimeException("Unhandled class: " + returnType);
+        }
+    }
+}

--- a/rest-server/src/test/java/org/opennms/horizon/server/GraphQLQueryValidationTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/GraphQLQueryValidationTest.java
@@ -1,0 +1,218 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ */
+
+package org.opennms.horizon.server;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opennms.horizon.server.test.util.GraphQLWebTestClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.stream.Stream;
+
+import static org.opennms.horizon.server.test.util.ResourceFileReader.read;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@Slf4j
+@SpringBootTest(
+    webEnvironment = RANDOM_PORT,
+    properties = {
+        "spring.main.allow-bean-definition-overriding=true",
+        "logging.level.org.opennms.horizon.server.service.graphql.DuplicateFieldValidation=DEBUG",
+        "logging.level.org.opennms.horizon.server.service.graphql.MaxAliasOccurrenceValidation=DEBUG",
+        "logging.level.org.opennms.horizon.server.service.graphql.MaxComplexityInstrumentation=DEBUG",
+        "logging.level.org.opennms.horizon.server.service.graphql.MaxDepthInstrumentation=DEBUG",
+        "logging.level.org.opennms.horizon.server.service.graphql.MaxDirectiveOccurrenceInstrumentation=DEBUG"
+
+    }
+)
+@Import(GraphQLQueryValidationConfig.class)
+public class GraphQLQueryValidationTest {
+    private static Arguments readArgumentPair(String filePath) {
+        return Arguments.of(filePath, read(filePath));
+    }
+
+    private static final String DESCRIPTIVE_DISPLAY_NAME = "[{index}]: {0}";
+
+    private GraphQLWebTestClient webClient;
+
+    @BeforeEach
+    void setUp(@Autowired WebTestClient webTestClient) {
+        webClient = GraphQLWebTestClient.builder()
+            .webClient(webTestClient)
+            .build();
+    }
+
+    public static Stream<Arguments> allowedRequests() {
+        return Stream.of(
+            readArgumentPair("/test/data/list-monitoring-policies.json"),
+            readArgumentPair("/test/data/mutation-create-location.json"),
+            readArgumentPair("/test/data/mutation-create-location-2.json"),
+            readArgumentPair("/test/data/mutation-create-monitor-policy.json"),
+            readArgumentPair("/test/data/mutation-create-or-update-active-icmp-discovery.json"),
+            readArgumentPair("/test/data/query-alerts-list.json"),
+            readArgumentPair("/test/data/query-build-network-inventory-page.json"),
+            readArgumentPair("/test/data/query-count-alerts.json"),
+            readArgumentPair("/test/data/query-find-application-summaries.json"),
+            readArgumentPair("/test/data/query-find-exporters-for-node-status.json"),
+            readArgumentPair("/test/data/query-find-exporters.json"),
+            readArgumentPair("/test/data/query-find-minions-by-location-id.json"),
+            readArgumentPair("/test/data/query-get-minion-certificate.json"),
+            readArgumentPair("/test/data/query-get-minion-certificate.json"),
+            readArgumentPair("/test/data/query-list-alert-event-definitions.json"),
+            readArgumentPair("/test/data/query-list-discoveries-passive-discoveries.json"),
+            readArgumentPair("/test/data/query-list-locations-for-discovery.json"),
+            readArgumentPair("/test/data/query-list-minions-for-table-minions-table.json"),
+            readArgumentPair("/test/data/query-list-monitory-policies.json"),
+            readArgumentPair("/test/data/query-list-node-status.json"),
+            readArgumentPair("/test/data/query-list-tags-search.json"),
+            readArgumentPair("/test/data/query-location-by-name.json"),
+            readArgumentPair("/test/data/query-locations-list.json"),
+            readArgumentPair("/test/data/query-network-traffic.json"),
+            readArgumentPair("/test/data/query-nodes-for-map-find-all-nodes.json"),
+            readArgumentPair("/test/data/query-search-location.json"),
+            readArgumentPair("/test/data/query-tags-by-active-discovery-id.json"),
+            readArgumentPair("/test/data/query-tags-by-passive-discovery-id.json")
+        );
+    }
+
+    @MethodSource("allowedRequests")
+    @ParameterizedTest(name = DESCRIPTIVE_DISPLAY_NAME)
+    void allowedRequestsPassValidation(
+        String description,
+        String requestBody
+    ) {
+        webClient.exchangePost(requestBody)
+            .expectCleanResponse();
+    }
+
+
+    public static Stream<Arguments> introspectionRequests() {
+        return Stream.of(
+            readArgumentPair("/test/data/introspection-query.json"),
+            readArgumentPair("/test/data/introspection-circular.json")
+        );
+    }
+
+    @MethodSource("introspectionRequests")
+    @ParameterizedTest(name = DESCRIPTIVE_DISPLAY_NAME)
+    void disallowsIntrospection(
+        String description,
+        String requestBody
+    ) {
+        webClient.exchangePost(requestBody)
+            .expectGraphQLErrorResponse()
+            .jsonPath("$.errors[*].message").value(Matchers.everyItem(
+                Matchers.matchesRegex("^Validation error.*: Field '.+' in type '__.+' is undefined$")
+            ));
+    }
+
+    @Test
+    void wellFormedButInvalidRequestShouldReturn200WithErrorDetails() {
+        String requestBody = read("/test/data/error-mishandling.json");
+
+        webClient
+            .exchangePost(requestBody)
+            .expectStatus().isEqualTo(HttpStatus.OK)
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+            .expectBody()
+            .jsonPath("$.data").doesNotExist()
+            .jsonPath("$.errors").isArray()
+            .jsonPath("$.trace").doesNotExist();
+    }
+
+    @Test
+    void limitsAliasOverloading() {
+        String requestBody = read("/test/data/alias-overloading.json");
+
+        webClient
+            .exchangePost(requestBody)
+            .expectStatus().isEqualTo(HttpStatus.OK)
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+            .expectBody()
+            .jsonPath("$.data").doesNotExist()
+            .jsonPath("$.errors").isArray()
+            .jsonPath("$.errors[*].message").value(Matchers.everyItem(
+                Matchers.matchesRegex("^Validation error.*: Alias '.+' is repeated too many times$")
+            ))
+            .jsonPath("$.trace").doesNotExist();
+    }
+
+    public static Stream<Arguments> fieldDuplicationRequests() {
+        return Stream.of(
+            readArgumentPair("/test/data/field-duplication.json")
+        );
+    }
+
+    @MethodSource("fieldDuplicationRequests")
+    @ParameterizedTest(name = DESCRIPTIVE_DISPLAY_NAME)
+    void limitsFieldDuplication(
+        String description,
+        String requestBody
+    ) {
+        webClient
+            .exchangePost(requestBody)
+            .expectStatus().isEqualTo(HttpStatus.OK)
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+            .expectBody()
+            .jsonPath("$.data").doesNotExist()
+            .jsonPath("$.errors").isArray()
+            .jsonPath("$.errors[*].message").value(Matchers.everyItem(
+                Matchers.matchesRegex("^Validation error.*: Field '.+' is repeated too many times$")
+            ))
+            .jsonPath("$.trace").doesNotExist();
+    }
+
+
+    @Test
+    void limitsDirectiveOverloading() {
+        String requestBody = read("/test/data/directive-overloading.json");
+
+        webClient
+            .exchangePost(requestBody)
+            .expectStatus().isEqualTo(HttpStatus.OK)
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+            .expectBody()
+            .jsonPath("$.data").doesNotExist()
+            .jsonPath("$.errors").isArray()
+            .jsonPath("$.errors[*].message").value(Matchers.everyItem(
+                Matchers.matchesRegex("^Validation error.*: Directive '.+' is repeated too many times$")
+            ))
+            .jsonPath("$.trace").doesNotExist();
+    }
+}

--- a/rest-server/src/test/java/org/opennms/horizon/server/GraphQLQueryValidationTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/GraphQLQueryValidationTest.java
@@ -39,8 +39,6 @@ import org.opennms.horizon.server.test.util.GraphQLWebTestClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import java.util.stream.Stream;
@@ -149,12 +147,7 @@ public class GraphQLQueryValidationTest {
 
         webClient
             .exchangePost(requestBody)
-            .expectStatus().isEqualTo(HttpStatus.OK)
-            .expectHeader().contentType(MediaType.APPLICATION_JSON)
-            .expectBody()
-            .jsonPath("$.data").doesNotExist()
-            .jsonPath("$.errors").isArray()
-            .jsonPath("$.trace").doesNotExist();
+            .expectGraphQLErrorResponse();
     }
 
     @Test
@@ -163,11 +156,7 @@ public class GraphQLQueryValidationTest {
 
         webClient
             .exchangePost(requestBody)
-            .expectStatus().isEqualTo(HttpStatus.OK)
-            .expectHeader().contentType(MediaType.APPLICATION_JSON)
-            .expectBody()
-            .jsonPath("$.data").doesNotExist()
-            .jsonPath("$.errors").isArray()
+            .expectGraphQLErrorResponse()
             .jsonPath("$.errors[*].message").value(Matchers.everyItem(
                 Matchers.matchesRegex("^Validation error.*: Alias '.+' is repeated too many times$")
             ))
@@ -176,7 +165,8 @@ public class GraphQLQueryValidationTest {
 
     public static Stream<Arguments> fieldDuplicationRequests() {
         return Stream.of(
-            readArgumentPair("/test/data/field-duplication.json")
+            readArgumentPair("/test/data/field-duplication.json"),
+            readArgumentPair("/test/data/notifyByEmail-duplication.json")
         );
     }
 
@@ -188,11 +178,7 @@ public class GraphQLQueryValidationTest {
     ) {
         webClient
             .exchangePost(requestBody)
-            .expectStatus().isEqualTo(HttpStatus.OK)
-            .expectHeader().contentType(MediaType.APPLICATION_JSON)
-            .expectBody()
-            .jsonPath("$.data").doesNotExist()
-            .jsonPath("$.errors").isArray()
+            .expectGraphQLErrorResponse()
             .jsonPath("$.errors[*].message").value(Matchers.everyItem(
                 Matchers.matchesRegex("^Validation error.*: Field '.+' is repeated too many times$")
             ))
@@ -206,11 +192,7 @@ public class GraphQLQueryValidationTest {
 
         webClient
             .exchangePost(requestBody)
-            .expectStatus().isEqualTo(HttpStatus.OK)
-            .expectHeader().contentType(MediaType.APPLICATION_JSON)
-            .expectBody()
-            .jsonPath("$.data").doesNotExist()
-            .jsonPath("$.errors").isArray()
+            .expectGraphQLErrorResponse()
             .jsonPath("$.errors[*].message").value(Matchers.everyItem(
                 Matchers.matchesRegex("^Validation error.*: Directive '.+' is repeated too many times$")
             ))

--- a/rest-server/src/test/java/org/opennms/horizon/server/GraphQLQueryValidationTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/GraphQLQueryValidationTest.java
@@ -102,6 +102,7 @@ public class GraphQLQueryValidationTest {
             readArgumentPair("/test/data/query-location-by-name.json"),
             readArgumentPair("/test/data/query-locations-list.json"),
             readArgumentPair("/test/data/query-network-traffic.json"),
+            readArgumentPair("/test/data/query-node-id.json"),
             readArgumentPair("/test/data/query-nodes-for-map-find-all-nodes.json"),
             readArgumentPair("/test/data/query-search-location.json"),
             readArgumentPair("/test/data/query-tags-by-active-discovery-id.json"),

--- a/rest-server/src/test/java/org/opennms/horizon/server/GraphQLQueryValidationTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/GraphQLQueryValidationTest.java
@@ -124,6 +124,7 @@ public class GraphQLQueryValidationTest {
 
     public static Stream<Arguments> introspectionRequests() {
         return Stream.of(
+            readArgumentPair("/test/data/simple-introspection-query.json"),
             readArgumentPair("/test/data/introspection-query.json"),
             readArgumentPair("/test/data/introspection-circular.json")
         );

--- a/rest-server/src/test/java/org/opennms/horizon/server/test/util/GraphQLWebTestClient.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/test/util/GraphQLWebTestClient.java
@@ -1,0 +1,181 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ */
+
+package org.opennms.horizon.server.test.util;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.With;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.CookieAssertions;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.FluxExchangeResult;
+import org.springframework.test.web.reactive.server.HeaderAssertions;
+import org.springframework.test.web.reactive.server.StatusAssertions;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.Map;
+
+@Builder
+@With
+@Slf4j
+public class GraphQLWebTestClient {
+
+    private final WebTestClient webClient;
+
+    @Builder.Default
+    private final String endpoint = "/graphql";
+
+    @Builder.Default
+    private final MediaType contentType = MediaType.APPLICATION_JSON;
+
+    @Builder.Default
+    private final String accessToken = "test-token-12345";
+
+    public GraphQLResponseSpec exchangePost(String body) {
+        WebTestClient.ResponseSpec base = webClient.post()
+            .uri(endpoint)
+            .header("Content-Type", contentType.toString())
+            .header("Authorization", "Bearer " + accessToken)
+            .bodyValue(body)
+            .exchange();
+        return new GraphQLResponseSpec(base);
+    }
+
+    public GraphQLResponseSpec exchangeGet(String uri, Map<String, ?> uriVariables) {
+        WebTestClient.ResponseSpec base = webClient.get()
+            .uri(uri, uriVariables)
+            .header("Content-Type", contentType.toString())
+            .header("Authorization", "Bearer " + accessToken)
+            .exchange();
+        return new GraphQLResponseSpec(base);
+    }
+
+    public WebTestClient.RequestHeadersUriSpec<?> get() {
+        return webClient.get();
+    }
+
+    @RequiredArgsConstructor
+    public static class GraphQLResponseSpec implements WebTestClient.ResponseSpec {
+
+        private final WebTestClient.ResponseSpec delegate;
+
+        public WebTestClient.BodyContentSpec expectCleanResponse() {
+            return this.expectStatus().isEqualTo(HttpStatus.OK)
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .consumeWith(this::logBody)
+                .jsonPath("$.errors").doesNotExist()
+                .jsonPath("$.trace").doesNotExist()
+                .jsonPath("$.data").exists();
+        }
+
+        public WebTestClient.BodyContentSpec expectJsonResponse(HttpStatus status) {
+            return this.expectStatus().isEqualTo(status)
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .consumeWith(this::logBody)
+                .jsonPath("$.trace").doesNotExist();
+        }
+
+        public WebTestClient.BodyContentSpec expectGraphQLErrorResponse() {
+            return this.expectStatus().isEqualTo(HttpStatus.OK)
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody()
+                .consumeWith(this::logBody)
+                .jsonPath("$.data").doesNotExist()
+                .jsonPath("$.trace").doesNotExist()
+                .jsonPath("$.errors").isArray();
+        }
+
+        public void logBody(EntityExchangeResult<byte[]> rawBody) {
+            String body = rawBody.getResponseBody() == null
+                ? null
+                : new String(rawBody.getResponseBody());
+            log.info("Response Body: {}", body);
+        }
+
+        @Override
+        public WebTestClient.ResponseSpec expectAll(ResponseSpecConsumer... consumers) {
+            return delegate.expectAll(consumers);
+        }
+
+        @Override
+        public StatusAssertions expectStatus() {
+            return delegate.expectStatus();
+        }
+
+        @Override
+        public HeaderAssertions expectHeader() {
+            return delegate.expectHeader();
+        }
+
+        @Override
+        public CookieAssertions expectCookie() {
+            return delegate.expectCookie();
+        }
+
+        @Override
+        public <B> WebTestClient.BodySpec<B, ?> expectBody(Class<B> bodyType) {
+            return delegate.expectBody(bodyType);
+        }
+
+        @Override
+        public <B> WebTestClient.BodySpec<B, ?> expectBody(ParameterizedTypeReference<B> bodyType) {
+            return delegate.expectBody(bodyType);
+        }
+
+        @Override
+        public <E> WebTestClient.ListBodySpec<E> expectBodyList(Class<E> elementType) {
+            return delegate.expectBodyList(elementType);
+        }
+
+        @Override
+        public <E> WebTestClient.ListBodySpec<E> expectBodyList(ParameterizedTypeReference<E> elementType) {
+            return delegate.expectBodyList(elementType);
+        }
+
+        @Override
+        public WebTestClient.BodyContentSpec expectBody() {
+            return delegate.expectBody();
+        }
+
+        @Override
+        public <T> FluxExchangeResult<T> returnResult(Class<T> elementClass) {
+            return delegate.returnResult(elementClass);
+        }
+
+        @Override
+        public <T> FluxExchangeResult<T> returnResult(ParameterizedTypeReference<T> elementTypeRef) {
+            return delegate.returnResult(elementTypeRef);
+        }
+    }
+}

--- a/rest-server/src/test/resources/application.yml
+++ b/rest-server/src/test/resources/application.yml
@@ -9,10 +9,10 @@ lokahi:
   bff:
     introspection-enabled: false
     max-alias-occurrence: 5
-    max-complexity: 60
+    max-complexity: 50
     max-directive-occurrence: 5
     max-field-occurrence: 5
-    max-query-depth: 13
+    max-query-depth: 5
 
 graphql:
   spqr:

--- a/rest-server/src/test/resources/application.yml
+++ b/rest-server/src/test/resources/application.yml
@@ -14,6 +14,12 @@ lokahi:
     max-field-occurrence: 5
     max-query-depth: 13
 
+graphql:
+  spqr:
+    # See https://github.com/leangen/graphql-spqr/issues/320
+    base-packages:
+      - org.opennms.horizon.server.model
+
 grpc:
   url:
     inventory: localhost:29065

--- a/rest-server/src/test/resources/application.yml
+++ b/rest-server/src/test/resources/application.yml
@@ -9,7 +9,7 @@ lokahi:
   bff:
     introspection-enabled: false
     max-alias-occurrence: 5
-    max-complexity: 50
+    max-complexity: 60
     max-directive-occurrence: 5
     max-field-occurrence: 5
     max-query-depth: 5

--- a/rest-server/src/test/resources/test/data/error-mishandling.json
+++ b/rest-server/src/test/resources/test/data/error-mishandling.json
@@ -1,3 +1,3 @@
 {
-  "query": "query {\n\tfindAllLocations {\n\t\taddress\n\t\tlatitude\n\t\ttenantId\n\t\tlocation\n\t\tid\n\t\tlongitude\n\t}\n}"
+  "query": "query { findAllLocations { nonExistentField address latitude location id longitude }}"
 }

--- a/rest-server/src/test/resources/test/data/list-monitoring-policies.json
+++ b/rest-server/src/test/resources/test/data/list-monitoring-policies.json
@@ -1,0 +1,5 @@
+{
+  "operationName": "ListMonitoryPolicies",
+  "variables": {},
+  "query": "query ListMonitoryPolicies {\n  listMonitoryPolicies {\n    ...MonitoringPolicyParts\n  }\n  defaultPolicy {\n    ...MonitoringPolicyParts\n  }\n}\n\nfragment MonitoringPolicyParts on MonitorPolicy {\n  id\n  memo\n  name\n  notifyByEmail\n  notifyByPagerDuty\n  notifyByWebhooks\n  rules {\n    id\n    name\n    componentType\n    detectionMethod\n    eventType\n    thresholdMetricName\n    alertConditions {\n      id\n      count\n      clearEvent {\n        id\n        name\n        eventType\n      }\n      overtime\n      overtimeUnit\n      severity\n      triggerEvent {\n        id\n        name\n        eventType\n      }\n    }\n  }\n  tags\n}\n"
+}

--- a/rest-server/src/test/resources/test/data/mutation-create-location-2.json
+++ b/rest-server/src/test/resources/test/data/mutation-create-location-2.json
@@ -1,0 +1,12 @@
+{
+  "variables": {
+    "location": {
+      "location": "location",
+      "address": "",
+      "longitude": 0,
+      "latitude": 0
+    }
+  },
+  "query": "mutation CreateLocation($location: MonitoringLocationCreateInput!) {\n  createLocation(location: $location) {\n    id\n    location\n    address\n    longitude\n    latitude\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/mutation-create-location.json
+++ b/rest-server/src/test/resources/test/data/mutation-create-location.json
@@ -1,0 +1,5 @@
+{
+  "variables": {},
+  "query": "\tmutation createLocation { createLocation(location: { location: \"default\" }) { id } }",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/mutation-create-monitor-policy.json
+++ b/rest-server/src/test/resources/test/data/mutation-create-monitor-policy.json
@@ -1,0 +1,65 @@
+{
+  "variables": {
+    "policy": {
+      "name": "A Policy",
+      "memo": "Memo",
+      "notifyByEmail": true,
+      "notifyByPagerDuty": true,
+      "notifyByWebhooks": false,
+      "tags": [
+        "default",
+        "tag"
+      ],
+      "rules": [
+        {
+          "name": "A Rule",
+          "componentType": "NODE",
+          "detectionMethod": "EVENT",
+          "eventType": "SNMP_TRAP",
+          "alertConditions": [
+            {
+              "count": 1,
+              "severity": "CRITICAL",
+              "overtimeUnit": "UNKNOWN_UNIT",
+              "triggerEvent": {
+                "id": 1,
+                "name": "SNMP Cold Start",
+                "eventType": "SNMP_TRAP"
+              }
+            },
+            {
+              "count": 1,
+              "severity": "CRITICAL",
+              "overtimeUnit": "UNKNOWN_UNIT",
+              "triggerEvent": {
+                "id": 2,
+                "name": "SNMP Warm Start",
+                "eventType": "SNMP_TRAP"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Rule 2",
+          "componentType": "NODE",
+          "detectionMethod": "EVENT",
+          "eventType": "INTERNAL",
+          "alertConditions": [
+            {
+              "count": 1,
+              "severity": "CRITICAL",
+              "overtimeUnit": "UNKNOWN_UNIT",
+              "triggerEvent": {
+                "id": 7,
+                "name": "Device Unreachable",
+                "eventType": "INTERNAL"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "query": "mutation CreateMonitorPolicy($policy: MonitorPolicyInput!) {\n  createMonitorPolicy(policy: $policy) {\n    id\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/mutation-create-or-update-active-icmp-discovery.json
+++ b/rest-server/src/test/resources/test/data/mutation-create-or-update-active-icmp-discovery.json
@@ -1,0 +1,26 @@
+{
+  "variables": {
+    "request": {
+      "ipAddresses": [
+        "172.4.2.1"
+      ],
+      "locationId": 1,
+      "name": "Discovery",
+      "snmpConfig": {
+        "ports": [
+          "161"
+        ],
+        "readCommunities": [
+          "public"
+        ]
+      },
+      "tags": [
+        {
+          "name": "default"
+        }
+      ]
+    }
+  },
+  "query": "mutation CreateOrUpdateActiveIcmpDiscovery($request: IcmpActiveDiscoveryCreateInput!) {\n  upsertIcmpActiveDiscovery(request: $request) {\n    id\n    name\n    ipAddresses\n    locationId\n    snmpConfig {\n      ports\n      readCommunities\n    }\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/notifyByEmail-duplication.json
+++ b/rest-server/src/test/resources/test/data/notifyByEmail-duplication.json
@@ -1,0 +1,5 @@
+{
+  "operationName": "ListMonitoryPolicies",
+  "variables": {},
+  "query": "query ListMonitoryPolicies {\n  listMonitoryPolicies {\n    ...MonitoringPolicyParts\n  }\n  defaultPolicy {\n    ...MonitoringPolicyParts\n  }\n}\n\nfragment MonitoringPolicyParts on MonitorPolicy {\n  id\n  memo\n  name\n  notifyByEmail\n  notifyByEmail\n  notifyByEmail\n  notifyByEmail\n  notifyByEmail\n  notifyByEmail\n  notifyByPagerDuty\n  notifyByWebhooks\n  rules {\n    id\n    name\n    componentType\n    detectionMethod\n    eventType\n    thresholdMetricName\n    alertConditions {\n      id\n      count\n      clearEvent {\n        id\n        name\n        eventType\n      }\n      overtime\n      overtimeUnit\n      severity\n      triggerEvent {\n        id\n        name\n        eventType\n      }\n    }\n  }\n  tags\n}\n"
+}

--- a/rest-server/src/test/resources/test/data/query-alerts-list.json
+++ b/rest-server/src/test/resources/test/data/query-alerts-list.json
@@ -1,0 +1,13 @@
+{
+  "variables": {
+    "page": 0,
+    "pageSize": 10,
+    "severities": [],
+    "sortAscending": true,
+    "sortBy": "id",
+    "timeRange": "ALL",
+    "nodeLabel": ""
+  },
+  "query": "query AlertsList($page: Int!, $pageSize: Int, $severities: [String], $sortAscending: Boolean!, $sortBy: String, $timeRange: TimeRange!, $nodeLabel: String) {\n  ...AlertsParts\n}\n\nfragment AlertsParts on Query {\n  findAllAlerts(\n    page: $page\n    pageSize: $pageSize\n    severities: $severities\n    sortAscending: $sortAscending\n    sortBy: $sortBy\n    timeRange: $timeRange\n    nodeLabel: $nodeLabel\n  ) {\n    lastPage\n    nextPage\n    totalAlerts\n    alerts {\n      acknowledged\n      description\n      firstEventTimeMs\n      lastUpdateTimeMs\n      severity\n      label\n      nodeName\n      databaseId\n      location\n      ruleNameList\n      policyNameList\n    }\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-build-network-inventory-page.json
+++ b/rest-server/src/test/resources/test/data/query-build-network-inventory-page.json
@@ -1,0 +1,5 @@
+{
+  "variables": {},
+  "query": "query BuildNetworkInventoryPage {\n  findAllNodes {\n    id\n    ipInterfaces {\n      id\n      ipAddress\n      nodeId\n      snmpPrimary\n    }\n    location {\n      id\n      location\n    }\n    tags {\n      id\n      name\n    }\n    monitoredState\n    monitoringLocationId\n    nodeLabel\n    scanType\n  }\n  allMetrics: metric(name: \"response_time_msec\") {\n    status\n    data {\n      resultType\n      result {\n        metric\n        value\n        values\n      }\n    }\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-count-alerts.json
+++ b/rest-server/src/test/resources/test/data/query-count-alerts.json
@@ -1,0 +1,10 @@
+{
+  "variables": {
+    "severityFilters": [
+      "WARNING"
+    ],
+    "timeRange": "ALL"
+  },
+  "query": "query CountAlerts($severityFilters: [String], $timeRange: TimeRange!) {\n  countAlerts(severityFilters: $severityFilters, timeRange: $timeRange) {\n    count\n    error\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-find-application-summaries.json
+++ b/rest-server/src/test/resources/test/data/query-find-application-summaries.json
@@ -1,0 +1,15 @@
+{
+  "variables": {
+    "requestCriteria": {
+      "count": 10,
+      "exporter": [],
+      "timeRange": {
+        "startTime": 1698334267634,
+        "endTime": 1698420667634
+      },
+      "applications": []
+    }
+  },
+  "query": "query findApplicationSummaries($requestCriteria: RequestCriteriaInput!) {\n  findApplicationSummaries(requestCriteria: $requestCriteria) {\n    label\n    bytesIn\n    bytesOut\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-find-exporters-for-node-status.json
+++ b/rest-server/src/test/resources/test/data/query-find-exporters-for-node-status.json
@@ -1,0 +1,17 @@
+{
+  "variables": {
+    "requestCriteria": {
+      "exporter": [
+        {
+          "nodeId": 1
+        }
+      ],
+      "timeRange": {
+        "startTime": 1697816401615,
+        "endTime": 1698421201615
+      }
+    }
+  },
+  "query": "query findExportersForNodeStatus($requestCriteria: RequestCriteriaInput!) {\n  findExporters(requestCriteria: $requestCriteria) {\n    snmpInterface {\n      ifIndex\n      ifName\n    }\n    ipInterface {\n      id\n      ipAddress\n    }\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-find-exporters.json
+++ b/rest-server/src/test/resources/test/data/query-find-exporters.json
@@ -1,0 +1,15 @@
+{
+  "variables": {
+    "requestCriteria": {
+      "count": 10,
+      "exporter": [],
+      "timeRange": {
+        "startTime": 1698334268770,
+        "endTime": 1698420668770
+      },
+      "applications": []
+    }
+  },
+  "query": "query findExporters($requestCriteria: RequestCriteriaInput!) {\n  findExporters(requestCriteria: $requestCriteria) {\n    node {\n      id\n      nodeLabel\n    }\n    ipInterface {\n      id\n      ipAddress\n    }\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-find-minions-by-location-id.json
+++ b/rest-server/src/test/resources/test/data/query-find-minions-by-location-id.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "locationId": 0
+  },
+  "query": "query FindMinionsByLocationId($locationId: Long!) {\n  findMinionsByLocationId(locationId: $locationId) {\n    id\n    label\n    lastCheckedTime\n    status\n    systemId\n    location {\n      id\n      location\n    }\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-get-minion-certificate-2.json
+++ b/rest-server/src/test/resources/test/data/query-get-minion-certificate-2.json
@@ -1,0 +1,1 @@
+{"variables":{"location":2},"query":"query getMinionCertificate($location: Long) {\n  getMinionCertificate(locationId: $location) {\n    password\n    certificate\n  }\n}","operationName":null}

--- a/rest-server/src/test/resources/test/data/query-get-minion-certificate.json
+++ b/rest-server/src/test/resources/test/data/query-get-minion-certificate.json
@@ -1,0 +1,5 @@
+{
+  "variables": {},
+  "query": "\tquery { getMinionCertificate(locationId: 1) { certificate, password } }",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-list-alert-event-definitions.json
+++ b/rest-server/src/test/resources/test/data/query-list-alert-event-definitions.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "eventType": "SNMP_TRAP"
+  },
+  "query": "query ListAlertEventDefinitions($eventType: EventType) {\n  listAlertEventDefinitions(eventType: $eventType) {\n    id\n    name\n    eventType\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-list-discoveries-passive-discoveries.json
+++ b/rest-server/src/test/resources/test/data/query-list-discoveries-passive-discoveries.json
@@ -1,0 +1,5 @@
+{
+  "variables": {},
+  "query": "query ListDiscoveries {\n  passiveDiscoveries {\n    id\n    locationId\n    name\n    snmpCommunities\n    snmpPorts\n    toggle\n  }\n  listActiveDiscovery {\n    details\n    discoveryType\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-list-locations-for-discovery.json
+++ b/rest-server/src/test/resources/test/data/query-list-locations-for-discovery.json
@@ -1,0 +1,5 @@
+{
+  "variables": {},
+  "query": "query ListLocationsForDiscovery {\n  ...LocationsParts\n}\n\nfragment LocationsParts on Query {\n  findAllLocations {\n    id\n    location\n    address\n    longitude\n    latitude\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-list-minions-for-table-minions-table.json
+++ b/rest-server/src/test/resources/test/data/query-list-minions-for-table-minions-table.json
@@ -1,0 +1,5 @@
+{
+  "variables": {},
+  "query": "query ListMinionsForTable {\n  ...MinionsTableParts\n}\n\nfragment MinionsTableParts on Query {\n  findAllMinions {\n    id\n    label\n    lastCheckedTime\n    location {\n      id\n      location\n    }\n    status\n    systemId\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-list-monitory-policies.json
+++ b/rest-server/src/test/resources/test/data/query-list-monitory-policies.json
@@ -1,0 +1,5 @@
+{
+  "variables": {},
+  "query": "query ListMonitoryPolicies {\n  listMonitoryPolicies {\n    ...MonitoringPolicyParts\n  }\n  defaultPolicy {\n    ...MonitoringPolicyParts\n  }\n}\n\nfragment MonitoringPolicyParts on MonitorPolicy {\n  id\n  memo\n  name\n  notifyByEmail\n  notifyByPagerDuty\n  notifyByWebhooks\n  rules {\n    id\n    name\n    componentType\n    detectionMethod\n    eventType\n    thresholdMetricName\n    alertConditions {\n      id\n      count\n      clearEvent {\n        id\n        name\n        eventType\n      }\n      overtime\n      overtimeUnit\n      severity\n      triggerEvent {\n        id\n        name\n        eventType\n      }\n    }\n  }\n  tags\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-list-node-status.json
+++ b/rest-server/src/test/resources/test/data/query-list-node-status.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "id": 1
+  },
+  "query": "query ListNodeStatus($id: Long) {\n  ...EventsByNodeIdParts\n  ...NodeByIdParts\n}\n\nfragment EventsByNodeIdParts on Query {\n  events: findEventsByNodeId(id: $id) {\n    id\n    uei\n    nodeId\n    ipAddress\n    producedTime\n  }\n}\n\nfragment NodeByIdParts on Query {\n  node: findNodeById(id: $id) {\n    id\n    nodeLabel\n    objectId\n    systemContact\n    systemDescr\n    systemLocation\n    systemName\n    scanType\n    location {\n      location\n    }\n    ipInterfaces {\n      id\n      hostname\n      ipAddress\n      netmask\n      nodeId\n      snmpPrimary\n      azureInterfaceId\n    }\n    snmpInterfaces {\n      id\n      ifAdminStatus\n      ifAlias\n      ifDescr\n      ifIndex\n      ifName\n      ifOperatorStatus\n      ifSpeed\n      ifType\n      ipAddress\n      nodeId\n      physicalAddr\n    }\n    azureInterfaces {\n      id\n      nodeId\n      interfaceName\n      privateIpId\n      publicIpAddress\n      publicIpId\n      location\n    }\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-list-tags-search.json
+++ b/rest-server/src/test/resources/test/data/query-list-tags-search.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "searchTerm": "tag"
+  },
+  "query": "query ListTagsSearch($searchTerm: String) {\n  ...TagsSearchParts\n}\n\nfragment TagsSearchParts on Query {\n  tags(searchTerm: $searchTerm) {\n    id\n    name\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-location-by-name.json
+++ b/rest-server/src/test/resources/test/data/query-location-by-name.json
@@ -1,0 +1,5 @@
+{
+  "variables": {},
+  "query": "\tquery { locationByName(locationName: \"default\") { id } }",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-locations-list.json
+++ b/rest-server/src/test/resources/test/data/query-locations-list.json
@@ -1,0 +1,5 @@
+{
+  "variables": {},
+  "query": "query LocationsList {\n  ...LocationsParts\n}\n\nfragment LocationsParts on Query {\n  findAllLocations {\n    id\n    location\n    address\n    longitude\n    latitude\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-network-traffic.json
+++ b/rest-server/src/test/resources/test/data/query-network-traffic.json
@@ -1,0 +1,9 @@
+{
+  "variables": {
+    "name": "total_network_bytes_out",
+    "timeRange": 24,
+    "timeRangeUnit": "HOUR"
+  },
+  "query": "query NetworkTraffic($name: String!, $timeRange: Int!, $timeRangeUnit: TimeRangeUnit!) {\n  metric(name: $name, timeRange: $timeRange, timeRangeUnit: $timeRangeUnit) {\n    status\n    ...MetricParts\n  }\n}\n\nfragment MetricParts on TimeSeriesQueryResult {\n  data {\n    result {\n      metric\n      values\n    }\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-node-id.json
+++ b/rest-server/src/test/resources/test/data/query-node-id.json
@@ -1,0 +1,7 @@
+{
+  "operationName": "ListNodeStatus",
+  "variables": {
+    "id": 3
+  },
+  "query": "fragment EventsByNodeIdParts on Query {\n  events: findEventsByNodeId(id: $id) {\n    id\n    uei\n    nodeId\n    ipAddress\n    producedTime\n  }\n}\n\nfragment NodeByIdParts on Query {\n  node: findNodeById(id: $id) {\n    id\n    nodeLabel\n    objectId\n    systemContact\n    systemDescr\n    systemLocation\n    systemName\n    scanType\n    location {\n      location\n    }\n    ipInterfaces {\n      id\n      hostname\n      ipAddress\n      netmask\n      nodeId\n      snmpPrimary\n      azureInterfaceId\n    }\n    snmpInterfaces {\n      id\n      ifAdminStatus\n      ifAlias\n      ifDescr\n      ifIndex\n      ifName\n      ifOperatorStatus\n      ifSpeed\n      ifType\n      ipAddress\n      nodeId\n      physicalAddr\n    }\n    azureInterfaces {\n      id\n      nodeId\n      interfaceName\n      privateIpId\n      publicIpAddress\n      publicIpId\n      location\n    }\n  }\n}\n\nquery ListNodeStatus($id: Long) {\n  ...EventsByNodeIdParts\n  ...NodeByIdParts\n}\n"
+}

--- a/rest-server/src/test/resources/test/data/query-nodes-for-map-find-all-nodes.json
+++ b/rest-server/src/test/resources/test/data/query-nodes-for-map-find-all-nodes.json
@@ -1,0 +1,5 @@
+{
+  "variables": {},
+  "query": "query NodesForMap {\n  findAllNodes {\n    id\n    nodeLabel\n    location {\n      latitude\n      longitude\n      location\n    }\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-search-location.json
+++ b/rest-server/src/test/resources/test/data/query-search-location.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "searchTerm": ""
+  },
+  "query": "query SearchLocation($searchTerm: String) {\n  searchLocation(searchTerm: $searchTerm) {\n    id\n    location\n    address\n    longitude\n    latitude\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-tags-by-active-discovery-id.json
+++ b/rest-server/src/test/resources/test/data/query-tags-by-active-discovery-id.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "discoveryId": 1
+  },
+  "query": "query TagsByActiveDiscoveryId($discoveryId: Long!) {\n  tagsByActiveDiscoveryId(activeDiscoveryId: $discoveryId) {\n    id\n    name\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/query-tags-by-passive-discovery-id.json
+++ b/rest-server/src/test/resources/test/data/query-tags-by-passive-discovery-id.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "discoveryId": 1
+  },
+  "query": "query TagsByPassiveDiscoveryId($discoveryId: Long!) {\n  tagsByPassiveDiscoveryId(passiveDiscoveryId: $discoveryId) {\n    id\n    name\n  }\n}",
+  "operationName": null
+}

--- a/rest-server/src/test/resources/test/data/simple-introspection-query.json
+++ b/rest-server/src/test/resources/test/data/simple-introspection-query.json
@@ -1,0 +1,5 @@
+{
+  "operationName": "cop",
+  "variables": {},
+  "query": "query cop {  __schema { types { name fields { name }}}}"
+}

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -40,6 +40,7 @@ OpenNMS:
         Cpu: '0'
         Memory: '0'
     CorsAllowed: true
+    PlaygroundGuiEnabled: true
   UI:
     Resources:
       Limits:


### PR DESCRIPTION
## Description
- Provide configuration values for GraphQL Complexity Validations in helm charts
- Add timing instrumentation to measure execution time
- Add a sampling of queries from UI to ensure validations don't prevent the UI from working
- Disable the GraphQL playground by default; enabled in tilt.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-1891

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
