### PR TITLE
release.sh: don't update develop

### DIFF
--- a/build-tools/release/release.sh
+++ b/build-tools/release/release.sh
@@ -73,8 +73,7 @@ git pull $PULL_FLAGS origin develop
 git checkout release
 git pull $PULL_FLAGS origin release
 
-# Do the rest of the work on develop, which we'll merge into release when we're done
-git checkout develop
+git merge --no-edit develop
 
 CHANGELOG="CHANGELOG/changelog-$CURRENT_TAG.md"
 
@@ -85,10 +84,7 @@ git log $PREVIOUS_TAG..HEAD --oneline --graph | grep 'Merge pull request' | sed 
 git add $CHANGELOG
 git commit -m "RELEASE $CURRENT_TAG - updated" $CHANGELOG
 
-git checkout release
-git merge --no-edit develop
 if [ $DRYRUN -eq 0 ]; then
-    git push origin develop
     git push origin release
 fi
 


### PR DESCRIPTION
This change stops trying to create CHANGELOG files in develop and just
creates them directly in release. I'll probably go back and remove the
CHANGELOG files in develop so there isn't confusion about why they
abruptly stopped there.

Previously, we got these errors when we tried to push to develop and it was
denied because we have required status checks for that branch:

    remote: error: GH006: Protected branch update failed for refs/heads/develop.
    remote: error: 18 of 18 required status checks are expected.

-- https://github.com/OpenNMS-Cloud/lokahi/actions/runs/7049125718/job/19186877109#step:3:425

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-XXXX

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
