### PR TITLE
LOK-2203: Restore usage of enum types

### DIFF
--- a/ui/src/components/Alerts/AlertsSeverityCard.vue
+++ b/ui/src/components/Alerts/AlertsSeverityCard.vue
@@ -50,7 +50,7 @@
 <script lang="ts" setup>
 import Add from '@featherds/icon/action/Add'
 import Cancel from '@featherds/icon/navigation/Cancel'
-import { TimeRange } from '@/types/graphql'
+import { Severity, TimeRange } from '@/types/graphql'
 import { useAlertsStore } from '@/store/Views/alertsStore'
 import { useAlertsQueries } from '@/store/Queries/alertsQueries'
 
@@ -58,7 +58,7 @@ const alertsStore = useAlertsStore()
 const alertsQueries = useAlertsQueries()
 
 const props = defineProps<{
-  severity: string
+  severity: Severity
   isFilter?: boolean
   timeRange?: TimeRange
 }>()

--- a/ui/src/components/Alerts/AlertsSeverityFilters.vue
+++ b/ui/src/components/Alerts/AlertsSeverityFilters.vue
@@ -25,14 +25,16 @@
 </template>
 
 <script lang="ts" setup>
-import { TimeRange } from '@/types/graphql'
+import {Severity, TimeRange} from '@/types/graphql'
 
 defineProps<{
   isFilter?: boolean
   timeRange?: TimeRange
 }>()
 
-const severities = ['critical', 'major', 'minor', 'warning', 'indeterminate']
+const severities: Severity[] = [
+  Severity.Critical, Severity.Major, Severity.Minor, Severity.Warning, Severity.Indeterminate
+]
 
 // for setting CSS properties
 const gap = 1.5


### PR DESCRIPTION
## Description
Prior to LOK-2091, it looks like the values used to create the `AlertSeverityFilters` component were a filtered array of `Severity` values:

```ts
const severitiesDisplay = ['critical', 'major', 'minor', 'warning', 'indeterminate']
const severities = Object.values(Severity).filter((s) => severitiesDisplay.includes(s.toLowerCase()))
```

It wasn't obvious, but the casing mattered; the `fetchCountAlerts` query, which these severities flow through, requires the enum value rather than a case-insensitive string. I've reverted the array to contain `Severity` types rather than strings, but in a more declarative way.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2203

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
