### PR TITLE
LOK-2204 open telemetry exception recording

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -110,7 +110,8 @@
         <netty4.version>4.1.78.Final</netty4.version>
         <opennms.tracker.version>0.7</opennms.tracker.version>
         <opentracing.version>0.31.0</opentracing.version>
-        <opentelemetry.version>1.25.0</opentelemetry.version>
+        <opentelemetry.version>1.32.0</opentelemetry.version>
+        <opentelemetry-semconv.version>1.23.1-alpha</opentelemetry-semconv.version>
         <org.osgi.service.jdbc.version>1.0.0</org.osgi.service.jdbc.version>
         <osgi.version>7.0.0</osgi.version>
         <micrometer.version>1.11.1</micrometer.version>
@@ -973,7 +974,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-semconv</artifactId>
-                <version>${opentelemetry.version}-alpha</version>
+                <version>${opentelemetry-semconv.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -161,6 +161,10 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/BffDataFetchExceptionHandler.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/graphql/BffDataFetchExceptionHandler.java
@@ -34,6 +34,8 @@ import graphql.execution.DataFetcherExceptionHandlerParameters;
 import graphql.execution.DataFetcherExceptionHandlerResult;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import lombok.extern.slf4j.Slf4j;
 import org.opennms.horizon.server.exception.GraphQLException;
 
@@ -49,6 +51,7 @@ import java.util.concurrent.CompletableFuture;
 public class BffDataFetchExceptionHandler implements DataFetcherExceptionHandler {
 
     /** {@inheritDoc} */
+    @WithSpan
     @Override
     public CompletableFuture<DataFetcherExceptionHandlerResult> handleException(
         DataFetcherExceptionHandlerParameters parameters
@@ -61,6 +64,7 @@ public class BffDataFetchExceptionHandler implements DataFetcherExceptionHandler
             parameters.getSourceLocation()
         );
 
+        Span.current().recordException(exception);
         log.warn("Caught exception during data fetching", exception);
 
         var result = DataFetcherExceptionHandlerResult


### PR DESCRIPTION
## Description

- Bumped version of opentelemetry to `1.32.0` (the latest)
- Added an explicit span to `BffDataFetchExceptionHandler`

**Explanation:** Upon diving deeper into the issue, the span that is marked as erroneous comes from the java-agents graphql instrumentation. It seems that the error is reported as a `graphql.ErrorType#DataFetchingException`, which despite its type, is _not actually_ an exception, but rather a classifier that indicates that a graphql data fetch was aborted due to an exception (as opposed to a validation error, being aborted, etc). [Otel source reference](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/3b77cc4b2de90ca821d53234e76ea8f279cfc34f/instrumentation/graphql-java-12.0/library/src/main/java/io/opentelemetry/instrumentation/graphql/v12_0/OpenTelemetryInstrumentation.java#L78).

If a new span is not created, the event is recorded in the parent span, which looks a little misleading. Therefore I created a new span, which records the exception after the `DataFetchingException` span:

![image](https://github.com/OpenNMS-Cloud/lokahi/assets/1214082/39dbe940-44fc-4d12-b037-2ea760ae0072)


## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2204

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
