### PR TITLE
LOK-2091: Add top nodes pagination and csv download

### DIFF
--- a/ui/codegen.yml
+++ b/ui/codegen.yml
@@ -1,5 +1,8 @@
 overwrite: true
-schema: "https://onmshs.local:1443/api/graphql"
+schema:
+  - https://onmshs.local:1443/api/graphql:
+      headers:
+        Authorization: "Bearer <token>"
 documents: './src/graphql/**/*'
 generates:
   src/types/graphql.ts:

--- a/ui/src/components/Inventory/InventoryFilter.vue
+++ b/ui/src/components/Inventory/InventoryFilter.vue
@@ -38,7 +38,6 @@ import { useInventoryQueries } from '@/store/Queries/inventoryQueries'
 import { useTagQueries } from '@/store/Queries/tagQueries'
 import { Tag } from '@/types/graphql'
 import { PropType } from 'vue'
-import { FeatherButton } from '@featherds/button'
 import { useTagStore } from '@/store/Components/tagStore'
 const inventoryStore = useInventoryStore()
 const tagStore = useTagStore()

--- a/ui/src/graphql/Views/dashboardQueries.graphql
+++ b/ui/src/graphql/Views/dashboardQueries.graphql
@@ -5,11 +5,43 @@ query NetworkTraffic($name: String!, $timeRange: Int!, $timeRangeUnit: TimeRange
   }
 }
 
-query TopNNodes($timeRange: Int!, $timeRangeUnit: TimeRangeUnit!) {
-  topNNode(timeRange: $timeRange, timeRangeUnit: $timeRangeUnit) {
-    nodeLabel
-    location
-    avgResponseTime
-    reachability
+query NodeCount {
+  nodeCount
+}
+
+query TopNNodes(
+  $timeRange: Int!, 
+  $timeRangeUnit: TimeRangeUnit!, 
+  $sortAscending: Boolean!, 
+  $pageSize: Int, 
+  $sortBy: String, 
+  $page: Int) {
+  topNNode(
+    timeRange: $timeRange, 
+    timeRangeUnit: $timeRangeUnit, 
+    sortAscending: $sortAscending, 
+    pageSize: $pageSize, 
+    sortBy: $sortBy, 
+    page: $page) {
+      nodeLabel
+      location
+      avgResponseTime
+      reachability
+  }
+}
+
+query DownloadTopN(
+  $downloadFormat: DownloadFormat!
+  $timeRange: Int!, 
+  $timeRangeUnit: TimeRangeUnit!, 
+  $sortAscending: Boolean!, 
+  $sortBy: String) {
+  downloadTopN(
+    timeRange: $timeRange, 
+    timeRangeUnit: $timeRangeUnit, 
+    sortAscending: $sortAscending,
+    sortBy: $sortBy,
+    downloadFormat: $downloadFormat) {
+      topNBytes
   }
 }

--- a/ui/src/types/graphql.ts
+++ b/ui/src/types/graphql.ts
@@ -166,6 +166,10 @@ export enum DetectionMethod {
   Unrecognized = 'UNRECOGNIZED'
 }
 
+export enum DownloadFormat {
+  Csv = 'CSV'
+}
+
 export type Event = {
   __typename?: 'Event';
   eventInfo?: Maybe<EventInfo>;
@@ -630,6 +634,7 @@ export type Query = {
   /** Returns the total count of alerts filtered by severity and time. */
   countAlerts?: Maybe<CountAlertResponse>;
   defaultPolicy?: Maybe<MonitorPolicy>;
+  downloadTopN?: Maybe<TopNResponse>;
   findAllAlerts?: Maybe<ListAlertResponse>;
   findAllEvents?: Maybe<Array<Maybe<Event>>>;
   findAllLocations?: Maybe<Array<Maybe<MonitoringLocation>>>;
@@ -656,6 +661,7 @@ export type Query = {
   listMonitoryPolicies?: Maybe<Array<Maybe<MonitorPolicy>>>;
   locationByName?: Maybe<MonitoringLocation>;
   metric?: Maybe<TimeSeriesQueryResult>;
+  nodeCount?: Maybe<Scalars['Int']>;
   nodeStatus?: Maybe<NodeStatus>;
   passiveDiscoveries?: Maybe<Array<Maybe<PassiveDiscovery>>>;
   searchLocation?: Maybe<Array<Maybe<MonitoringLocation>>>;
@@ -684,6 +690,16 @@ export type QueryCountAlertByRuleIdArgs = {
 export type QueryCountAlertsArgs = {
   severityFilters?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   timeRange?: InputMaybe<TimeRange>;
+};
+
+
+/** Query root */
+export type QueryDownloadTopNArgs = {
+  downloadFormat?: InputMaybe<DownloadFormat>;
+  sortAscending: Scalars['Boolean'];
+  sortBy?: InputMaybe<Scalars['String']>;
+  timeRange?: InputMaybe<Scalars['Int']>;
+  timeRangeUnit?: InputMaybe<TimeRangeUnit>;
 };
 
 
@@ -857,6 +873,10 @@ export type QueryTagsByPassiveDiscoveryIdArgs = {
 
 /** Query root */
 export type QueryTopNNodeArgs = {
+  page?: InputMaybe<Scalars['Int']>;
+  pageSize?: InputMaybe<Scalars['Int']>;
+  sortAscending: Scalars['Boolean'];
+  sortBy?: InputMaybe<Scalars['String']>;
   timeRange?: InputMaybe<Scalars['Int']>;
   timeRangeUnit?: InputMaybe<TimeRangeUnit>;
 };
@@ -996,6 +1016,12 @@ export type TopNNode = {
   location?: Maybe<Scalars['String']>;
   nodeLabel?: Maybe<Scalars['String']>;
   reachability: Scalars['Float'];
+};
+
+export type TopNResponse = {
+  __typename?: 'TopNResponse';
+  downloadFormat?: Maybe<DownloadFormat>;
+  topNBytes?: Maybe<Scalars['Base64String']>;
 };
 
 export type TrafficSummary = {
@@ -1335,13 +1361,33 @@ export type NetworkTrafficQueryVariables = Exact<{
 
 export type NetworkTrafficQuery = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
 
+export type NodeCountQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type NodeCountQuery = { __typename?: 'Query', nodeCount?: number };
+
 export type TopNNodesQueryVariables = Exact<{
   timeRange: Scalars['Int'];
   timeRangeUnit: TimeRangeUnit;
+  sortAscending: Scalars['Boolean'];
+  pageSize?: InputMaybe<Scalars['Int']>;
+  sortBy?: InputMaybe<Scalars['String']>;
+  page?: InputMaybe<Scalars['Int']>;
 }>;
 
 
 export type TopNNodesQuery = { __typename?: 'Query', topNNode?: Array<{ __typename?: 'TopNNode', nodeLabel?: string, location?: string, avgResponseTime: number, reachability: number }> };
+
+export type DownloadTopNQueryVariables = Exact<{
+  downloadFormat: DownloadFormat;
+  timeRange: Scalars['Int'];
+  timeRangeUnit: TimeRangeUnit;
+  sortAscending: Scalars['Boolean'];
+  sortBy?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type DownloadTopNQuery = { __typename?: 'Query', downloadTopN?: { __typename?: 'TopNResponse', topNBytes?: any } };
 
 export type ListLocationsForDiscoveryQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1575,7 +1621,9 @@ export const ListMinionMetricsDocument = {"kind":"Document", "definitions":[{"ki
 export const ListNodeMetricsDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListNodeMetrics"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"instance"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodeLatencyParts"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodeStatusParts"}}]}},...NodeLatencyPartsFragmentDoc.definitions,...MetricPartsFragmentDoc.definitions,...NodeStatusPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListNodeMetricsQuery, ListNodeMetricsQueryVariables>;
 export const ListMinionsAndDevicesForTablesDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListMinionsAndDevicesForTables"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodesTableParts"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"MinionsTableParts"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"LocationsParts"}}]}},...NodesTablePartsFragmentDoc.definitions,...MinionsTablePartsFragmentDoc.definitions,...LocationsPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListMinionsAndDevicesForTablesQuery, ListMinionsAndDevicesForTablesQueryVariables>;
 export const NetworkTrafficDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"NetworkTraffic"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"MetricParts"}}]}}]}},...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<NetworkTrafficQuery, NetworkTrafficQueryVariables>;
