### PR TITLE
LOK-2270: Update tilt to use manual trigger for all services

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -90,23 +90,6 @@ def jib_project(resource_name, image_name, base_path, k8s_resource_name, resourc
         labels=[resource_name]
 
 
-    #compile_resource_name = '{}:live-reload'.format(resource_name)
-
-    # This is the Tilt resource that compiles code for the purpose of rapid development.
-    #
-    # Triggers compilation when source files are changed. This produces compiled class files, which are copied in to the
-    # running container by the main Tilt resource.
-    #
-    # Disable this resource to turn off live reload. Trigger the main Tilt resource for full builds instead.
-    #local_resource(
-      #  compile_resource_name,
-     #   'mvn clean compile -f {} -am'.format(base_path),
-    #    deps=['{}/src'.format(base_path)],
-    #    ignore=['**/target'],
-    #    labels=labels,
-   # )
-
-
     # This is the image build part of the main Tilt resource.
     #
     # It will perform a full build and produces an image using Jib. This can be triggered manually when needed.

--- a/Tiltfile
+++ b/Tiltfile
@@ -90,7 +90,7 @@ def jib_project(resource_name, image_name, base_path, k8s_resource_name, resourc
         labels=[resource_name]
 
 
-    compile_resource_name = '{}:live-reload'.format(resource_name)
+    #compile_resource_name = '{}:live-reload'.format(resource_name)
 
     # This is the Tilt resource that compiles code for the purpose of rapid development.
     #
@@ -98,13 +98,13 @@ def jib_project(resource_name, image_name, base_path, k8s_resource_name, resourc
     # running container by the main Tilt resource.
     #
     # Disable this resource to turn off live reload. Trigger the main Tilt resource for full builds instead.
-    local_resource(
-        compile_resource_name,
-        'mvn clean compile -f {} -am'.format(base_path),
-        deps=['{}/src'.format(base_path)],
-        ignore=['**/target'],
-        labels=labels,
-    )
+    #local_resource(
+      #  compile_resource_name,
+     #   'mvn clean compile -f {} -am'.format(base_path),
+    #    deps=['{}/src'.format(base_path)],
+    #    ignore=['**/target'],
+    #    labels=labels,
+   # )
 
 
     # This is the image build part of the main Tilt resource.
@@ -135,9 +135,10 @@ def jib_project(resource_name, image_name, base_path, k8s_resource_name, resourc
         k8s_resource_name,
         new_name=resource_name,
         labels=labels,
-        resource_deps=resource_deps + [compile_resource_name],
+        resource_deps=resource_deps,
         links=links,
         port_forwards=port_forwards,
+        trigger_mode=TRIGGER_MODE_MANUAL,
     )
 
 def jib_project_multi_module(resource_name, image_name, base_path, k8s_resource_name, resource_deps=[], port_forwards=[], links=[], labels=None, submodule=None):


### PR DESCRIPTION
## Description
Update tilt to use manual trigger instead of auto update for every small change.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2270

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
