### PR TITLE
Fix intermittent off-by-one error in rest-service test

### DIFF
--- a/rest-server/src/main/java/org/opennms/horizon/server/service/metrics/QueryService.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/metrics/QueryService.java
@@ -88,8 +88,12 @@ public class QueryService {
     
     public String getQueryString(Optional<NodeDTO> node, String metricName, Map<String, String> labels,
                                  Integer timeRange, TimeRangeUnit timeRangeUnit) {
+        return getQueryString(node, metricName, labels, timeRange, timeRangeUnit, System.currentTimeMillis() / 1000L);
+    }
+
+    public String getQueryString(Optional<NodeDTO> node, String metricName, Map<String, String> labels,
+            Integer timeRange, TimeRangeUnit timeRangeUnit, long end) {
         if (isRangeQuery(metricName)) {
-            long end = System.currentTimeMillis() / 1000L;
             long start = end - getDuration(timeRange, timeRangeUnit).orElse(Duration.ofHours(24)).getSeconds();
             String rangeQuerySuffix = "&start=" + start + "&end=" + end +
                 "&step=2m";

--- a/rest-server/src/test/java/org/opennms/horizon/server/metrics/QueryServiceTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/metrics/QueryServiceTest.java
@@ -86,14 +86,17 @@ public class QueryServiceTest {
         long end = System.currentTimeMillis() / 1000L;
         long start = end - Duration.ofHours(24).getSeconds();
         QueryService queryService = new QueryService();
-        var bitsInQuery = queryService.getQueryString(Optional.empty(), TOTAL_NETWORK_BITS_IN, new HashMap<>(), 24, TimeRangeUnit.HOUR);
+
+        // We pass our 'end' value to ensure our start/end values match exactly
+        var bitsInQuery = queryService.getQueryString(Optional.empty(), TOTAL_NETWORK_BITS_IN, new HashMap<>(), 24, TimeRangeUnit.HOUR, end);
         var inSplitQuery = bitsInQuery.split("&");
         Assertions.assertEquals(QUERY_PREFIX + URLEncoder.encode(QUERY_FOR_TOTAL_NETWORK_BITS_IN, StandardCharsets.UTF_8), inSplitQuery[0]);
         Assertions.assertEquals("start=" + start, inSplitQuery[1]);
         Assertions.assertEquals("end=" + end, inSplitQuery[2]);
         Assertions.assertEquals("step=2m", inSplitQuery[3]);
 
-        var bitsOutQuery = queryService.getQueryString(Optional.empty(), TOTAL_NETWORK_BITS_OUT, new HashMap<>(), 24, TimeRangeUnit.HOUR);
+        // We pass our 'end' value to ensure our start/end values match exactly
+        var bitsOutQuery = queryService.getQueryString(Optional.empty(), TOTAL_NETWORK_BITS_OUT, new HashMap<>(), 24, TimeRangeUnit.HOUR, end);
         var outSplitQuery = bitsOutQuery.split("&");
         Assertions.assertEquals(QUERY_PREFIX + URLEncoder.encode(QUERY_FOR_TOTAL_NETWORK_BITS_OUT, StandardCharsets.UTF_8), outSplitQuery[0]);
         Assertions.assertEquals("start=" + start, outSplitQuery[1]);


### PR DESCRIPTION
QueryServiceTest.testTotalQuery computes its own start/end
values based on when it calls System.currentTimeMillis() and
QueryService.getQueryString also calls currentTimeMillis()
which will cause the expected result to be off on occasion:

    QueryServiceTest.testTotalQuery:99 expected: <start=1703196215> but was: <start=1703196216>

Add another method signature to getQueryString so we can pass
in our value of 'end' from our test to ensure the comparisions
always pass. This succeded for > 1 million runs for me, where
before it would fail around 10k - 100k runs.

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-XXXX

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
