### PR TITLE
LOK-2181: Add Mattermost notification when release is completed.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,3 +219,18 @@ jobs:
           docker push opennms/${{ matrix.image }}:latest
           docker push opennms/${{ matrix.image }}:${{ env.RELEASE_TAG }}
 
+  notify:
+    needs: [release, minion]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create the Mattermost Init Message
+        run: |
+          echo "{\"text\":\"Release ${{ env.RELEASE_TAG }} completed.\"}" > mattermost.json
+
+      - name: Post Init Message to Mattermost
+        uses: mattermost/action-mattermost-notify@master
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          MATTERMOST_CHANNEL: "horizon-stream-wg"
+          MATTERMOST_USERNAME: "github_actions"
+          MATTERMOST_ICON: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
MATTERMOST_WEBHOOK_URL secret has already been added to the repo (from `Mattermost DevOps/SRE Notifications Webhook` in bitwarden).

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2181

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
