### PR TITLE
Tiny fix to tenant span attribute name

### DIFF
--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -28,6 +28,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- opentelemetry BOM needs to be first so it overrides older versions in spring-boot -->
+            <!-- this pulls in the right dependency versions for opentelemetry-sdk-testing -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -37,7 +46,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-	<dependencies>
+    <dependencies>
         <dependency>
             <groupId>org.opennms.lokahi.shared</groupId>
             <artifactId>spring-boot-logback-json</artifactId>
@@ -289,6 +298,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/notifications/src/main/java/org/opennms/horizon/notifications/service/NotificationService.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/service/NotificationService.java
@@ -64,7 +64,7 @@ public class NotificationService {
     @WithTenant(tenantIdArg = 0, tenantIdArgInternalMethod = "getTenantId", tenantIdArgInternalClass = "org.opennms.horizon.alerts.proto.Alert")
     public void postNotification(Alert alert) {
         Span span = Span.current();
-        span.setAttribute("tenantId", alert.getTenantId());
+        span.setAttribute("user", alert.getTenantId());
         span.setAttribute("alertId", alert.getDatabaseId());
 
         if (alert.getMonitoringPolicyIdList().isEmpty()) {


### PR DESCRIPTION
- We use 'user' everywhere else, so be consistent here, so we can find while searching.
- Add first test for tracing data -- in this case, that the tenant is set (as the "user" span attribute)

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-XXXX

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
