### PR TITLE
LOK-2210: Remove display/copy of cert password on locations

### DIFF
--- a/ui/src/components/Locations/LocationsCertificateDownload.vue
+++ b/ui/src/components/Locations/LocationsCertificateDownload.vue
@@ -25,32 +25,6 @@
             {{ props.secondaryButtonText }}
           </FeatherButton>
         </div>
-
-        <div class="input-wrapper">
-          <FeatherInput
-            :label="inputPlaceholder"
-            :modelValue="certificatePassword"
-            type="text"
-            class="download-input"
-            :disabled="true"
-            data-test="download-input"
-          />
-          <FeatherButton
-            :disabled="!certificatePassword"
-            text
-            @click="copyClick"
-            class="download-copy-button"
-          >
-            <template v-slot:icon>
-              <FeatherIcon
-                :icon="CopyIcon"
-                aria-hidden="true"
-                focusable="false"
-              />
-              Copy
-            </template>
-          </FeatherButton>
-        </div>
       </div>
     </div>
   </div>
@@ -71,12 +45,9 @@
 
 <script lang="ts" setup>
 import { PropType } from 'vue'
-import CopyIcon from '@featherds/icon/action/ContentCopy'
 import { useLocationStore } from '@/store/Views/locationStore'
 import useModal from '@/composables/useModal'
 
-import useSnackbar from '@/composables/useSnackbar'
-const { showSnackbar } = useSnackbar()
 const locationStore = useLocationStore()
 const { openModal, closeModal, isVisible } = useModal()
 
@@ -102,10 +73,6 @@ const props = defineProps({
     type: Function as PropType<(event: Event) => void>,
     default: () => ({})
   },
-  inputPlaceholder: {
-    default: 'Unlock File Password',
-    type: String
-  },
   certificatePassword: {
     required: true,
     type: String
@@ -115,13 +82,6 @@ const props = defineProps({
     type: Boolean
   }
 })
-
-const copyClick = () => {
-  navigator.clipboard.writeText(props.certificatePassword).catch(() => 'Copy to clipboard was unsuccessful.')
-  showSnackbar({
-    msg: 'Certificate password copied.'
-  })
-}
 </script>
 
 <style lang="scss" scoped>
@@ -140,22 +100,9 @@ const copyClick = () => {
   border-radius: 4px;
   padding: var(variables.$spacing-l);
 }
-.input-wrapper {
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  flex: 1 1 0;
-  gap: var(variables.$spacing-xs);
-}
 .download-title {
   @include typography.subtitle2();
   margin-bottom: var(variables.$spacing-m);
-}
-.download-copy-button {
-  min-width: 87px;
-}
-.download-input {
-  width: 285px;
 }
 .download-buttons {
   display: flex;


### PR DESCRIPTION
## Description
Just removes the input/copy which displays the cert password. This is no longer needed.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2210

![screenshot-localhost_3009-2023 11 17-11_51_13](https://github.com/OpenNMS-Cloud/lokahi/assets/8680122/e2cf0a7c-b143-4b17-a4f1-470a517879b2)


## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
