### PR TITLE
LOK-2232 BE: BFF: Discovery: GetDiscoveriesByNode

### DIFF
--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/model/Node.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/model/Node.java
@@ -46,6 +46,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import org.opennms.horizon.inventory.component.NodeKafkaProducer;
 import org.opennms.horizon.inventory.dto.MonitoredState;
 import org.opennms.taskset.contract.ScanType;
@@ -67,6 +69,10 @@ public class Node {
     @NotNull
     @Column(name = "tenant_id")
     private String tenantId;
+
+    @Column(name = "active_discovery_ids", columnDefinition = "bigint[]")
+    @JdbcTypeCode(SqlTypes.ARRAY)
+    private List<Long> discoveryIds = new ArrayList<>();
 
     @NotNull
     @Column(name = "node_label")

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseService.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.util.Strings;
 import org.opennms.horizon.azure.api.AzureScanItem;
 import org.opennms.horizon.azure.api.AzureScanNetworkInterfaceItem;
 import org.opennms.horizon.azure.api.AzureScanResponse;
-import org.opennms.horizon.inventory.dto.IpInterfaceDTO;
 import org.opennms.horizon.inventory.dto.ListTagsByEntityIdParamsDTO;
 import org.opennms.horizon.inventory.dto.MonitoredServiceDTO;
 import org.opennms.horizon.inventory.dto.MonitoredServiceTypeDTO;
@@ -149,11 +148,13 @@ public class ScannerResponseService {
                     .setManagementIp(pingResponse.getIpAddress())
                     .setLabel(pingResponse.getIpAddress())
                     .addAllTags(getTagCreateDTO(icmpDiscovery.getId(), tenantId))
+                    .addDiscoveryIds(icmpDiscovery.getId())
                     .build();
                 try {
                     var optionalNode = nodeService.getNode(pingResponse.getIpAddress(), locationId, tenantId);
                     if (optionalNode.isPresent()) {
                         var nodeDTO = optionalNode.get();
+                        //nodeDTO.getDiscoveryIDs().addDiscoveryIds(icmpDiscovery.getId());
                         tagService.addTags(tenantId, TagCreateListDTO.newBuilder()
                             .addEntityIds(TagEntityIdDTO.newBuilder()
                                 .setNodeId(nodeDTO.getId()))

--- a/inventory/main/src/main/resources/db/changelog/changelog.xml
+++ b/inventory/main/src/main/resources/db/changelog/changelog.xml
@@ -30,4 +30,5 @@
     <include file="db/changelog/hs-0.1.0/tables/monitored-service-state.xml" />
     <include file="db/changelog/hs-0.1.0/tables/azure-interface.xml"/>
     <include file="db/changelog/hs-0.1.0/tables/node-alias.xml"/>
+    <include file="db/changelog/hs-0.1.0/tables/node-active-discovery-ids.xml"/>
 </databaseChangeLog>

--- a/inventory/main/src/main/resources/db/changelog/hs-0.1.0/tables/node-active-discovery-ids.xml
+++ b/inventory/main/src/main/resources/db/changelog/hs-0.1.0/tables/node-active-discovery-ids.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="0.1.0-node-discoveries" author="shahidmunir">
+        <addColumn tableName="node">
+            <column name="active_discovery_ids" type="bigint[]" />
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/shared-lib/inventory/src/main/proto/nodeService.proto
+++ b/shared-lib/inventory/src/main/proto/nodeService.proto
@@ -57,6 +57,7 @@ message NodeDTO {
   repeated opennms.inventory.TagDTO tags = 16;
   string location = 17;
   optional string node_alias = 18;
+  repeated int64 discovery_ids = 19;
 }
 
 message NodeCreateDTO {
@@ -65,12 +66,14 @@ message NodeCreateDTO {
   optional string management_ip = 3;
   repeated opennms.inventory.TagCreateDTO tags = 4;
   optional MonitoredState monitored_state = 5; // optional for now - may change
+  repeated int64 discovery_ids = 6;
 }
 
 message NodeUpdateDTO {
   int64 id = 1;
   string tenant_id = 2;
   optional string node_alias = 3;
+  repeated int64 discovery_ids = 4;
 }
 
 enum MonitoredState {


### PR DESCRIPTION
## Description
This involves adding a field discoveryIds ( array of long) in Node table, entity ( Inventory Service) ( should be nullable)

set that field in ScannerResponseService#processDiscoveryScanResponse while creating node / updating node

Add a grpc service  GetDiscoveriesByNode in NodeGrpcService

Add GraphQL API in BFF (rest-server) for this.

Take care of Node being updated with null discoveryId when deleting Discovery.

Also take care of this for PassiveDiscovery while creating node (InternalEventConsumer#handleNewSuspectEvent)
## Jira link(s)
https://opennms.atlassian.net/browse/LOK-2232

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
