### PR TITLE
Improve Docker container arm64 build support

### DIFF
--- a/build-tools/basic/mk-docker-images.sh
+++ b/build-tools/basic/mk-docker-images.sh
@@ -93,7 +93,9 @@ time {
 	echo "==="
 	echo "=== GRAFANA IMAGE"
 	echo "==="
-	docker build -t opennms/lokahi-grafana:local-basic grafana
+	docker build \
+		-t opennms/lokahi-grafana:local-basic \
+		grafana
 
 	echo ""
 	echo "==="

--- a/build-tools/basic/mk-docker-images.sh
+++ b/build-tools/basic/mk-docker-images.sh
@@ -104,7 +104,7 @@ time {
 	DOCKER_BUILDKIT=1 docker build \
 		--build-arg VITE_BASE_URL=http://localhost:14080 \
 		--build-arg VITE_KEYCLOAK_URL=http://localhost:26080 \
-		--target development \
+		--target production \
 		-t opennms/lokahi-ui:local-basic \
 		ui
 }

--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/CucumberRunnerIT.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/CucumberRunnerIT.java
@@ -105,7 +105,7 @@ public class CucumberRunnerIT {
 
         String alertHost = "opennms-alert";
         int alertPort = 4770;
-        mockAlertContainer = new GenericContainer<>(DockerImageName.parse("tkpd/gripmock"))
+        mockAlertContainer = new GenericContainer<>(DockerImageName.parse("tkpd/gripmock:v1.12.1"))
             .withNetwork(network)
             .withNetworkAliases(alertHost)
             .withExposedPorts(alertPort)

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -1191,6 +1191,30 @@
                 <jib.container.creationTime>USE_CURRENT_TIMESTAMP</jib.container.creationTime>
             </properties>
         </profile>
+
+        <profile>
+            <id>arch-amd64</id>
+            <activation>
+                <os>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <properties>
+                <jib.from.platforms>linux/amd64</jib.from.platforms>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>arch-arm64</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <jib.from.platforms>linux/arm64</jib.from.platforms>
+            </properties>
+        </profile>
     </profiles>
 
     <repositories>


### PR DESCRIPTION
- Use profiles with arch activation to set default Docker platforms
- We no longer have a development target for the ui container
- inventory CucumberRunnerIT: use v1.12.1 version of tkpd/gripmock with arm64 support

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-XXXX

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
