### PR TITLE
LOK-2249: Make sure setup-env.sh fails cleanly on macOS with old bash and fix some assembly properties in the minion

### DIFF
--- a/charts/lokahi/scripts/opennms/minion/prepareLocationAndCerts.sh
+++ b/charts/lokahi/scripts/opennms/minion/prepareLocationAndCerts.sh
@@ -418,6 +418,12 @@ setup_curl_args ()
 set -eEuo pipefail
 trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
+if ! grep -q '^[4-9]\.' <<< "$BASH_VERSION"; then
+	echo "$(basename $0): Running on '$BASH_VERSION', but this needs to run on bash version 4 or higher." >&2
+	echo "If you are running on macOS, run 'brew install bash' and make sure Homebrew's bin directory is in your PATH." >&2
+	exit 1
+fi
+
 parse_command_line "$@"
 
 setup_curl_args

--- a/minion/assembly/src/main/resources/etc/org.opennms.core.ipc.grpc.client.cfg
+++ b/minion/assembly/src/main/resources/etc/org.opennms.core.ipc.grpc.client.cfg
@@ -8,7 +8,7 @@ grpc.client.keystore=${env:GRPC_CLIENT_KEYSTORE:-/opt/karaf/minion.p12}
 grpc.client.keystore.type=${env:GRPC_CLIENT_KEYSTORE_TYPE:-pkcs12}
 grpc.client.keystore.password=${env:GRPC_CLIENT_KEYSTORE_PASSWORD}
 grpc.client.truststore=${env:GRPC_CLIENT_TRUSTSTORE}
-grpc.client.truststore.type=${GRPC_CLIENT_TRUSTSTORE_TYPE:-file}
-grpc.client.truststore.password${GRPC_CLIENT_TRUSTSTORE_PASSWORD}
+grpc.client.truststore.type=${env:GRPC_CLIENT_TRUSTSTORE_TYPE:-file}
+grpc.client.truststore.password=${env:GRPC_CLIENT_TRUSTSTORE_PASSWORD}
 
 grpc.override.authority=${env:GRPC_CLIENT_OVERRIDE_AUTHORITY}


### PR DESCRIPTION
- LOK-2249: Make sure setup-env.sh fails cleanly on macOS with old bash
- Fix assembly properties in the minion

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2249

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
