### PR TITLE
LOK-2086: Doc: Passive Discovery: Remove mention of syslog

### DIFF
--- a/docs/modules/operation/pages/get-started/discovery/introduction.adoc
+++ b/docs/modules/operation/pages/get-started/discovery/introduction.adoc
@@ -2,7 +2,7 @@
 :!sectids:
 
 = Network Discovery
-:description: Learn about network discovery with OpenNMS Lōkahi/Cloud using ICMP/SNMP, Azure, or Syslog and SNMP traps to identify monitoring inventory and devices.
+:description: Learn about network discovery with OpenNMS Lōkahi/Cloud using ICMP/SNMP, Azure, or SNMP traps to identify monitoring inventory and devices.
 
 The discovery process identifies devices and entities on your monitored network through either active or passive discovery.
 
@@ -24,10 +24,10 @@ _**Disadvantages:** Can slow network performance as the discovery process tries 
 [[passive-discovery]]
 == What is passive discovery?
 
-Passive discovery uses Syslog and SNMP traps to identify network devices. It does so by monitoring their activity through events, flows, and indirectly by evaluating other devices' configuration settings.
+Passive discovery uses SNMP traps to identify network devices. It does so by monitoring their activity through events, flows, and indirectly by evaluating other devices' configuration settings.
 
 Note that you can set only one passive discovery configuration.
 
 _**Benefits:** Low bandwidth consumption._
 
-_**Disadvantages:** May miss devices if they are not active. All devices must be enabled and configured to send Syslogs._
+_**Disadvantages:** May miss devices if they are not active._

--- a/docs/modules/operation/pages/get-started/discovery/passive.adoc
+++ b/docs/modules/operation/pages/get-started/discovery/passive.adoc
@@ -1,5 +1,5 @@
 = Create a Passive Discovery
-:description: Learn how to identify network inventory with OpenNMS Lōkahi/Cloud using Syslog and SNMP traps (passive discovery).
+:description: Learn how to identify network inventory with OpenNMS Lōkahi/Cloud using SNMP traps (passive discovery).
 
 A xref:get-started/discovery/introduction.adoc#passive-discovery[passive discovery] is one method to identify the devices on your network and add them to your monitoring inventory.
 You may also choose to xref:get-started/discovery/active.adoc[create an active discovery].
@@ -10,10 +10,11 @@ You can create only one passive discovery:
 
 . Choose *Discovery* in the left navigation menu.
 . On the Discovery page, click *Add Discovery*.
-. In the Passive Discovery area, toggle *SYSLOG & SNMP TRAPS* on.
+. In the Passive Discovery area, click *SNMP Traps*.
 . Fill in the appropriate information in each field.
 +
-NOTE: To create xref:inventory/nodes.adoc#tag-create[tags], click the drop-down arrow in the *Search/Add tags* field, type a name for the tag, and click *New*.
+NOTE: To create xref:inventory/nodes.adoc#tag-create[tags], type a name for the tag in the *Tags* field, and click on the name when it appears in the drop-down list.
+The new tag appears below the field and is available for use elsewhere, such as with nodes and alerts.
 
 . Click *Save Discovery*.
 

--- a/docs/modules/operation/pages/get-started/policies/create.adoc
+++ b/docs/modules/operation/pages/get-started/policies/create.adoc
@@ -5,7 +5,7 @@
 A monitoring policy uses tags and rules to customize the type of monitoring data that you collect and the notifications you receive about that data.
 
 Note that you can also create a monitoring policy by copying an existing one and editing it.
-Click the *copy* symbol next to the policy name field label.
+Click the policy, then click the *copy* symbol at the top right of the *Policy Name* .
 
 To create a monitoring policy, follow these steps:
 

--- a/docs/modules/operation/pages/get-started/policies/manage.adoc
+++ b/docs/modules/operation/pages/get-started/policies/manage.adoc
@@ -2,10 +2,10 @@
 = Manage Monitoring Policies
 :description: Learn how to edit a monitoring policy in OpenNMS Lōkahi/Cloud.
 
-You can edit monitoring policies.
-Currently, it is not possible to delete a monitoring policy or edit the default monitoring policy.
+You can edit or delete any monitoring policy, except for the default one.
 
-// <TBD - any caveats for deleting/editing policies?>
+With the default policy, you can only edit add or remove tags.
+To turn off the default monitoring policy, remove the tag(s) associated with it.
 
 == Edit a monitoring policy
 
@@ -18,3 +18,17 @@ Follow these steps to edit a monitoring policy:
 . Click **Save Rule** (if you edited a rule) and **Save Policy**.
 
 The policy's configuration settings are updated.
+
+== Delete a monitoring policy
+
+You cannot delete the default monitoring policy.
+//any caveats about deleting a monitoring policy?
+
+Follow these steps to delete a monitoring policy:
+. Click **Monitoring Policies** in the left navigation menu.
+. Select a policy from the **Existing Policies** list.
+. Click the *delete* symbol on the top right of the *Policy Name* area.
+. Click *Delete* to confirm deletion.
+
+
+

--- a/docs/modules/operation/pages/get-started/policies/manage.adoc
+++ b/docs/modules/operation/pages/get-started/policies/manage.adoc
@@ -21,10 +21,13 @@ The policy's configuration settings are updated.
 
 == Delete a monitoring policy
 
-You cannot delete the default monitoring policy.
-//any caveats about deleting a monitoring policy?
+When you delete a monitoring policy, all associated alerts will be removed.
+Before deletion, a prompt appears that details the number of associated alerts, to confirm you want to proceed.
+
+Note that you cannot delete the default monitoring policy.
 
 Follow these steps to delete a monitoring policy:
+
 . Click **Monitoring Policies** in the left navigation menu.
 . Select a policy from the **Existing Policies** list.
 . Click the *delete* symbol on the top right of the *Policy Name* area.


### PR DESCRIPTION
LOK-2086: Doc: Passive Discovery: Remove mention of syslog - removed mention of syslog in the discovery section of the docs.

LOK- 1907: Doc: Monitoring Policy: Deletion of monitoring policies and rules within a policy - added information about deleting policies, including that you cannot delete the default policy.

## Description
LOK-2086: Doc: Passive Discovery: Remove mention of syslog - removed mention of syslog in the discovery section of the docs.

LOK- 1907: Doc: Monitoring Policy: Deletion of monitoring policies and rules within a policy - added information about deleting policies, including that you cannot delete the default policy.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2086
- - https://opennms.atlassian.net/browse/LOK-1907

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