-export const TopNNodesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TopNNodes"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"topNNode"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"avgResponseTime"}},{"kind":"Field","name":{"kind":"Name","value":"reachability"}}]}}]}}]} as unknown as DocumentNode<TopNNodesQuery, TopNNodesQueryVariables>;
+export const NodeCountDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"NodeCount"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodeCount"}}]}}]} as unknown as DocumentNode<NodeCountQuery, NodeCountQueryVariables>;
+export const TopNNodesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TopNNodes"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sortAscending"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"pageSize"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sortBy"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"page"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"topNNode"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}},{"kind":"Argument","name":{"kind":"Name","value":"sortAscending"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sortAscending"}}},{"kind":"Argument","name":{"kind":"Name","value":"pageSize"},"value":{"kind":"Variable","name":{"kind":"Name","value":"pageSize"}}},{"kind":"Argument","name":{"kind":"Name","value":"sortBy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sortBy"}}},{"kind":"Argument","name":{"kind":"Name","value":"page"},"value":{"kind":"Variable","name":{"kind":"Name","value":"page"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"avgResponseTime"}},{"kind":"Field","name":{"kind":"Name","value":"reachability"}}]}}]}}]} as unknown as DocumentNode<TopNNodesQuery, TopNNodesQueryVariables>;
+export const DownloadTopNDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"DownloadTopN"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"downloadFormat"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DownloadFormat"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sortAscending"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sortBy"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"downloadTopN"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}},{"kind":"Argument","name":{"kind":"Name","value":"sortAscending"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sortAscending"}}},{"kind":"Argument","name":{"kind":"Name","value":"sortBy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sortBy"}}},{"kind":"Argument","name":{"kind":"Name","value":"downloadFormat"},"value":{"kind":"Variable","name":{"kind":"Name","value":"downloadFormat"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"topNBytes"}}]}}]}}]} as unknown as DocumentNode<DownloadTopNQuery, DownloadTopNQueryVariables>;
 export const ListLocationsForDiscoveryDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListLocationsForDiscovery"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"LocationsParts"}}]}},...LocationsPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListLocationsForDiscoveryQuery, ListLocationsForDiscoveryQueryVariables>;
 export const ListDiscoveriesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListDiscoveries"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"passiveDiscoveries"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"locationId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"snmpCommunities"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPorts"}},{"kind":"Field","name":{"kind":"Name","value":"toggle"}}]}},{"kind":"Field","name":{"kind":"Name","value":"listActiveDiscovery"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"details"}},{"kind":"Field","name":{"kind":"Name","value":"discoveryType"}}]}}]}}]} as unknown as DocumentNode<ListDiscoveriesQuery, ListDiscoveriesQueryVariables>;
 export const TagsByActiveDiscoveryIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TagsByActiveDiscoveryId"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"discoveryId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tagsByActiveDiscoveryId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"activeDiscoveryId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"discoveryId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<TagsByActiveDiscoveryIdQuery, TagsByActiveDiscoveryIdQueryVariables>;


### PR DESCRIPTION
## Description
Part of LOK-2091 - Adds the top nodes pagination and csv download to the UI

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2091

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
