### PR TITLE
Remove custom sql to distrubute tables

### DIFF
--- a/events/persistence/src/main/resources/db/changelog/hs-0.1.0/tables/eventTenantKey.xml
+++ b/events/persistence/src/main/resources/db/changelog/hs-0.1.0/tables/eventTenantKey.xml
@@ -18,16 +18,6 @@
 
         <dropPrimaryKey tableName="event"/>
         <addPrimaryKey tableName="event" columnNames="id, tenant_id" constraintName="pk_events_id"/>
-        <sql>DO
-             '
-             BEGIN
-             if exists(select 1 from pg_extension where extname = ''citus'') THEN
-               if exists(select * from master_get_active_worker_nodes()) THEN
-                 perform create_distributed_table(''event'', ''tenant_id'');
-               END IF;
-             END IF;
-             END; ';
-         </sql>
     </changeSet>
 
 </databaseChangeLog>

--- a/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/monitoringPolicyTenantKey.xml
+++ b/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/monitoringPolicyTenantKey.xml
@@ -18,17 +18,6 @@
 
         <dropPrimaryKey tableName="monitoring_policy"/>
         <addPrimaryKey tableName="monitoring_policy" columnNames="id, tenant_id" constraintName="pk_monitoring_policy_id"/>
-        <sql>DO
-             '
-             BEGIN
-             if exists(select 1 from pg_extension where extname = ''citus'') THEN
-               if exists(select * from master_get_active_worker_nodes()) THEN
-                 perform create_distributed_table(''monitoring_policy'', ''tenant_id'');
-               END IF;
-             END IF;
-             END; ';
-         </sql>
-
     </changeSet>
 
 </databaseChangeLog>

--- a/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/pagerDutyTenantKey.xml
+++ b/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/pagerDutyTenantKey.xml
@@ -8,26 +8,16 @@
 		http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
 	<changeSet author="jhutc" id="pager_duty_tenant_key_update">
-		<validCheckSum>ANY</validCheckSum>
-		<preConditions onFail="MARK_RAN">
-			<tableExists tableName="pager_duty_config" />
-            <primaryKeyExists primaryKeyName="pk_pager_duty_config_id"/>
+            <validCheckSum>ANY</validCheckSum>
+            <preConditions onFail="MARK_RAN">
+                <tableExists tableName="pager_duty_config" />
+                <primaryKeyExists primaryKeyName="pk_pager_duty_config_id"/>
             <tableExists tableName="monitoring_policy"/>
-        </preConditions>
+            </preConditions>
 
-        <dropPrimaryKey tableName="pager_duty_config"/>
-        <addPrimaryKey tableName="pager_duty_config" columnNames="id, tenant_id"
+            <dropPrimaryKey tableName="pager_duty_config"/>
+            <addPrimaryKey tableName="pager_duty_config" columnNames="id, tenant_id"
                        constraintName="pk_pager_duty_config_id"/>
-        <sql>DO
-             '
-             BEGIN
-             if exists(select 1 from pg_extension where extname = ''citus'') THEN
-               if exists(select * from master_get_active_worker_nodes()) THEN
-                 perform create_distributed_table(''pager_duty_config'', ''tenant_id'', colocate_with => ''monitoring_policy'');
-               END IF;
-             END IF;
-             END; ';
-         </sql>
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Description
Distributing the tables will lock in the distribution column/index types. As we want to change these in the future we will hold off distributing until then.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2169

## Flagged for review
The changesets appear to work even after modifying them. The checksum / all setting appears to allow this but we should look at removing it as the checksum provides valuable protections.

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
