### PR TITLE
LOK-2171: Fix discovery page call for tags when no discovery available

### DIFF
--- a/ui/src/components/Discovery/DiscoveryListCard.vue
+++ b/ui/src/components/Discovery/DiscoveryListCard.vue
@@ -9,7 +9,7 @@
         v-for="(item, index) in list"
         :key="index"
         class="discovery-name pointer"
-        :class="{ selected: selectedId == item.id }"
+        :class="{ selected: selectedId == item.id && item.type === selectedType }"
       >
         <div
           class="name pointer"
@@ -56,6 +56,7 @@ defineProps<{
   toggleDiscovery?: (discovery: NewOrUpdatedDiscovery) => void
   passive?: boolean
   selectedId?: number
+  selectedType?: string
 }>()
 </script>
 

--- a/ui/src/containers/Discovery.vue
+++ b/ui/src/containers/Discovery.vue
@@ -25,6 +25,7 @@
             :selectDiscovery="discoveryStore.editDiscovery"
             :selectedId="discoveryStore.selectedDiscovery.id"
             :showInstructions="() => openInstructions(InstructionsType.Active)"
+            :selectedType="discoveryStore.selectedDiscovery.type"
           />
           <DiscoveryListCard
             passive
@@ -34,6 +35,7 @@
             :selectDiscovery="discoveryStore.editDiscovery"
             :selectedId="discoveryStore.selectedDiscovery.id"
             :showInstructions="() => openInstructions(InstructionsType.Passive)"
+            :selectedType="discoveryStore.selectedDiscovery.type"
           />
         </div>
       </section>

--- a/ui/src/store/Queries/discoveryQueries.ts
+++ b/ui/src/store/Queries/discoveryQueries.ts
@@ -50,7 +50,8 @@ export const useDiscoveryQueries = defineStore('discoveryQueries', () => {
   const { data: tagsByDiscoveryIdData, execute: tagsByDiscoveryIdExecute } = useQuery({
     query: TagsByActiveDiscoveryIdDocument,
     cachePolicy: 'network-only',
-    variables: discoveryId
+    variables: discoveryId,
+    paused: true
   })
 
   const getTagsByActiveDiscoveryId = async (id: number) => {
@@ -63,7 +64,8 @@ export const useDiscoveryQueries = defineStore('discoveryQueries', () => {
   const { data: tagsByPassiveDiscoveryIdData, execute: tagsByPassiveDiscoveryIdExecute } = useQuery({
     query: TagsByPassiveDiscoveryIdDocument,
     cachePolicy: 'network-only',
-    variables: discoveryId
+    variables: discoveryId,
+    paused: true
   })
 
   const getTagsByPassiveDiscoveryId = async (id: number) => {


### PR DESCRIPTION
## Description
Right now if we have only passive type discoveries or only active type discoveries, the frontend will make a tags call for both types. This fixes things so that it will only make the tags call for the type which has available discoveries.

Also fixes the selected/highlighted issue when both a passive and active discovery have the same id.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2171

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
