### PR TITLE
LOK-2300: Migrate to ESLint stylistic

### DIFF
--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -18,17 +18,18 @@
   },
   "plugins": [
     "vue",
-    "@typescript-eslint"
+    "@typescript-eslint",
+    "@stylistic"
   ],
   "rules": {
-    "vue/script-setup-uses-vars": "error",
-    "indent": ["error", 2, {"SwitchCase": 1}],
-      "semi": ["error", "never"],
-      "quotes": ["error", "single"],
-      "vue/html-quotes": [ "error", "double", { "avoidEscape": false } ],
-      "@typescript-eslint/no-explicit-any": "off",
-      "vue/multi-word-component-names": "off",
-      "comma-dangle": ["error", "never"]
+    "@stylistic/comma-dangle": ["error", "never"],
+    "@stylistic/indent": ["error", 2, { "SwitchCase": 1 }],
+    "@stylistic/quotes": ["error", "single"],
+    "@stylistic/semi": ["error", "never"],
+    "@typescript-eslint/no-explicit-any": "off",
+    "vue/html-quotes": ["error", "double", { "avoidEscape": false }],
+    "vue/multi-word-component-names": "off",
+    "vue/script-setup-uses-vars": "error"
   },
   "globals": {
     "defineProps": "readonly",

--- a/ui/mock-graphql/src/data/alerts.ts
+++ b/ui/mock-graphql/src/data/alerts.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import casual from 'casual'
 import { rndSeverity, rndDuration, rndNodeType } from '../helpers/random'

--- a/ui/mock-graphql/src/data/discovery.ts
+++ b/ui/mock-graphql/src/data/discovery.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import casual from 'casual'
 

--- a/ui/mock-graphql/src/data/minions.ts
+++ b/ui/mock-graphql/src/data/minions.ts
@@ -1,5 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import casual from 'casual'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { rndNumber, rndStatus, rndLatency, rndUptime } from '../helpers/random'
 
 casual.define('minion', function () {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "version": "0.0.0",
-  "license": "AGPL v3",
+  "license": "AGPL-3.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/ui/package.json
+++ b/ui/package.json
@@ -81,6 +81,7 @@
     "@graphql-codegen/typescript-operations": "^2.5.12",
     "@graphql-typed-document-node/core": "^3.1.1",
     "@pinia/testing": "^0.0.14",
+    "@stylistic/eslint-plugin": "^1.6.1",
     "@types/d3": "^7.4.0",
     "@types/leaflet": "1.9.4",
     "@types/lodash": "^4.14.191",

--- a/ui/src/components/Alerts/AlertsCard.vue
+++ b/ui/src/components/Alerts/AlertsCard.vue
@@ -95,6 +95,7 @@ const props = defineProps<{
   alert: IAlert
 }>()
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const pillColor = { style: props.alert.severity! }
 
 const alertSelectedHandler = (databaseId: number) => {

--- a/ui/src/components/Common/AtomicAutocomplete.vue
+++ b/ui/src/components/Common/AtomicAutocomplete.vue
@@ -79,6 +79,7 @@
 import Search from '@featherds/icon/action/Search'
 import KeyboardArrowDown from '@featherds/icon/navigation/ExpandMore'
 import { PropType } from 'vue'
+
 const wrapper = ref()
 const listRef = ref()
 const props = defineProps({
@@ -95,7 +96,7 @@ const props = defineProps({
   textChanged: { type: Function as PropType<(text: string) => void>, default: () => ({}) },
   wrapperClicked: { type: Function as PropType<() => void>, default: () => ({}) }
 })
-const log = console.log
+
 const disabledClass = computed(() => (props.disabled ? 'disabled' : ''))
 const keyDownCheck = (key: KeyboardEvent) => {
   if (key.key === 'ArrowDown') {
@@ -114,11 +115,13 @@ const itemKey = (keypress: KeyboardEvent, listItem: unknown, index: number) => {
     ;((keypress.target as HTMLInputElement)?.previousElementSibling as HTMLElement)?.focus()
   }
 }
+
 const wrapperClickCheck = () => {
   if (!props.disabled) {
     props.wrapperClicked()
   }
 }
+
 const shortenedList = computed(() => (props.results?.length > 10 ? props.results?.slice(0, 10) : props.results))
 </script>
 <style lang="scss" scoped>

--- a/ui/src/components/Common/ButtonWithSpinner.vue
+++ b/ui/src/components/Common/ButtonWithSpinner.vue
@@ -20,6 +20,7 @@ import { PropType } from 'vue'
 import { FeatherSpinner } from '@featherds/progress'
 
 defineProps({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   click: { type: Function as PropType<(...payload: any[]) => void>, default: () => {} },
   primary: { type: Boolean, default: false },
   secondary: { type: Boolean, default: false },

--- a/ui/src/components/Common/CollapsingCard.vue
+++ b/ui/src/components/Common/CollapsingCard.vue
@@ -20,12 +20,15 @@
 <script lang='ts' setup>
 import ExpandMore from '@featherds/icon/navigation/ExpandMore'
 import { PropType } from 'vue'
-const slots = useSlots();
+
+const slots = useSlots()
+
 defineOptions({ inheritAttrs: false })
+
 defineProps({
-    title: { type: String, default: '' },
-    open: { type: Boolean, default: false },
-    headerClicked: { type: Function as PropType<() => void>, default: () => ({}) }
+  title: { type: String, default: '' },
+  open: { type: Boolean, default: false },
+  headerClicked: { type: Function as PropType<() => void>, default: () => ({}) }
 })
 
 </script>

--- a/ui/src/components/Common/CollapsingWrapper.vue
+++ b/ui/src/components/Common/CollapsingWrapper.vue
@@ -9,9 +9,8 @@
 <script setup lang="ts">
 
 defineProps({
-    open: { type: Boolean, default: false },
+  open: { type: Boolean, default: false }
 })
-
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/Common/EditModal.vue
+++ b/ui/src/components/Common/EditModal.vue
@@ -34,7 +34,7 @@
 import { fncArgVoid } from '@/types'
 
 const input = ref()
-const newValue = ref("")
+const newValue = ref('')
 const isCalling = ref(false)
 
 const props = defineProps<{

--- a/ui/src/components/Common/MoreOptionsMenu.vue
+++ b/ui/src/components/Common/MoreOptionsMenu.vue
@@ -24,6 +24,7 @@
     </template>
     <FeatherDropdownItem
       v-for="item in items"
+      :key="item.label"
       data-test="dropdownItem"
       @click="item.handler"
     >

--- a/ui/src/components/Common/Stepper/CustomFeatherStepper.vue
+++ b/ui/src/components/Common/Stepper/CustomFeatherStepper.vue
@@ -23,7 +23,7 @@
 <template>
   <div class="container">
     <div class="stepper-container">
-      <template v-for="stepNum of stepNumbers">
+      <template v-for="stepNum of stepNumbers" :key="stepNum">
         <!-- circular step element with number -->
         <div class="step" 
           :class="{ 
@@ -57,24 +57,28 @@
 </template>
 
 <script setup lang="ts">
-import { render, VNode } from "vue"
+import { render, VNode } from 'vue'
+
 const slots = useSlots()
 const stepNumbers = ref<number[]>([])
 const currentStep = ref(1)
 const currentContent = ref<VNode>()
 
 const prevBtnText = computed(() => currentContent.value?.props?.prevBtnText || 'Prev')
+
 const nextBtnText = computed(() => {
   let text = 'Next'
   if (currentStep.value === stepNumbers.value.length) text = 'Finish'
   return currentContent.value?.props?.nextBtnText || text
 })
+
 const hideNextBtn = computed(() => {
   if (slots.default){
     // must call default slot to keep hideNextBtn prop reactive
     return slots.default()[currentStep.value - 1].props?.hideNextBtn
   }
 })
+
 const disableNextBtn = computed(() => {
   if (slots.default){
     // must call default slot to keep disableNextBtn prop reactive
@@ -88,6 +92,7 @@ const next = () => {
   currentStep.value++
   updateContent()
 }
+
 // exposed for explicit manual use
 const prev = () => {
   if (currentStep.value === 1) return

--- a/ui/src/components/Common/commonTypes.ts
+++ b/ui/src/components/Common/commonTypes.ts
@@ -1,22 +1,22 @@
 export interface ItemStatus {
-    title: string;
-    status: string;
-    statusColor: string;
-    statusText: string;
+  title: string;
+  status: string;
+  statusColor: string;
+  statusText: string;
 }
 
 export interface ItemPreviewProps {
-    loading: boolean;
-    loadingCopy: string;
-    title: string;
-    itemTitle: string;
-    itemSubtitle: string;
-    itemStatuses: ItemStatus[];
-    bottomCopy: string;
+  loading: boolean;
+  loadingCopy: string;
+  title: string;
+  itemTitle: string;
+  itemSubtitle: string;
+  itemStatuses: ItemStatus[];
+  bottomCopy: string;
 }
 
 export enum BadgeTypes {
-    info = 'indeterminate',
-    error = 'critical',
-    success = 'normal'
+  info = 'indeterminate',
+  error = 'critical',
+  success = 'normal'
 }

--- a/ui/src/components/Dashboard/dashboardNetworkTraffic.config.ts
+++ b/ui/src/components/Dashboard/dashboardNetworkTraffic.config.ts
@@ -1,4 +1,4 @@
-import { humanFileSizeFromBits } from "../utils"
+import { humanFileSizeFromBits } from '../utils'
 
 export const optionsGraph: any = {
   fill: true,

--- a/ui/src/components/Discovery/DiscoveryTypeSelector.vue
+++ b/ui/src/components/Discovery/DiscoveryTypeSelector.vue
@@ -133,7 +133,7 @@ const discoveryTypeList = [
         title: 'SNMP Traps',
         icon: AddNote,
         subtitle:
-          "Identify devices through events, flows, and indirectly by evaluating other devices' configuration settings.",
+          'Identify devices through events, flows, and indirectly by evaluating other devices\' configuration settings.',
         value: DiscoveryType.SyslogSNMPTraps
       }
     ]

--- a/ui/src/components/Discovery/discovery.text.ts
+++ b/ui/src/components/Discovery/discovery.text.ts
@@ -5,7 +5,7 @@ export default {
       add: 'Add Discovery'
     },
     empty: 'No discoveries performed.'
-  },
+  }
 }
 
 export const Instructions = {

--- a/ui/src/components/Graphs/LineGraph.vue
+++ b/ui/src/components/Graphs/LineGraph.vue
@@ -86,7 +86,7 @@ const options = computed<ChartOptions<any>>(() => ({
           return ''
         }
       }
-    },
+    }
   },
   scales: {
     y: {
@@ -95,7 +95,7 @@ const options = computed<ChartOptions<any>>(() => ({
         text: props.graph.label
       } as TitleOptions,
       ticks: {
-        callback: (value: any, index: any) => (formatAxisBasedOnType(value)),
+        callback: (value: any) => (formatAxisBasedOnType(value)),
         maxTicksLimit: 8,
         color: colorFromFeatherVar.value
       },

--- a/ui/src/components/Inventory/InventoryNodeTagEditOverlay.vue
+++ b/ui/src/components/Inventory/InventoryNodeTagEditOverlay.vue
@@ -42,8 +42,7 @@ const props = defineProps({
 
 const isChecked = computed(() => !!inventoryStore.nodesSelected.find((d) => d.id === props.node.id) || false)
 
-
-
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const storage: IIcon = {
   image: Storage,
   title: 'Node',
@@ -56,7 +55,6 @@ const storage: IIcon = {
 @use '@/styles/vars';
 
 .overlay {
-
   position: absolute;
   left: 0;
   top: 0;

--- a/ui/src/components/Locations/LocationsMinionsCard.vue
+++ b/ui/src/components/Locations/LocationsMinionsCard.vue
@@ -85,6 +85,7 @@ const latencyThreshold = (latency: number) => {
 
 let statusPill = reactive({} as Pill)
 let latencyPill = reactive({} as Pill)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 let ipPill = reactive({} as Pill)
 
 const minion = computed(() => {

--- a/ui/src/components/Map/LeafletMap.vue
+++ b/ui/src/components/Map/LeafletMap.vue
@@ -56,6 +56,7 @@ import { useMapStore } from '@/store/Views/mapStore'
 import useSpinner from '@/composables/useSpinner'
 import { Node } from '@/types/graphql'
 import useTheme from '@/composables/useTheme'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { Map as LeafletMap, divIcon, MarkerCluster as Cluster } from 'leaflet'
 import 'leaflet/dist/leaflet.css'
@@ -64,6 +65,7 @@ import { render, createVNode } from 'vue'
 import MapPin from './MapPin.vue'
 
 globalThis.L = L
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const { onThemeChange, isDark } = useTheme()
 const map = ref()
 const route = useRoute()
@@ -84,10 +86,12 @@ const bounds = computed(() => {
   const coordinatedMap = getNodeCoordinateMap.value
   return mapStore.nodesWithCoordinates.map((node: Node) => coordinatedMap.get(node?.id))
 })
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const nodeLabelAlarmServerityMap = computed(() => mapStore.getDeviceAlarmSeverityMap())
 
 const lightDarkFilter = computed(() => isDark.value ? 'invert(1) hue-rotate(180deg) grayscale(0.3)' : '')
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getHighestSeverity = (severitites: string[]) => {
   let highestSeverity = 'NORMAL'
   for (const severity of severitites) {
@@ -98,6 +102,7 @@ const getHighestSeverity = (severitites: string[]) => {
   return highestSeverity
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const onClusterUncluster = (t: any) => {
   nodeClusterCoords.value = {}
   t.target.refreshClusters()

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesEventCondition.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesEventCondition.vue
@@ -108,6 +108,7 @@ const props = defineProps<{
 
 const alertEventDefinitionStore = useAlertEventDefinitionQueries()
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const emit = defineEmits(['updateCondition', 'deleteCondition'])
 
 const alertCondition = ref(props.condition)

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesExistingItems.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesExistingItems.vue
@@ -6,6 +6,7 @@
     <div
       class="list"
       v-for="item in list"
+      :key="item.id"
     >
       <div
         class="card"

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesPolicyForm.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesPolicyForm.vue
@@ -131,8 +131,10 @@ const icons = markRaw({
   Delete
 })
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const selectTags = (tags: TagSelectItem[]) => (store.selectedPolicy!.tags = tags.map((tag) => tag.name))
 const populateForm = (policy: Policy) => store.displayPolicyForm(policy)
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const formattedTags = computed(() => store.selectedPolicy!.tags!.map((tag: string) => ({ name: tag, id: tag })))
 
 const countAlertsAndOpenDeleteModal = async (policy?: Policy) => {
@@ -144,7 +146,7 @@ const countAlertsAndOpenDeleteModal = async (policy?: Policy) => {
 }
 
 const deleteMsg = computed(() => 
-`Deleting monitoring policy ${store.selectedPolicy?.name} removes ${store.numOfAlertsForPolicy} associated alerts. Do you wish to proceed?`
+  `Deleting monitoring policy ${store.selectedPolicy?.name} removes ${store.numOfAlertsForPolicy} associated alerts. Do you wish to proceed?`
 )
 </script>
 

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
@@ -193,15 +193,20 @@ const eventTypeOptions = [
   { id: EventType.Internal, name: 'Internal' }
 ]
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const selectComponentType = (type: ManagedObjectType) => (store.selectedRule!.componentType = type)
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const selectThresholdMetric = (metric: string) => (store.selectedRule!.thresholdMetricName = metric)
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const selectEventType = (eventType: EventType) => (store.selectedRule!.eventType = eventType)
 const populateForm = async (rule: PolicyRule) => await store.displayRuleForm(rule)
 
 const selectDetectionMethod = async (method: DetectionMethod) => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   store.selectedRule!.detectionMethod = method
   await store.resetDefaultConditions()
 }
+
 const disableSaveRuleBtn = computed(
   () => store.selectedPolicy?.isDefault || !store.selectedRule?.name || !store.selectedRule?.alertConditions?.length
 )
@@ -212,7 +217,7 @@ const countAlertsAndOpenDeleteModal = async () => {
 }
 
 const deleteMsg = computed(() => 
-`Deleting rule ${store.selectedRule?.name} removes ${store.numOfAlertsForRule} associated alerts. Do you wish to proceed?`
+  `Deleting rule ${store.selectedRule?.name} removes ${store.numOfAlertsForRule} associated alerts. Do you wish to proceed?`
 )
 </script>
 

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesThresholdCondition.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesThresholdCondition.vue
@@ -109,6 +109,7 @@ const props = defineProps<{
   index: number
 }>()
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const emit = defineEmits(['updateCondition', 'deleteCondition'])
 const alertCondition = ref<ThresholdCondition>(props.condition)
 

--- a/ui/src/components/MonitoringPolicies/monitoringPolicies.constants.ts
+++ b/ui/src/components/MonitoringPolicies/monitoringPolicies.constants.ts
@@ -8,7 +8,7 @@ export enum ThresholdLevels {
   ABOVE = 'ABOVE',
   EQUAL_TO = 'EQUAL_TO',
   BELOW = 'BELOW',
-  NOT_EQUAL_TO = 'NOT_EQUAL_TO',
+  NOT_EQUAL_TO = 'NOT_EQUAL_TO'
 }
 
 export enum Unknowns {

--- a/ui/src/components/NodeStatus/EventsTable.vue
+++ b/ui/src/components/NodeStatus/EventsTable.vue
@@ -43,9 +43,11 @@ import {format as fnsFormat} from 'date-fns'
 const nodeStatusStore = useNodeStatusStore()
 
 // Pagination
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const page = ref(1)
 const pageSize = ref(10)
 const total = ref(0)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const updatePageSize = (v: number) => { pageSize.value = v }
   
 const nodeData = computed(() => {

--- a/ui/src/components/NodeStatus/NodeAlerts.vue
+++ b/ui/src/components/NodeStatus/NodeAlerts.vue
@@ -49,9 +49,8 @@ const alertData = ref<any[]>([
   { id: 1, type: 'Custom Severity 90', severity: 'Critical', date: '2/28/2023', time: '04:15.10 am est' },
   { id: 2, type: 'Custom Severity 90', severity: 'Critical', date: '2/28/2023', time: '04:15.10 am est' },
   { id: 3, type: 'Custom Severity 90', severity: 'Critical', date: '2/28/2023', time: '04:15.10 am est' },
-  { id: 4, type: 'Custom Severity 80', severity: 'Major', date: '2/28/2023', time: '04:15.10 am est' },
+  { id: 4, type: 'Custom Severity 80', severity: 'Major', date: '2/28/2023', time: '04:15.10 am est' }
 ])
-
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/UsageStats/OptInOutCtrl.vue
+++ b/ui/src/components/UsageStats/OptInOutCtrl.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup lang="ts">
-import Settings from "@featherds/icon/action/Settings"
+import Settings from '@featherds/icon/action/Settings'
 import useModal from '@/composables/useModal'
 // import { useUsageStatsMutations } from '@/store/Mutations/usageStatsMutations'
 // import { useUsageStatsQueries } from '@/store/Queries/usageStatsQueries'
@@ -57,7 +57,8 @@ const state = useStorage<{ showModalOnLoad: boolean } >('first-load', {
   showModalOnLoad: true
 })
 
-const opt = (choice: boolean = false) => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const opt = (choice = false) => {
   state.value.showModalOnLoad = false
 
   // usageStatsMutations.toggleUsageStats({ 

--- a/ui/src/components/Welcome/WelcomeSlideOne.vue
+++ b/ui/src/components/Welcome/WelcomeSlideOne.vue
@@ -85,7 +85,7 @@ import { useWelcomeStore } from '@/store/Views/welcomeStore'
 
 const welcomeStore = useWelcomeStore()
 defineProps({
-    visible: { type: Boolean, default: false }
+  visible: { type: Boolean, default: false }
 })
 </script>
 <style lang="scss" scoped>

--- a/ui/src/components/Welcome/WelcomeSlideThree.vue
+++ b/ui/src/components/Welcome/WelcomeSlideThree.vue
@@ -48,9 +48,11 @@
 <script lang="ts" setup>
 import { useWelcomeStore } from '@/store/Views/welcomeStore'
 import ItemPreview from '../Common/ItemPreview.vue'
+
 defineProps({
-    visible: { type: Boolean, default: false }
+  visible: { type: Boolean, default: false }
 })
+
 const welcomeStore = useWelcomeStore()
 </script>
 <style lang="scss" scoped>

--- a/ui/src/components/Welcome/WelcomeSlideTwo.vue
+++ b/ui/src/components/Welcome/WelcomeSlideTwo.vue
@@ -134,23 +134,24 @@ import CollapsingWrapper from '../Common/CollapsingWrapper.vue'
 import { FeatherSpinner } from '@featherds/progress'
 
 defineProps({
-    visible: { type: Boolean, default: false }
+  visible: { type: Boolean, default: false }
 })
 
 const icons = markRaw({
-    DownloadIcon,
-    InformationIcon,
-    CopyIcon,
-    CheckIcon
+  DownloadIcon,
+  InformationIcon,
+  CopyIcon,
+  CheckIcon
 })
 
 const localDownloadHandler = () => {
-    welcomeStore.downloadClick();
+  welcomeStore.downloadClick()
 }
 
 const welcomeStore = useWelcomeStore()
-const { isDark } = useTheme();
+const { isDark } = useTheme()
 </script>
+
 <style lang="scss" scoped>
 @import '@featherds/styles/themes/variables';
 @import '@featherds/styles/mixins/typography';

--- a/ui/src/components/utils.ts
+++ b/ui/src/components/utils.ts
@@ -102,7 +102,7 @@ export const humanFileSize = (bytes: number, si = true, dp = 1) => {
     ++u
   } while (Math.round(Math.abs(bytes) * r) / r >= thresh && u < units.length - 1)
 
-  return bytes.toFixed(dp) + ' ' + units[u];
+  return bytes.toFixed(dp) + ' ' + units[u]
 }
 
 export const addOpacity = (hex: string, opacity: number) => {
@@ -190,5 +190,5 @@ export const humanFileSizeFromBits = (bits: number, dp = 1) => {
     ++u
   } while (Math.round(Math.abs(bits) * r) / r >= thresh && u < units.length - 1)
 
-   return bits.toFixed(dp) + ' ' + units[u]
+  return bits.toFixed(dp) + ' ' + units[u]
 }

--- a/ui/src/composables/useWidgets.ts
+++ b/ui/src/composables/useWidgets.ts
@@ -24,7 +24,7 @@ const useWidgets = () => {
     widget: string,
     element: HTMLElement,
     props: { [x: string]: string } = {},
-    directory: string = 'Widgets',
+    directory = 'Widgets',
     styles?: { height: string }
   ) => {
     // async import a component from a given path

--- a/ui/src/containers/Graphs.vue
+++ b/ui/src/containers/Graphs.vue
@@ -27,10 +27,13 @@ const store = useGraphsQueries()
 const isAzure = computed(() => {
   return store.node.scanType === AZURE_SCAN
 })
+
 const instance = computed(() => {
   const snmpPrimaryIpAddress = store.node.ipInterfaces?.filter(({ snmpPrimary }) => snmpPrimary === true)[0]?.ipAddress
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return isAzure.value ? `azure-node-${store.node.id}` : snmpPrimaryIpAddress!
 })
+
 const monitor = computed(() => {
   return isAzure.value ? 'AZURE' : 'ICMP'
 })
@@ -97,6 +100,7 @@ const azureNodeBytesInOut = computed<GraphProps>(() => {
 
 const onDownload = () => {
   const page = document.getElementById('graphs-container') as HTMLElement
+  // eslint-disable-next-line no-undef
   const canvases = document.getElementsByClassName('canvas') as HTMLCollectionOf<HTMLCanvasElement>
   downloadMultipleCanvases(page, canvases)
 }

--- a/ui/src/containers/Locations.vue
+++ b/ui/src/containers/Locations.vue
@@ -59,7 +59,7 @@
     </div>
   </div>
   <LocationsInstructions
-    :instructionsType='instructionsType'
+    :instructionsType="instructionsType"
     :isOpen="showInstructions"
     @drawerClosed="() => (showInstructions = false)"
   />

--- a/ui/src/containers/Welcome.vue
+++ b/ui/src/containers/Welcome.vue
@@ -22,12 +22,13 @@ import WelcomeSlideTwo from '../components/Welcome/WelcomeSlideTwo.vue'
 import WelcomeSlideThree from '../components/Welcome/WelcomeSlideThree.vue'
 import { useWelcomeStore } from '@/store/Views/welcomeStore'
 import useTheme from '@/composables/useTheme'
+
 const welcomeStore = useWelcomeStore()
-const { isDark } = useTheme();
+const { isDark } = useTheme()
 
 const fullSequence = ['ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowRight', 'ArrowRight', 'ArrowRight']
 const inputtedSequence = ref<string[]>([])
-const router = useRouter();
+const router = useRouter()
 
 /**
  * Used to verify if we should be overriding the Welcome Guide
@@ -41,23 +42,25 @@ const router = useRouter();
  * @param keyValue A keyboard event from 'keyup' on addEventListener
  */
 const overrideChecker = (keyValue: KeyboardEvent) => {
-  let clear = false;
-  let totalExact = 0;
+  let clear = false
+  let totalExact = 0
 
   // Store the keypress key
   inputtedSequence.value.push(keyValue.key)
   for (let i = 0; i < inputtedSequence.value.length; i++) {
     // If we have something that doesn't match, we clear the sequence so the user can restart.
     if (inputtedSequence.value[i] !== fullSequence[i]) {
-      clear = true;
+      clear = true
     } else {
       totalExact += 1
     }
   }
+
   // We found an incorrect value in the sequence, reset.
   if (clear) {
     inputtedSequence.value = []
   }
+
   // The sequence is identical. Toggle the override value.
   if (totalExact === fullSequence.length) {
     if (sessionStorage.getItem('welcomeOverride') === 'true') {
@@ -68,17 +71,19 @@ const overrideChecker = (keyValue: KeyboardEvent) => {
     }
   }
 }
+
 onMounted(() => {
   window.addEventListener('keyup', overrideChecker)
   if (sessionStorage.getItem('welcomeOverride') === 'true') {
-    welcomeStore.init();
+    welcomeStore.init()
   }
 })
+
 onUnmounted(() => {
   window.removeEventListener('keyup', overrideChecker)
 })
-
 </script>
+
 <style lang="scss" scoped>
 @import '@featherds/styles/themes/variables';
 @import '@featherds/styles/mixins/typography';

--- a/ui/src/services/authService.ts
+++ b/ui/src/services/authService.ts
@@ -1,9 +1,7 @@
 import axios, { AxiosRequestHeaders } from 'axios'
-import useSpinner from '@/composables/useSpinner'
 import keycloakConfig from '../../keycloak.config'
 import useKeycloak from '@/composables/useKeycloak'
 
-const { startSpinner, stopSpinner } = useSpinner()
 const { keycloak } = useKeycloak()
 
 const auth = axios.create({

--- a/ui/src/services/gqlService.ts
+++ b/ui/src/services/gqlService.ts
@@ -82,7 +82,7 @@ const errorNotificationPlugin = definePlugin(({ afterQuery }) => {
     }
 
     const notificationMsg = () => {
-      const errorObj = errorsMsgs.filter(({ err }) => hasError(err))?.[0];
+      const errorObj = errorsMsgs.filter(({ err }) => hasError(err))?.[0]
 
       return (errorObj?.msg || 'An unknown error has occurred.') + traceDetails
     }

--- a/ui/src/store/Mutations/usageStatsMutations.ts
+++ b/ui/src/store/Mutations/usageStatsMutations.ts
@@ -1,5 +1,5 @@
-import { defineStore } from 'pinia'
-import { useMutation } from 'villus'
+// import { defineStore } from 'pinia'
+// import { useMutation } from 'villus'
 // import { ToggleUsageStatsReportDocument } from '@/types/graphql'
 
 // export const useUsageStatsMutations = defineStore('usageStatsMutations', () => {

--- a/ui/src/store/Queries/usageStatsQueries.ts
+++ b/ui/src/store/Queries/usageStatsQueries.ts
@@ -1,5 +1,5 @@
-import { defineStore } from 'pinia'
-import { useQuery } from 'villus'
+// import { defineStore } from 'pinia'
+// import { useQuery } from 'villus'
 // import { UsageStatsReportDocument } from '@/types/graphql'
 
 // export const useUsageStatsQueries = defineStore('usageStatsQueries', () => {

--- a/ui/src/store/Queries/welcomeQueries.ts
+++ b/ui/src/store/Queries/welcomeQueries.ts
@@ -1,76 +1,82 @@
-import { Monitor } from "@/types";
-import { DownloadMinionCertificateForWelcomeDocument, FindLocationsForWelcomeDocument, ListMinionsForTableDocument, ListNodeMetricsDocument, ListNodesForTableDocument, TimeRangeUnit } from "@/types/graphql";
-import { defineStore } from "pinia";
-import { useQuery } from "villus";
-
+import { Monitor } from '@/types'
+import {
+  DownloadMinionCertificateForWelcomeDocument,
+  FindLocationsForWelcomeDocument,
+  ListMinionsForTableDocument,
+  ListNodeMetricsDocument,
+  ListNodesForTableDocument,
+  TimeRangeUnit
+} from '@/types/graphql'
+import { defineStore } from 'pinia'
+import { useQuery } from 'villus'
 
 export const useWelcomeQueries = defineStore('welcomeQueries', () => {
+  const getAllMinions = async (): Promise<unknown[]> => {
+    const { execute } = useQuery({
+      query: ListMinionsForTableDocument,
+      cachePolicy: 'network-only'
+    })
 
-    const getAllMinions = async (): Promise<unknown[]> => {
-        const { execute } = useQuery({
-            query: ListMinionsForTableDocument,
-            cachePolicy: 'network-only'
-        });
+    const allMinions = await execute()
+    const rawResult = toRaw(allMinions.data)?.findAllMinions ?? []
+    return allMinions.error ? [] : rawResult
+  }
 
-        const allMinions = await execute();
-        const rawResult = toRaw(allMinions.data)?.findAllMinions ?? []
-        return allMinions.error ? [] : rawResult
-    }
+  const getLocationsForWelcome = async () => {
+    const { execute } = useQuery({
+      query: FindLocationsForWelcomeDocument,
+      cachePolicy: 'network-only',
+      fetchOnMount: false
+    })
 
-    const getLocationsForWelcome = async () => {
+    const response = await execute()
+    return toRaw(response?.data?.findAllLocations)?.map((d) => ({ id: d.id, location: d.location ?? '' })) ?? []
+  }
 
-        const { execute } = useQuery({
-            query: FindLocationsForWelcomeDocument,
-            cachePolicy: 'network-only',
-            fetchOnMount: false,
-        })
-        const response = await execute();
-        return toRaw(response?.data?.findAllLocations)?.map((d) => ({ id: d.id, location: d.location ?? '' })) ?? [];
-    }
+  const getMinionCertificate = async (locationId: number) => {
+    const { execute } = useQuery({
+      query: DownloadMinionCertificateForWelcomeDocument,
+      cachePolicy: 'network-only',
+      fetchOnMount: false,
+      variables: { location: locationId }
+    })
 
-    const getMinionCertificate = async (locationId: number) => {
+    const cert = await execute()
+    return { password: cert.data?.getMinionCertificate?.password, certificate: cert.data?.getMinionCertificate?.certificate }
+  }
 
-        const { execute } = useQuery({
-            query: DownloadMinionCertificateForWelcomeDocument,
-            cachePolicy: 'network-only',
-            fetchOnMount: false,
-            variables: { location: locationId }
-        })
-        const cert = await execute();
-        return { password: cert.data?.getMinionCertificate?.password, certificate: cert.data?.getMinionCertificate?.certificate };
-    }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const getNodeDetails = async (name: string) => {
+    const { execute: getDetails } = useQuery({
+      query: ListNodesForTableDocument,
+      cachePolicy: 'network-only',
+      fetchOnMount: false
+    })
 
-    const getNodeDetails = async (name: string) => {
+    const details = await getDetails()
+    const firstDetail = details?.data?.findAllNodes?.[0]
+    let metrics
 
-        const { execute: getDetails } = useQuery({
-            query: ListNodesForTableDocument,
-            cachePolicy: 'network-only',
-            fetchOnMount: false
-        })
-        const details = await getDetails();
-        const firstDetail = details?.data?.findAllNodes?.[0]
-        let metrics;
-        if (firstDetail) {
-            const { execute: getMetrics } = useQuery({
-                query: ListNodeMetricsDocument,
-                cachePolicy: 'network-only',
-                fetchOnMount: false,
-                variables: {
-                    id: firstDetail.id,
-                    instance: firstDetail.ipInterfaces?.[0].ipAddress ?? '',
-                    monitor: Monitor.ICMP, timeRange: 1, timeRangeUnit: TimeRangeUnit.Minute
-                }
-            })
-            metrics = await getMetrics();
+    if (firstDetail) {
+      const { execute: getMetrics } = useQuery({
+        query: ListNodeMetricsDocument,
+        cachePolicy: 'network-only',
+        fetchOnMount: false,
+        variables: {
+          id: firstDetail.id,
+          instance: firstDetail.ipInterfaces?.[0].ipAddress ?? '',
+          monitor: Monitor.ICMP, timeRange: 1, timeRangeUnit: TimeRangeUnit.Minute
         }
-        return { detail: firstDetail, metrics: metrics?.data }
+      })
+      metrics = await getMetrics()
     }
+    return { detail: firstDetail, metrics: metrics?.data }
+  }
 
-    return {
-        getAllMinions,
-        getLocationsForWelcome,
-        getMinionCertificate,
-        getNodeDetails
-    };
-
+  return {
+    getAllMinions,
+    getLocationsForWelcome,
+    getMinionCertificate,
+    getNodeDetails
+  }
 })

--- a/ui/src/store/Views/flowsApplicationStore.ts
+++ b/ui/src/store/Views/flowsApplicationStore.ts
@@ -46,26 +46,26 @@ export const useFlowsApplicationStore = defineStore('flowsApplicationStore', {
       const applicationsLineData = await flowsQueries.getApplicationsSeries(requestData)
 
       if (applicationsLineData.value?.findApplicationSeries) {
-        //Get Inbound Data
+        // Get Inbound Data
         this.lineInboundData =
           flowsAppDataToChartJSDirection(
             applicationsLineData.value?.findApplicationSeries as FlowsApplicationData[],
             'INGRESS'
           ) || []
 
-        //Get Outbound Data
+        // Get Outbound Data
         this.lineOutboundData =
           flowsAppDataToChartJSDirection(
             applicationsLineData.value?.findApplicationSeries as FlowsApplicationData[],
             'EGRESS'
           ) || []
 
-        //Get Total Data
+        // Get Total Data
         this.lineTotalData =
           flowsAppDataToChartJSTotal(applicationsLineData.value?.findApplicationSeries as FlowsApplicationData[]) || []
       }
 
-      //Get Total App Flows
+      // Get Total App Flows
       this.totalFlows = applicationsLineData.value?.findApplicationSeries?.length || 0
     },
     createApplicationTableChartData() {
@@ -104,8 +104,7 @@ export const useFlowsApplicationStore = defineStore('flowsApplicationStore', {
         const data = this.getLineChartDataForSelectedTraffic()
         const datasetArr = {
           type: 'line',
-          datasets: data?.map((element: any, index: number) => {
-
+          datasets: data?.map((element: any) => {
             const mappedData = [
               ...element.data.map((data: any) => {
                 return {

--- a/ui/src/store/Views/flowsStore.ts
+++ b/ui/src/store/Views/flowsStore.ts
@@ -177,6 +177,6 @@ export const useFlowsStore = defineStore('flowsStore', {
           }))
         this.filters.isExportersLoading = false
       }, 500)
-    },
+    }
   }
 })

--- a/ui/src/store/Views/inventoryStore.ts
+++ b/ui/src/store/Views/inventoryStore.ts
@@ -32,6 +32,7 @@ export const useInventoryStore = defineStore('inventoryStore', {
     },
     async filterNodesByTags() {
       const {getNodesByTags} = useInventoryQueries()
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const tags = this.tagsSelected.map((tag) => tag.name!)
       const nodes = await getNodesByTags(tags)
       const b = InventoryMapper.fromServer(nodes.value?.findAllNodesByTags as Array<NewInventoryNode>, nodes.value?.allMetrics as RawMetrics)

--- a/ui/src/store/Views/mapStore.ts
+++ b/ui/src/store/Views/mapStore.ts
@@ -13,6 +13,7 @@ export const useMapStore = defineStore('mapStore', () => {
   const nodesWithCoordinates = computed(() => mapQueries.nodes.filter((node: Node) => node.location?.latitude && node.location.longitude))
 
   const devicesInbounds = computed(() =>
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     mapQueries.nodes.filter((node: Node) => {
       return false
       // const location: LatLngLiteral = {
@@ -61,6 +62,6 @@ export const useMapStore = defineStore('mapStore', () => {
     deviceSortObject,
     alarmSortObject,
     fetchAlarms,
-    getDeviceAlarmSeverityMap,
+    getDeviceAlarmSeverityMap
   }
 })

--- a/ui/src/store/Views/monitoringPoliciesStore.ts
+++ b/ui/src/store/Views/monitoringPoliciesStore.ts
@@ -53,6 +53,7 @@ function getDefaultThresholdCondition(): ThresholdCondition {
 async function getDefaultEventCondition(): Promise<AlertCondition> {
   const alertEventDefinitionQueries = useAlertEventDefinitionQueries()
   const alertEventDefinitions = await alertEventDefinitionQueries.listAlertEventDefinitions(EventType.SnmpTrap)
+
   if (alertEventDefinitions.value?.listAlertEventDefinitions?.length) {
     return {
       id: new Date().getTime(),
@@ -62,7 +63,7 @@ async function getDefaultEventCondition(): Promise<AlertCondition> {
       triggerEvent: alertEventDefinitions.value.listAlertEventDefinitions[0]
     }
   } else {
-    throw Error("Can't load alertEventDefinitions")
+    throw Error('Can\'t load alertEventDefinitions')
   }
 }
 
@@ -100,7 +101,9 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       this.selectedRule = rule ? cloneDeep(rule) : await getDefaultRule()
     },
     async resetDefaultConditions() {
-      if (!this.selectedRule) return
+      if (!this.selectedRule) {
+        return
+      }
 
       // detection method THRESHOLD
       if (this.selectedRule.detectionMethod === DetectionMethod.Threshold) {
@@ -111,7 +114,9 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       return (this.selectedRule.alertConditions = [await getDefaultEventCondition()])
     },
     async addNewCondition() {
-      if (!this.selectedRule) return
+      if (!this.selectedRule) {
+        return
+      }
 
       // detection method THRESHOLD
       if (this.selectedRule.detectionMethod === DetectionMethod.Threshold) {
@@ -122,6 +127,7 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       return this.selectedRule.alertConditions?.push(await getDefaultEventCondition())
     },
     updateCondition(id: string, condition: Condition) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.selectedRule!.alertConditions?.map((currentCondition: AlertCondition) => {
         if (currentCondition.id === id) {
           return { ...currentCondition, ...condition }
@@ -130,18 +136,22 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       })
     },
     deleteCondition(id: string) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.selectedRule!.alertConditions = this.selectedRule!.alertConditions?.filter(
         (c: AlertCondition) => c.id !== id
       )
     },
     async saveRule() {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const existingItemIndex = findIndex(this.selectedPolicy!.rules, { id: this.selectedRule!.id })
 
       if (existingItemIndex !== -1) {
         // replace existing rule
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.selectedPolicy!.rules?.splice(existingItemIndex, 1, this.selectedRule!)
       } else {
         // add new rule
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.selectedPolicy!.rules?.push(this.selectedRule!)
       }
 
@@ -152,14 +162,21 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       const { addMonitoringPolicy, error } = useMonitoringPoliciesMutations()
 
       // modify payload to comply with current BE format
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const policy = cloneDeep(this.selectedPolicy!)
       policy.rules = policy.rules?.map((rule) => {
         rule.alertConditions = rule.alertConditions?.map((condition) => {
           if (!policy.id) delete condition.id // don't send generated ids
           return condition
         })
-        if (!policy.id) delete rule.id // don't send generated ids
-        if (policy.isDefault) delete policy.isDefault // for updating default (tags only)
+        if (!policy.id) {
+          delete rule.id // don't send generated ids
+        }
+
+        if (policy.isDefault) {
+          delete policy.isDefault // for updating default (tags only)
+        }
+
         return rule
       })
 
@@ -185,9 +202,11 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       const { deleteRule } = useMonitoringPoliciesMutations()
       await deleteRule({ id: this.selectedRule?.id })
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const ruleIndex = findIndex(this.selectedPolicy!.rules, { id: this.selectedRule!.id })
 
       if (ruleIndex !== -1) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         this.selectedPolicy!.rules?.splice(ruleIndex, 1)
       }
 

--- a/ui/src/store/Views/searchStore.ts
+++ b/ui/src/store/Views/searchStore.ts
@@ -11,6 +11,7 @@ export const useSearchStore = defineStore('searchStore', {
       searchResults: []
     },
   actions: {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars 
     async search(searchStr: string) {
       // todo: add graphQL query
       const responses = [] as SearchResultResponse[]

--- a/ui/src/store/Views/syntheticTransactionsStore.ts
+++ b/ui/src/store/Views/syntheticTransactionsStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 type TState = {}
 
 export const useSyntheticTransactionsStore = defineStore('syntheticTransactionsStore', {

--- a/ui/src/store/Views/topologyStore.ts
+++ b/ui/src/store/Views/topologyStore.ts
@@ -155,6 +155,7 @@ export const useTopologyStore = defineStore('topologyStore', {
       let resp: false | VerticesAndEdges
 
       try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const SZLRequest: SZLRequest = {
           semanticZoomLevel: this.semanticZoomLevel,
           verticesInFocus: this.focusObjects.map((obj) => obj.id)

--- a/ui/src/store/Views/welcomeStore.ts
+++ b/ui/src/store/Views/welcomeStore.ts
@@ -30,6 +30,7 @@ interface WelcomeStoreState {
   downloaded: boolean
   firstDiscovery: Record<string, string>
   firstDiscoveryErrors: Record<string, string>
+  // eslint-disable-next-line @typescript-eslint/ban-types
   firstDiscoveryValidation: yup.ObjectSchema<{}>,
   firstLocation: { id: number, location: string }
   invalidForm: boolean
@@ -122,7 +123,6 @@ export const useWelcomeStore = defineStore('welcomeStore', {
       }, 650)
     },
     buildItemStatus({ title, condition, status }: { title: string, status: string, condition: boolean }) {
-
       const successStatus = condition ? this.getSuccessStatus() : this.getFailureStatus()
 
       return {
@@ -135,9 +135,11 @@ export const useWelcomeStore = defineStore('welcomeStore', {
       const { getLocationsForWelcome } = useWelcomeQueries()
       const locations = await getLocationsForWelcome()
       const existingDefault = locations?.find((def: { location: string }) => def.location === 'default')
+
       if (!existingDefault) {
         const locationMutations = useLocationMutations()
         const { data } = await locationMutations.createLocation({ location: 'default' })
+
         if (data?.location && data?.id) {
           this.firstLocation = { location: data.location, id: data.id }
         }
@@ -178,7 +180,6 @@ export const useWelcomeStore = defineStore('welcomeStore', {
       this.minionErrorTimeout = window.setTimeout(() => {
         this.minionStatusCopy = 'Please wait while we detect your Minion. This can sometimes take more than 10 minutes.'
       }, 600000)
-
     },
     async getFirstNode() {
       const defaultLatency = 0

--- a/ui/src/types/discovery.d.ts
+++ b/ui/src/types/discovery.d.ts
@@ -40,8 +40,6 @@ export interface DiscoverySNMPV3AuthPrivacy extends DiscoverySNMPV3Auth {
   usePrivacyAsKey?: boolean;
 }
 
-
-
 export interface DiscoveryAzureMeta {
   clientId?: string;
   clientSecret?: string;
@@ -49,7 +47,7 @@ export interface DiscoveryAzureMeta {
   directoryId?: string;
 }
 
-export type DiscoveryMeta = DiscoverySNMPMeta | DiscoveryTrapMeta | DiscoveryAzureMeta;
+export type DiscoveryMeta = DiscoverySNMPMeta | DiscoveryTrapMeta | DiscoveryAzureMeta
 
 export interface NewOrUpdatedDiscovery {
   id?: number;
@@ -61,9 +59,22 @@ export interface NewOrUpdatedDiscovery {
 }
 
 export interface DiscoveryStoreErrors {
-  name?:string,tags?:string,locations?:string,locationId?:string,
-    ip?:string,communityString?:string,updPort?:string,clientId?:string,clientSubscription?:string,subscriptionId?:string,directoryId?:string, clientSecret?: string, password?: string, username?: string,context?: string, privacy?: string
-  
+  name?: string,
+  tags?: string,
+  locations?: string,
+  locationId?: string,
+  ip?: string,
+  communityString?: string,
+  updPort?: string,
+  clientId?: string,
+  clientSubscription?: string,
+  subscriptionId?: string,
+  directoryId?: string,
+  clientSecret?: string,
+  password?: string,
+  username?: string,
+  context?: string,
+  privacy?: string
 }
 
 export interface DiscoveryStore {
@@ -103,20 +114,20 @@ export interface ServerDiscovery {
       readCommunities:Array<string>,
     }}
 }
-export interface PassiveServerDiscovery {
 
+export interface PassiveServerDiscovery {
   id?: any; 
   locationId?: string | undefined;
-   name?: string | undefined; 
-   snmpCommunities?: string[] | undefined; 
-   snmpPorts?: number[] | undefined; toggle: boolean; 
-   tags?: Array<Tag>;
+  name?: string | undefined; 
+  snmpCommunities?: string[] | undefined; 
+  snmpPorts?: number[] | undefined; toggle: boolean; 
+  tags?: Array<Tag>;
 }
+
 export interface ServerDiscoveries {
   listActiveDiscovery?:Array<ServerDiscovery>;
   passiveDiscoveries?:Array<PassiveServerDiscovery>;
 }
-
 
 export interface IcmpActiveDiscoveryPlusTags extends IcmpActiveDiscovery {
   tags: Array<Tag>

--- a/ui/src/types/graphql-mocks.ts
+++ b/ui/src/types/graphql-mocks.ts
@@ -1,9 +1,10 @@
-import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
-export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+export type Maybe<T> = T | null
+export type InputMaybe<T> = Maybe<T>
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> }
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> }
+
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -11,7 +12,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-};
+}
 
 export type Alert = {
   __typename?: 'Alert';
@@ -26,7 +27,7 @@ export type Alert = {
   nodeType: Scalars['String'];
   severity: Scalars['String'];
   time: Scalars['String'];
-};
+}
 
 export type AzureDiscovery = {
   __typename?: 'AzureDiscovery';
@@ -37,30 +38,28 @@ export type AzureDiscovery = {
   name: Scalars['String'];
   subscriptionId: Scalars['String'];
   tags: Array<Maybe<Scalars['String']>>;
-};
+}
 
 export type Location = {
   __typename?: 'Location';
   id: Scalars['String'];
   location: Scalars['String'];
-};
+}
 
 export type Query = {
   __typename?: 'Query';
   alertsList: Array<Alert>;
   listAzureDiscoveries: Array<AzureDiscovery>;
-};
+}
 
-export type AlertsListQueryVariables = Exact<{ [key: string]: never; }>;
+export type AlertsListQueryVariables = Exact<{ [key: string]: never; }>
 
+export type AlertsListQuery = { __typename?: 'Query', alertsList: Array<{ __typename?: 'Alert', id: string, name: string, severity: string, cause: string, duration: string, nodeType: string, date: string, time: string, isAcknowledged: boolean, description: string }> }
 
-export type AlertsListQuery = { __typename?: 'Query', alertsList: Array<{ __typename?: 'Alert', id: string, name: string, severity: string, cause: string, duration: string, nodeType: string, date: string, time: string, isAcknowledged: boolean, description: string }> };
+export type ListAzureDiscoveriesQueryVariables = Exact<{ [key: string]: never; }>
 
-export type ListAzureDiscoveriesQueryVariables = Exact<{ [key: string]: never; }>;
+export type ListAzureDiscoveriesQuery = { __typename?: 'Query', listAzureDiscoveries: Array<{ __typename?: 'AzureDiscovery', id: string, name: string, clientId: string, directoryId: string, subscriptionId: string, tags: Array<string | null>, location: { __typename?: 'Location', id: string, location: string } }> }
 
+export const AlertsListDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'alertsList'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'alertsList'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'severity'}},{'kind':'Field','name':{'kind':'Name','value':'cause'}},{'kind':'Field','name':{'kind':'Name','value':'duration'}},{'kind':'Field','name':{'kind':'Name','value':'nodeType'}},{'kind':'Field','name':{'kind':'Name','value':'date'}},{'kind':'Field','name':{'kind':'Name','value':'time'}},{'kind':'Field','name':{'kind':'Name','value':'isAcknowledged'}},{'kind':'Field','name':{'kind':'Name','value':'description'}}]}}]}}]} as unknown as DocumentNode<AlertsListQuery, AlertsListQueryVariables>
 
-export type ListAzureDiscoveriesQuery = { __typename?: 'Query', listAzureDiscoveries: Array<{ __typename?: 'AzureDiscovery', id: string, name: string, clientId: string, directoryId: string, subscriptionId: string, tags: Array<string | null>, location: { __typename?: 'Location', id: string, location: string } }> };
-
-
-export const AlertsListDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"alertsList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"alertsList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"severity"}},{"kind":"Field","name":{"kind":"Name","value":"cause"}},{"kind":"Field","name":{"kind":"Name","value":"duration"}},{"kind":"Field","name":{"kind":"Name","value":"nodeType"}},{"kind":"Field","name":{"kind":"Name","value":"date"}},{"kind":"Field","name":{"kind":"Name","value":"time"}},{"kind":"Field","name":{"kind":"Name","value":"isAcknowledged"}},{"kind":"Field","name":{"kind":"Name","value":"description"}}]}}]}}]} as unknown as DocumentNode<AlertsListQuery, AlertsListQueryVariables>;
-export const ListAzureDiscoveriesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListAzureDiscoveries"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"listAzureDiscoveries"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"clientId"}},{"kind":"Field","name":{"kind":"Name","value":"directoryId"}},{"kind":"Field","name":{"kind":"Name","value":"subscriptionId"}},{"kind":"Field","name":{"kind":"Name","value":"tags"}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}}]}}]}}]} as unknown as DocumentNode<ListAzureDiscoveriesQuery, ListAzureDiscoveriesQueryVariables>;
+export const ListAzureDiscoveriesDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListAzureDiscoveries'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'listAzureDiscoveries'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'clientId'}},{'kind':'Field','name':{'kind':'Name','value':'directoryId'}},{'kind':'Field','name':{'kind':'Name','value':'subscriptionId'}},{'kind':'Field','name':{'kind':'Name','value':'tags'}},{'kind':'Field','name':{'kind':'Name','value':'location'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}}]}}]}}]} as unknown as DocumentNode<ListAzureDiscoveriesQuery, ListAzureDiscoveriesQueryVariables>

--- a/ui/src/types/graphql.ts
+++ b/ui/src/types/graphql.ts
@@ -1,9 +1,11 @@
-import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
-export type Maybe<T> = T;
-export type InputMaybe<T> = T;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+
+export type Maybe<T> = T
+export type InputMaybe<T> = T
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> }
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> }
+
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -17,13 +19,13 @@ export type Scalars = {
   Long: any;
   Map_String_LongScalar: any;
   Map_String_StringScalar: any;
-};
+}
 
 export type ActiveDiscovery = {
   __typename?: 'ActiveDiscovery';
   details?: Maybe<Scalars['Json']>;
   discoveryType?: Maybe<Scalars['String']>;
-};
+}
 
 export type Alert = {
   __typename?: 'Alert';
@@ -48,7 +50,7 @@ export type Alert = {
   severity?: Maybe<Severity>;
   type?: Maybe<AlertType>;
   uei?: Maybe<Scalars['String']>;
-};
+}
 
 export type AlertCondition = {
   __typename?: 'AlertCondition';
@@ -59,7 +61,7 @@ export type AlertCondition = {
   overtimeUnit?: Maybe<Scalars['String']>;
   severity?: Maybe<Scalars['String']>;
   triggerEvent?: Maybe<AlertEventDefinition>;
-};
+}
 
 export type AlertConditionInput = {
   clearEvent?: InputMaybe<AlertEventDefinitionInput>;
@@ -69,20 +71,20 @@ export type AlertConditionInput = {
   overtimeUnit?: InputMaybe<Scalars['String']>;
   severity?: InputMaybe<Scalars['String']>;
   triggerEvent?: InputMaybe<AlertEventDefinitionInput>;
-};
+}
 
 export type AlertCount = {
   __typename?: 'AlertCount';
   acknowledgedCount?: Maybe<Scalars['Long']>;
   countBySeverity?: Maybe<Scalars['Map_String_LongScalar']>;
   totalAlertCount?: Maybe<Scalars['Long']>;
-};
+}
 
 export type AlertError = {
   __typename?: 'AlertError';
   databaseId: Scalars['Long'];
   error?: Maybe<Scalars['String']>;
-};
+}
 
 export type AlertEventDefinition = {
   __typename?: 'AlertEventDefinition';
@@ -92,7 +94,7 @@ export type AlertEventDefinition = {
   name?: Maybe<Scalars['String']>;
   reductionKey?: Maybe<Scalars['String']>;
   uei?: Maybe<Scalars['String']>;
-};
+}
 
 export type AlertEventDefinitionInput = {
   clearKey?: InputMaybe<Scalars['String']>;
@@ -101,13 +103,13 @@ export type AlertEventDefinitionInput = {
   name?: InputMaybe<Scalars['String']>;
   reductionKey?: InputMaybe<Scalars['String']>;
   uei?: InputMaybe<Scalars['String']>;
-};
+}
 
 export type AlertResponse = {
   __typename?: 'AlertResponse';
   alertErrorList?: Maybe<Array<Maybe<AlertError>>>;
   alertList?: Maybe<Array<Maybe<Alert>>>;
-};
+}
 
 export enum AlertType {
   AlarmTypeUndefined = 'ALARM_TYPE_UNDEFINED',
@@ -126,7 +128,7 @@ export type AzureActiveDiscovery = {
   locationId?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   subscriptionId?: Maybe<Scalars['String']>;
-};
+}
 
 export type AzureActiveDiscoveryCreateInput = {
   clientId?: InputMaybe<Scalars['String']>;
@@ -136,7 +138,7 @@ export type AzureActiveDiscoveryCreateInput = {
   name?: InputMaybe<Scalars['String']>;
   subscriptionId?: InputMaybe<Scalars['String']>;
   tags?: InputMaybe<Array<InputMaybe<TagCreateInput>>>;
-};
+}
 
 export type AzureInterface = {
   __typename?: 'AzureInterface';
@@ -148,25 +150,25 @@ export type AzureInterface = {
   publicIpAddress?: Maybe<Scalars['String']>;
   publicIpId?: Maybe<Scalars['String']>;
   tenantId?: Maybe<Scalars['String']>;
-};
+}
 
 export type CertificateResponse = {
   __typename?: 'CertificateResponse';
   certificate?: Maybe<Scalars['Base64String']>;
   password?: Maybe<Scalars['String']>;
-};
+}
 
 export type CountAlertResponse = {
   __typename?: 'CountAlertResponse';
   count: Scalars['Int'];
   error?: Maybe<Scalars['String']>;
-};
+}
 
 export type DeleteAlertResponse = {
   __typename?: 'DeleteAlertResponse';
   alertDatabaseIdList?: Maybe<Array<Maybe<Scalars['Long']>>>;
   alertErrorList?: Maybe<Array<Maybe<AlertError>>>;
-};
+}
 
 export enum DetectionMethod {
   Event = 'EVENT',
@@ -187,12 +189,12 @@ export type Event = {
   nodeId: Scalars['Int'];
   producedTime: Scalars['Long'];
   uei?: Maybe<Scalars['String']>;
-};
+}
 
 export type EventInfo = {
   __typename?: 'EventInfo';
   snmp?: Maybe<SnmpInfo>;
-};
+}
 
 export type EventParameter = {
   __typename?: 'EventParameter';
@@ -200,7 +202,7 @@ export type EventParameter = {
   name?: Maybe<Scalars['String']>;
   type?: Maybe<Scalars['String']>;
   value?: Maybe<Scalars['String']>;
-};
+}
 
 export enum EventType {
   Internal = 'INTERNAL',
@@ -213,12 +215,12 @@ export type Exporter = {
   ipInterface?: Maybe<IpInterface>;
   node?: Maybe<Node>;
   snmpInterface?: Maybe<SnmpInterface>;
-};
+}
 
 export type ExporterFilterInput = {
   ipInterfaceId?: InputMaybe<Scalars['Long']>;
   nodeId?: InputMaybe<Scalars['Long']>;
-};
+}
 
 export type FlowingPoint = {
   __typename?: 'FlowingPoint';
@@ -226,7 +228,7 @@ export type FlowingPoint = {
   label?: Maybe<Scalars['String']>;
   timestamp?: Maybe<Scalars['Instant']>;
   value: Scalars['Float'];
-};
+}
 
 export type IcmpActiveDiscovery = {
   __typename?: 'IcmpActiveDiscovery';
@@ -235,7 +237,7 @@ export type IcmpActiveDiscovery = {
   locationId?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   snmpConfig?: Maybe<SnmpConfig>;
-};
+}
 
 export type IcmpActiveDiscoveryCreateInput = {
   id?: InputMaybe<Scalars['Long']>;
@@ -244,7 +246,7 @@ export type IcmpActiveDiscoveryCreateInput = {
   name?: InputMaybe<Scalars['String']>;
   snmpConfig?: InputMaybe<SnmpConfigInput>;
   tags?: InputMaybe<Array<InputMaybe<TagCreateInput>>>;
-};
+}
 
 export type IpInterface = {
   __typename?: 'IpInterface';
@@ -255,7 +257,7 @@ export type IpInterface = {
   netmask?: Maybe<Scalars['String']>;
   nodeId: Scalars['Long'];
   snmpPrimary?: Maybe<Scalars['Boolean']>;
-};
+}
 
 export type ListAlertResponse = {
   __typename?: 'ListAlertResponse';
@@ -263,20 +265,20 @@ export type ListAlertResponse = {
   lastPage: Scalars['Int'];
   nextPage: Scalars['Int'];
   totalAlerts: Scalars['Long'];
-};
+}
 
 export type ManagedObject = {
   __typename?: 'ManagedObject';
   instance?: Maybe<ManagedObjectInstance>;
   type?: Maybe<ManagedObjectType>;
-};
+}
 
 export type ManagedObjectInstance = {
   __typename?: 'ManagedObjectInstance';
   nodeVal?: Maybe<NodeRef>;
   snmpInterfaceLinkVal?: Maybe<SnmpInterfaceLinkRef>;
   snmpInterfaceVal?: Maybe<SnmpInterfaceRef>;
-};
+}
 
 export enum ManagedObjectType {
   Any = 'ANY',
@@ -296,7 +298,7 @@ export type Minion = {
   locationId: Scalars['Long'];
   status?: Maybe<Scalars['String']>;
   systemId?: Maybe<Scalars['String']>;
-};
+}
 
 export type MonitorPolicy = {
   __typename?: 'MonitorPolicy';
@@ -309,7 +311,7 @@ export type MonitorPolicy = {
   notifyInstruction?: Maybe<Scalars['String']>;
   rules?: Maybe<Array<Maybe<PolicyRule>>>;
   tags?: Maybe<Array<Maybe<Scalars['String']>>>;
-};
+}
 
 export type MonitorPolicyInput = {
   id?: InputMaybe<Scalars['Long']>;
@@ -321,7 +323,7 @@ export type MonitorPolicyInput = {
   notifyInstruction?: InputMaybe<Scalars['String']>;
   rules?: InputMaybe<Array<InputMaybe<PolicyRuleInput>>>;
   tags?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-};
+}
 
 export type MonitoringLocation = {
   __typename?: 'MonitoringLocation';
@@ -330,14 +332,14 @@ export type MonitoringLocation = {
   latitude?: Maybe<Scalars['Float']>;
   location?: Maybe<Scalars['String']>;
   longitude?: Maybe<Scalars['Float']>;
-};
+}
 
 export type MonitoringLocationCreateInput = {
   address?: InputMaybe<Scalars['String']>;
   latitude?: InputMaybe<Scalars['Float']>;
   location?: InputMaybe<Scalars['String']>;
   longitude?: InputMaybe<Scalars['Float']>;
-};
+}
 
 export type MonitoringLocationUpdateInput = {
   address?: InputMaybe<Scalars['String']>;
@@ -345,7 +347,7 @@ export type MonitoringLocationUpdateInput = {
   latitude?: InputMaybe<Scalars['Float']>;
   location?: InputMaybe<Scalars['String']>;
   longitude?: InputMaybe<Scalars['Float']>;
-};
+}
 
 /** Mutation root */
 export type Mutation = {
@@ -377,169 +379,142 @@ export type Mutation = {
   updateNode?: Maybe<Scalars['Long']>;
   upsertIcmpActiveDiscovery?: Maybe<IcmpActiveDiscovery>;
   upsertPassiveDiscovery?: Maybe<PassiveDiscovery>;
-};
-
+}
 
 /** Mutation root */
 export type MutationAcknowledgeAlertArgs = {
   ids?: InputMaybe<Array<InputMaybe<Scalars['Long']>>>;
-};
-
+}
 
 /** Mutation root */
 export type MutationAddNodeArgs = {
   node?: InputMaybe<NodeCreateInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationAddTagsToNodesArgs = {
   tags?: InputMaybe<TagListNodesAddInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationClearAlertArgs = {
   ids?: InputMaybe<Array<InputMaybe<Scalars['Long']>>>;
-};
-
+}
 
 /** Mutation root */
 export type MutationCreateAzureActiveDiscoveryArgs = {
   discovery?: InputMaybe<AzureActiveDiscoveryCreateInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationCreateIcmpActiveDiscoveryArgs = {
   request?: InputMaybe<IcmpActiveDiscoveryCreateInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationCreateLocationArgs = {
   location?: InputMaybe<MonitoringLocationCreateInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationCreateMonitorPolicyArgs = {
   policy?: InputMaybe<MonitorPolicyInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationDeleteAlertArgs = {
   ids?: InputMaybe<Array<InputMaybe<Scalars['Long']>>>;
-};
-
+}
 
 /** Mutation root */
 export type MutationDeleteIcmpActiveDiscoveryArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Mutation root */
 export type MutationDeleteLocationArgs = {
   id: Scalars['Long'];
-};
-
+}
 
 /** Mutation root */
 export type MutationDeleteMinionArgs = {
   id: Scalars['Long'];
-};
-
+}
 
 /** Mutation root */
 export type MutationDeleteNodeArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Mutation root */
 export type MutationDeletePassiveDiscoveryArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Mutation root */
 export type MutationDeletePolicyByIdArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Mutation root */
 export type MutationDeleteRuleByIdArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Mutation root */
 export type MutationDiscoveryByNodeIdsArgs = {
   ids?: InputMaybe<Array<InputMaybe<Scalars['Long']>>>;
-};
-
+}
 
 /** Mutation root */
 export type MutationEscalateAlertArgs = {
   ids?: InputMaybe<Array<InputMaybe<Scalars['Long']>>>;
-};
-
+}
 
 /** Mutation root */
 export type MutationRemoveTagsFromNodesArgs = {
   tags?: InputMaybe<TagListNodesRemoveInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationRevokeMinionCertificateArgs = {
   locationId?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Mutation root */
 export type MutationSavePagerDutyConfigArgs = {
   config?: InputMaybe<PagerDutyConfigInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationTogglePassiveDiscoveryArgs = {
   toggle?: InputMaybe<PassiveDiscoveryToggleInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationUnacknowledgeAlertArgs = {
   ids?: InputMaybe<Array<InputMaybe<Scalars['Long']>>>;
-};
-
+}
 
 /** Mutation root */
 export type MutationUpdateLocationArgs = {
   location?: InputMaybe<MonitoringLocationUpdateInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationUpdateNodeArgs = {
   node?: InputMaybe<NodeUpdateInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationUpsertIcmpActiveDiscoveryArgs = {
   request?: InputMaybe<IcmpActiveDiscoveryCreateInput>;
-};
-
+}
 
 /** Mutation root */
 export type MutationUpsertPassiveDiscoveryArgs = {
   discovery?: InputMaybe<PassiveDiscoveryUpsertInput>;
-};
+}
 
 export type Node = {
   __typename?: 'Node';
@@ -560,40 +535,40 @@ export type Node = {
   systemLocation?: Maybe<Scalars['String']>;
   systemName?: Maybe<Scalars['String']>;
   tags?: Maybe<Array<Maybe<Tag>>>;
-};
+}
 
 export type NodeCreateInput = {
   label?: InputMaybe<Scalars['String']>;
   locationId?: InputMaybe<Scalars['String']>;
   managementIp?: InputMaybe<Scalars['String']>;
   tags?: InputMaybe<Array<InputMaybe<TagCreateInput>>>;
-};
+}
 
 export type NodeRef = {
   __typename?: 'NodeRef';
   nodeID: Scalars['Long'];
-};
+}
 
 export type NodeStatus = {
   __typename?: 'NodeStatus';
   id: Scalars['Long'];
   status?: Maybe<Scalars['String']>;
-};
+}
 
 export type NodeTags = {
   __typename?: 'NodeTags';
   nodeId: Scalars['Long'];
   tags?: Maybe<Array<Maybe<Tag>>>;
-};
+}
 
 export type NodeUpdateInput = {
   id: Scalars['Long'];
   nodeAlias?: InputMaybe<Scalars['String']>;
-};
+}
 
 export type PagerDutyConfigInput = {
   integrationkey?: InputMaybe<Scalars['String']>;
-};
+}
 
 export type PassiveDiscovery = {
   __typename?: 'PassiveDiscovery';
@@ -604,18 +579,18 @@ export type PassiveDiscovery = {
   snmpCommunities?: Maybe<Array<Maybe<Scalars['String']>>>;
   snmpPorts?: Maybe<Array<Maybe<Scalars['Int']>>>;
   toggle: Scalars['Boolean'];
-};
+}
 
 export type PassiveDiscoveryToggle = {
   __typename?: 'PassiveDiscoveryToggle';
   id: Scalars['Long'];
   toggle: Scalars['Boolean'];
-};
+}
 
 export type PassiveDiscoveryToggleInput = {
   id: Scalars['Long'];
   toggle: Scalars['Boolean'];
-};
+}
 
 export type PassiveDiscoveryUpsertInput = {
   id?: InputMaybe<Scalars['Long']>;
@@ -624,7 +599,7 @@ export type PassiveDiscoveryUpsertInput = {
   snmpCommunities?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   snmpPorts?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
   tags?: InputMaybe<Array<InputMaybe<TagCreateInput>>>;
-};
+}
 
 export type PolicyRule = {
   __typename?: 'PolicyRule';
@@ -635,7 +610,7 @@ export type PolicyRule = {
   id?: Maybe<Scalars['Long']>;
   name?: Maybe<Scalars['String']>;
   thresholdMetricName?: Maybe<Scalars['String']>;
-};
+}
 
 export type PolicyRuleInput = {
   alertConditions?: InputMaybe<Array<InputMaybe<AlertConditionInput>>>;
@@ -645,7 +620,7 @@ export type PolicyRuleInput = {
   id?: InputMaybe<Scalars['Long']>;
   name?: InputMaybe<Scalars['String']>;
   thresholdMetricName?: InputMaybe<Scalars['String']>;
-};
+}
 
 /** Query root */
 export type Query = {
@@ -694,27 +669,23 @@ export type Query = {
   tagsByNodeIds?: Maybe<Array<Maybe<NodeTags>>>;
   tagsByPassiveDiscoveryId?: Maybe<Array<Maybe<Tag>>>;
   topNNode?: Maybe<Array<Maybe<TopNNode>>>;
-};
-
+}
 
 /** Query root */
 export type QueryCountAlertByPolicyIdArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Query root */
 export type QueryCountAlertByRuleIdArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Query root */
 export type QueryCountAlertsArgs = {
   severityFilters?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   timeRange?: InputMaybe<TimeRange>;
-};
-
+}
 
 /** Query root */
 export type QueryDownloadTopNArgs = {
@@ -723,8 +694,7 @@ export type QueryDownloadTopNArgs = {
   sortBy?: InputMaybe<Scalars['String']>;
   timeRange?: InputMaybe<Scalars['Int']>;
   timeRangeUnit?: InputMaybe<TimeRangeUnit>;
-};
-
+}
 
 /** Query root */
 export type QueryFindAllAlertsArgs = {
@@ -735,110 +705,92 @@ export type QueryFindAllAlertsArgs = {
   sortAscending: Scalars['Boolean'];
   sortBy?: InputMaybe<Scalars['String']>;
   timeRange?: InputMaybe<TimeRange>;
-};
-
+}
 
 /** Query root */
 export type QueryFindAllNodesByMonitoredStateArgs = {
   monitoredState?: InputMaybe<Scalars['String']>;
-};
-
+}
 
 /** Query root */
 export type QueryFindAllNodesByNodeLabelSearchArgs = {
   labelSearchTerm?: InputMaybe<Scalars['String']>;
-};
-
+}
 
 /** Query root */
 export type QueryFindAllNodesByTagsArgs = {
   tags?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-};
-
+}
 
 /** Query root */
 export type QueryFindApplicationSeriesArgs = {
   requestCriteria?: InputMaybe<RequestCriteriaInput>;
-};
-
+}
 
 /** Query root */
 export type QueryFindApplicationSummariesArgs = {
   requestCriteria?: InputMaybe<RequestCriteriaInput>;
-};
-
+}
 
 /** Query root */
 export type QueryFindApplicationsArgs = {
   requestCriteria?: InputMaybe<RequestCriteriaInput>;
-};
-
+}
 
 /** Query root */
 export type QueryFindEventsByNodeIdArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Query root */
 export type QueryFindExportersArgs = {
   requestCriteria?: InputMaybe<RequestCriteriaInput>;
-};
-
+}
 
 /** Query root */
 export type QueryFindLocationByIdArgs = {
   id: Scalars['Long'];
-};
-
+}
 
 /** Query root */
 export type QueryFindMinionByIdArgs = {
   id: Scalars['Long'];
-};
-
+}
 
 /** Query root */
 export type QueryFindMinionsByLocationIdArgs = {
   locationId: Scalars['Long'];
-};
-
+}
 
 /** Query root */
 export type QueryFindMonitorPolicyByIdArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Query root */
 export type QueryFindNodeByIdArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Query root */
 export type QueryGetMinionCertificateArgs = {
   locationId?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Query root */
 export type QueryIcmpActiveDiscoveryByIdArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Query root */
 export type QueryListAlertEventDefinitionsArgs = {
   eventType?: InputMaybe<EventType>;
-};
-
+}
 
 /** Query root */
 export type QueryLocationByNameArgs = {
   locationName?: InputMaybe<Scalars['String']>;
-};
-
+}
 
 /** Query root */
 export type QueryMetricArgs = {
@@ -846,53 +798,45 @@ export type QueryMetricArgs = {
   name?: InputMaybe<Scalars['String']>;
   timeRange?: InputMaybe<Scalars['Int']>;
   timeRangeUnit?: InputMaybe<TimeRangeUnit>;
-};
-
+}
 
 /** Query root */
 export type QueryNodeStatusArgs = {
   id?: InputMaybe<Scalars['Long']>;
-};
-
+}
 
 /** Query root */
 export type QuerySearchLocationArgs = {
   searchTerm?: InputMaybe<Scalars['String']>;
-};
-
+}
 
 /** Query root */
 export type QueryTagsArgs = {
   searchTerm?: InputMaybe<Scalars['String']>;
-};
-
+}
 
 /** Query root */
 export type QueryTagsByActiveDiscoveryIdArgs = {
   activeDiscoveryId?: InputMaybe<Scalars['Long']>;
   searchTerm?: InputMaybe<Scalars['String']>;
-};
-
+}
 
 /** Query root */
 export type QueryTagsByNodeIdArgs = {
   nodeId?: InputMaybe<Scalars['Long']>;
   searchTerm?: InputMaybe<Scalars['String']>;
-};
-
+}
 
 /** Query root */
 export type QueryTagsByNodeIdsArgs = {
   nodeIds?: InputMaybe<Array<InputMaybe<Scalars['Long']>>>;
-};
-
+}
 
 /** Query root */
 export type QueryTagsByPassiveDiscoveryIdArgs = {
   passiveDiscoveryId?: InputMaybe<Scalars['Long']>;
   searchTerm?: InputMaybe<Scalars['String']>;
-};
-
+}
 
 /** Query root */
 export type QueryTopNNodeArgs = {
@@ -902,7 +846,7 @@ export type QueryTopNNodeArgs = {
   sortBy?: InputMaybe<Scalars['String']>;
   timeRange?: InputMaybe<Scalars['Int']>;
   timeRangeUnit?: InputMaybe<TimeRangeUnit>;
-};
+}
 
 export type RequestCriteriaInput = {
   applications?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
@@ -911,18 +855,18 @@ export type RequestCriteriaInput = {
   includeOther?: InputMaybe<Scalars['Boolean']>;
   step?: InputMaybe<Scalars['Int']>;
   timeRange?: InputMaybe<TimeRangeInput>;
-};
+}
 
 export type SnmpConfig = {
   __typename?: 'SNMPConfig';
   ports?: Maybe<Array<Maybe<Scalars['Int']>>>;
   readCommunities?: Maybe<Array<Maybe<Scalars['String']>>>;
-};
+}
 
 export type SnmpConfigInput = {
   ports?: InputMaybe<Array<InputMaybe<Scalars['Int']>>>;
   readCommunities?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-};
+}
 
 export enum Severity {
   Cleared = 'CLEARED',
@@ -944,7 +888,7 @@ export type SnmpInfo = {
   specific: Scalars['Int'];
   trapOid?: Maybe<Scalars['String']>;
   version?: Maybe<Scalars['String']>;
-};
+}
 
 export type SnmpInterface = {
   __typename?: 'SnmpInterface';
@@ -960,52 +904,52 @@ export type SnmpInterface = {
   ipAddress?: Maybe<Scalars['String']>;
   nodeId: Scalars['Long'];
   physicalAddr?: Maybe<Scalars['String']>;
-};
+}
 
 export type SnmpInterfaceLinkRef = {
   __typename?: 'SnmpInterfaceLinkRef';
   ifA?: Maybe<SnmpInterfaceRef>;
   ifB?: Maybe<SnmpInterfaceRef>;
-};
+}
 
 export type SnmpInterfaceRef = {
   __typename?: 'SnmpInterfaceRef';
   ifIndex: Scalars['Long'];
   node?: Maybe<NodeRef>;
-};
+}
 
 export type TsData = {
   __typename?: 'TSData';
   result?: Maybe<Array<Maybe<TsResult>>>;
   resultType?: Maybe<Scalars['String']>;
-};
+}
 
 export type TsResult = {
   __typename?: 'TSResult';
   metric?: Maybe<Scalars['Map_String_StringScalar']>;
   value?: Maybe<Array<Maybe<Scalars['Float']>>>;
   values?: Maybe<Array<Maybe<Array<Maybe<Scalars['Float']>>>>>;
-};
+}
 
 export type Tag = {
   __typename?: 'Tag';
   id: Scalars['Long'];
   name?: Maybe<Scalars['String']>;
-};
+}
 
 export type TagCreateInput = {
   name?: InputMaybe<Scalars['String']>;
-};
+}
 
 export type TagListNodesAddInput = {
   nodeIds?: InputMaybe<Array<InputMaybe<Scalars['Long']>>>;
   tags?: InputMaybe<Array<InputMaybe<TagCreateInput>>>;
-};
+}
 
 export type TagListNodesRemoveInput = {
   nodeIds?: InputMaybe<Array<InputMaybe<Scalars['Long']>>>;
   tagIds?: InputMaybe<Array<InputMaybe<Scalars['Long']>>>;
-};
+}
 
 export enum TimeRange {
   All = 'ALL',
@@ -1017,7 +961,7 @@ export enum TimeRange {
 export type TimeRangeInput = {
   endTime?: InputMaybe<Scalars['Instant']>;
   startTime?: InputMaybe<Scalars['Instant']>;
-};
+}
 
 export enum TimeRangeUnit {
   Day = 'DAY',
@@ -1031,7 +975,7 @@ export type TimeSeriesQueryResult = {
   __typename?: 'TimeSeriesQueryResult';
   data?: Maybe<TsData>;
   status?: Maybe<Scalars['String']>;
-};
+}
 
 export type TopNNode = {
   __typename?: 'TopNNode';
@@ -1039,36 +983,34 @@ export type TopNNode = {
   location?: Maybe<Scalars['String']>;
   nodeLabel?: Maybe<Scalars['String']>;
   reachability: Scalars['Float'];
-};
+}
 
 export type TopNResponse = {
   __typename?: 'TopNResponse';
   downloadFormat?: Maybe<DownloadFormat>;
   topNBytes?: Maybe<Scalars['Base64String']>;
-};
+}
 
 export type TrafficSummary = {
   __typename?: 'TrafficSummary';
   bytesIn: Scalars['Long'];
   bytesOut: Scalars['Long'];
   label?: Maybe<Scalars['String']>;
-};
+}
 
 export type AcknowledgeAlertsMutationVariables = Exact<{
   ids?: InputMaybe<Array<InputMaybe<Scalars['Long']>> | InputMaybe<Scalars['Long']>>;
-}>;
+}>
 
-
-export type AcknowledgeAlertsMutation = { __typename?: 'Mutation', acknowledgeAlert?: { __typename?: 'AlertResponse', alertList?: Array<{ __typename?: 'Alert', acknowledged: boolean, databaseId: any }>, alertErrorList?: Array<{ __typename?: 'AlertError', databaseId: any, error?: string }> } };
+export type AcknowledgeAlertsMutation = { __typename?: 'Mutation', acknowledgeAlert?: { __typename?: 'AlertResponse', alertList?: Array<{ __typename?: 'Alert', acknowledged: boolean, databaseId: any }>, alertErrorList?: Array<{ __typename?: 'AlertError', databaseId: any, error?: string }> } }
 
 export type ClearAlertsMutationVariables = Exact<{
   ids?: InputMaybe<Array<InputMaybe<Scalars['Long']>> | InputMaybe<Scalars['Long']>>;
-}>;
+}>
 
+export type ClearAlertsMutation = { __typename?: 'Mutation', clearAlert?: { __typename?: 'AlertResponse', alertList?: Array<{ __typename?: 'Alert', acknowledged: boolean, databaseId: any }>, alertErrorList?: Array<{ __typename?: 'AlertError', databaseId: any, error?: string }> } }
 
-export type ClearAlertsMutation = { __typename?: 'Mutation', clearAlert?: { __typename?: 'AlertResponse', alertList?: Array<{ __typename?: 'Alert', acknowledged: boolean, databaseId: any }>, alertErrorList?: Array<{ __typename?: 'AlertError', databaseId: any, error?: string }> } };
-
-export type AlertsPartsFragment = { __typename?: 'Query', findAllAlerts?: { __typename?: 'ListAlertResponse', lastPage: number, nextPage: number, totalAlerts: any, alerts?: Array<{ __typename?: 'Alert', acknowledged: boolean, description?: string, firstEventTimeMs: any, lastUpdateTimeMs: any, severity?: Severity, label?: string, nodeName?: string, databaseId: any, location?: string, ruleNameList?: Array<string>, policyNameList?: Array<string> }> } };
+export type AlertsPartsFragment = { __typename?: 'Query', findAllAlerts?: { __typename?: 'ListAlertResponse', lastPage: number, nextPage: number, totalAlerts: any, alerts?: Array<{ __typename?: 'Alert', acknowledged: boolean, description?: string, firstEventTimeMs: any, lastUpdateTimeMs: any, severity?: Severity, label?: string, nodeName?: string, databaseId: any, location?: string, ruleNameList?: Array<string>, policyNameList?: Array<string> }> } }
 
 export type AlertsListQueryVariables = Exact<{
   page: Scalars['Int'];
@@ -1078,298 +1020,259 @@ export type AlertsListQueryVariables = Exact<{
   sortBy?: InputMaybe<Scalars['String']>;
   timeRange: TimeRange;
   nodeLabel?: InputMaybe<Scalars['String']>;
-}>;
+}>
 
-
-export type AlertsListQuery = { __typename?: 'Query', findAllAlerts?: { __typename?: 'ListAlertResponse', lastPage: number, nextPage: number, totalAlerts: any, alerts?: Array<{ __typename?: 'Alert', acknowledged: boolean, description?: string, firstEventTimeMs: any, lastUpdateTimeMs: any, severity?: Severity, label?: string, nodeName?: string, databaseId: any, location?: string, ruleNameList?: Array<string>, policyNameList?: Array<string> }> } };
+export type AlertsListQuery = { __typename?: 'Query', findAllAlerts?: { __typename?: 'ListAlertResponse', lastPage: number, nextPage: number, totalAlerts: any, alerts?: Array<{ __typename?: 'Alert', acknowledged: boolean, description?: string, firstEventTimeMs: any, lastUpdateTimeMs: any, severity?: Severity, label?: string, nodeName?: string, databaseId: any, location?: string, ruleNameList?: Array<string>, policyNameList?: Array<string> }> } }
 
 export type CountAlertsQueryVariables = Exact<{
   severityFilters?: InputMaybe<Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>>;
   timeRange: TimeRange;
-}>;
+}>
 
+export type CountAlertsQuery = { __typename?: 'Query', countAlerts?: { __typename?: 'CountAlertResponse', count: number, error?: string } }
 
-export type CountAlertsQuery = { __typename?: 'Query', countAlerts?: { __typename?: 'CountAlertResponse', count: number, error?: string } };
+export type AlertCountsQueryVariables = Exact<{ [key: string]: never; }>
 
-export type AlertCountsQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type AlertCountsQuery = { __typename?: 'Query', alertCounts?: { __typename?: 'AlertCount', acknowledgedCount?: any, totalAlertCount?: any, countBySeverity?: any } };
+export type AlertCountsQuery = { __typename?: 'Query', alertCounts?: { __typename?: 'AlertCount', acknowledgedCount?: any, totalAlertCount?: any, countBySeverity?: any } }
 
 export type CreateAzureActiveDiscoveryMutationVariables = Exact<{
   discovery: AzureActiveDiscoveryCreateInput;
-}>;
+}>
 
-
-export type CreateAzureActiveDiscoveryMutation = { __typename?: 'Mutation', createAzureActiveDiscovery?: { __typename?: 'AzureActiveDiscovery', createTimeMsec?: any, locationId?: string, subscriptionId?: string, clientId?: string } };
+export type CreateAzureActiveDiscoveryMutation = { __typename?: 'Mutation', createAzureActiveDiscovery?: { __typename?: 'AzureActiveDiscovery', createTimeMsec?: any, locationId?: string, subscriptionId?: string, clientId?: string } }
 
 export type CreateIcmpActiveDiscoveryMutationVariables = Exact<{
   request: IcmpActiveDiscoveryCreateInput;
-}>;
+}>
 
-
-export type CreateIcmpActiveDiscoveryMutation = { __typename?: 'Mutation', createIcmpActiveDiscovery?: { __typename?: 'IcmpActiveDiscovery', name?: string, ipAddresses?: Array<string>, locationId?: string, snmpConfig?: { __typename?: 'SNMPConfig', ports?: Array<number>, readCommunities?: Array<string> } } };
+export type CreateIcmpActiveDiscoveryMutation = { __typename?: 'Mutation', createIcmpActiveDiscovery?: { __typename?: 'IcmpActiveDiscovery', name?: string, ipAddresses?: Array<string>, locationId?: string, snmpConfig?: { __typename?: 'SNMPConfig', ports?: Array<number>, readCommunities?: Array<string> } } }
 
 export type CreateOrUpdateActiveIcmpDiscoveryMutationVariables = Exact<{
   request: IcmpActiveDiscoveryCreateInput;
-}>;
+}>
 
-
-export type CreateOrUpdateActiveIcmpDiscoveryMutation = { __typename?: 'Mutation', upsertIcmpActiveDiscovery?: { __typename?: 'IcmpActiveDiscovery', id: any, name?: string, ipAddresses?: Array<string>, locationId?: string, snmpConfig?: { __typename?: 'SNMPConfig', ports?: Array<number>, readCommunities?: Array<string> } } };
+export type CreateOrUpdateActiveIcmpDiscoveryMutation = { __typename?: 'Mutation', upsertIcmpActiveDiscovery?: { __typename?: 'IcmpActiveDiscovery', id: any, name?: string, ipAddresses?: Array<string>, locationId?: string, snmpConfig?: { __typename?: 'SNMPConfig', ports?: Array<number>, readCommunities?: Array<string> } } }
 
 export type DeleteActiveIcmpDiscoveryMutationVariables = Exact<{
   id: Scalars['Long'];
-}>;
+}>
 
-
-export type DeleteActiveIcmpDiscoveryMutation = { __typename?: 'Mutation', deleteIcmpActiveDiscovery?: boolean };
+export type DeleteActiveIcmpDiscoveryMutation = { __typename?: 'Mutation', deleteIcmpActiveDiscovery?: boolean }
 
 export type TogglePassiveDiscoveryMutationVariables = Exact<{
   toggle: PassiveDiscoveryToggleInput;
-}>;
+}>
 
-
-export type TogglePassiveDiscoveryMutation = { __typename?: 'Mutation', togglePassiveDiscovery?: { __typename?: 'PassiveDiscoveryToggle', id: any, toggle: boolean } };
+export type TogglePassiveDiscoveryMutation = { __typename?: 'Mutation', togglePassiveDiscovery?: { __typename?: 'PassiveDiscoveryToggle', id: any, toggle: boolean } }
 
 export type UpsertPassiveDiscoveryMutationVariables = Exact<{
   passiveDiscovery: PassiveDiscoveryUpsertInput;
-}>;
+}>
 
-
-export type UpsertPassiveDiscoveryMutation = { __typename?: 'Mutation', upsertPassiveDiscovery?: { __typename?: 'PassiveDiscovery', id?: any, locationId?: string, name?: string, snmpCommunities?: Array<string>, snmpPorts?: Array<number>, toggle: boolean } };
+export type UpsertPassiveDiscoveryMutation = { __typename?: 'Mutation', upsertPassiveDiscovery?: { __typename?: 'PassiveDiscovery', id?: any, locationId?: string, name?: string, snmpCommunities?: Array<string>, snmpPorts?: Array<number>, toggle: boolean } }
 
 export type DeletePassiveDiscoveryMutationVariables = Exact<{
   id: Scalars['Long'];
-}>;
+}>
 
-
-export type DeletePassiveDiscoveryMutation = { __typename?: 'Mutation', deletePassiveDiscovery?: boolean };
+export type DeletePassiveDiscoveryMutation = { __typename?: 'Mutation', deletePassiveDiscovery?: boolean }
 
 export type FindApplicationSeriesQueryVariables = Exact<{
   requestCriteria: RequestCriteriaInput;
-}>;
+}>
 
-
-export type FindApplicationSeriesQuery = { __typename?: 'Query', findApplicationSeries?: Array<{ __typename?: 'FlowingPoint', timestamp?: any, label?: string, value: number, direction?: string }> };
+export type FindApplicationSeriesQuery = { __typename?: 'Query', findApplicationSeries?: Array<{ __typename?: 'FlowingPoint', timestamp?: any, label?: string, value: number, direction?: string }> }
 
 export type FindApplicationSummariesQueryVariables = Exact<{
   requestCriteria: RequestCriteriaInput;
-}>;
+}>
 
-
-export type FindApplicationSummariesQuery = { __typename?: 'Query', findApplicationSummaries?: Array<{ __typename?: 'TrafficSummary', label?: string, bytesIn: any, bytesOut: any }> };
+export type FindApplicationSummariesQuery = { __typename?: 'Query', findApplicationSummaries?: Array<{ __typename?: 'TrafficSummary', label?: string, bytesIn: any, bytesOut: any }> }
 
 export type FindApplicationsQueryVariables = Exact<{
   requestCriteria: RequestCriteriaInput;
-}>;
+}>
 
-
-export type FindApplicationsQuery = { __typename?: 'Query', findApplications?: Array<string> };
+export type FindApplicationsQuery = { __typename?: 'Query', findApplications?: Array<string> }
 
 export type FindExportersQueryVariables = Exact<{
   requestCriteria: RequestCriteriaInput;
-}>;
+}>
 
-
-export type FindExportersQuery = { __typename?: 'Query', findExporters?: Array<{ __typename?: 'Exporter', node?: { __typename?: 'Node', id: any, nodeLabel?: string }, ipInterface?: { __typename?: 'IpInterface', id: any, ipAddress?: string } }> };
+export type FindExportersQuery = { __typename?: 'Query', findExporters?: Array<{ __typename?: 'Exporter', node?: { __typename?: 'Node', id: any, nodeLabel?: string }, ipInterface?: { __typename?: 'IpInterface', id: any, ipAddress?: string } }> }
 
 export type CreateLocationMutationVariables = Exact<{
   location: MonitoringLocationCreateInput;
-}>;
+}>
 
-
-export type CreateLocationMutation = { __typename?: 'Mutation', createLocation?: { __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number } };
+export type CreateLocationMutation = { __typename?: 'Mutation', createLocation?: { __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number } }
 
 export type UpdateLocationMutationVariables = Exact<{
   location?: InputMaybe<MonitoringLocationUpdateInput>;
-}>;
+}>
 
-
-export type UpdateLocationMutation = { __typename?: 'Mutation', updateLocation?: { __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number } };
+export type UpdateLocationMutation = { __typename?: 'Mutation', updateLocation?: { __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number } }
 
 export type DeleteLocationMutationVariables = Exact<{
   id: Scalars['Long'];
-}>;
+}>
 
-
-export type DeleteLocationMutation = { __typename?: 'Mutation', deleteLocation?: boolean };
+export type DeleteLocationMutation = { __typename?: 'Mutation', deleteLocation?: boolean }
 
 export type RevokeMinionCertificateMutationVariables = Exact<{
   locationId: Scalars['Long'];
-}>;
+}>
 
+export type RevokeMinionCertificateMutation = { __typename?: 'Mutation', revokeMinionCertificate?: boolean }
 
-export type RevokeMinionCertificateMutation = { __typename?: 'Mutation', revokeMinionCertificate?: boolean };
+export type LocationsPartsFragment = { __typename?: 'Query', findAllLocations?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number }> }
 
-export type LocationsPartsFragment = { __typename?: 'Query', findAllLocations?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number }> };
+export type LocationsListQueryVariables = Exact<{ [key: string]: never; }>
 
-export type LocationsListQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type LocationsListQuery = { __typename?: 'Query', findAllLocations?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number }> };
+export type LocationsListQuery = { __typename?: 'Query', findAllLocations?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number }> }
 
 export type SearchLocationQueryVariables = Exact<{
   searchTerm?: InputMaybe<Scalars['String']>;
-}>;
+}>
 
-
-export type SearchLocationQuery = { __typename?: 'Query', searchLocation?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number }> };
+export type SearchLocationQuery = { __typename?: 'Query', searchLocation?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number }> }
 
 export type GetMinionCertificateQueryVariables = Exact<{
   location?: InputMaybe<Scalars['Long']>;
-}>;
+}>
 
+export type GetMinionCertificateQuery = { __typename?: 'Query', getMinionCertificate?: { __typename?: 'CertificateResponse', password?: string, certificate?: any } }
 
-export type GetMinionCertificateQuery = { __typename?: 'Query', getMinionCertificate?: { __typename?: 'CertificateResponse', password?: string, certificate?: any } };
+export type DeviceUptimePartsFragment = { __typename?: 'Query', deviceUptime?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
-export type DeviceUptimePartsFragment = { __typename?: 'Query', deviceUptime?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
+export type DeviceLatencyPartsFragment = { __typename?: 'Query', deviceLatency?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
-export type DeviceLatencyPartsFragment = { __typename?: 'Query', deviceLatency?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
+export type MetricPartsFragment = { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } }
 
-export type MetricPartsFragment = { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } };
+export type TimeSeriesMetricFragment = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
-export type TimeSeriesMetricFragment = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
+export type MinionUptimePartsFragment = { __typename?: 'Query', minionUptime?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
-export type MinionUptimePartsFragment = { __typename?: 'Query', minionUptime?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
+export type MinionLatencyPartsFragment = { __typename?: 'Query', minionLatency?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
-export type MinionLatencyPartsFragment = { __typename?: 'Query', minionLatency?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
-
-export type NodeLatencyPartsFragment = { __typename?: 'Query', nodeLatency?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
+export type NodeLatencyPartsFragment = { __typename?: 'Query', nodeLatency?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
 export type DeleteMinionMutationVariables = Exact<{
   id: Scalars['Long'];
-}>;
+}>
 
-
-export type DeleteMinionMutation = { __typename?: 'Mutation', deleteMinion?: boolean };
+export type DeleteMinionMutation = { __typename?: 'Mutation', deleteMinion?: boolean }
 
 export type FindMinionsByLocationIdQueryVariables = Exact<{
   locationId: Scalars['Long'];
-}>;
+}>
 
-
-export type FindMinionsByLocationIdQuery = { __typename?: 'Query', findMinionsByLocationId?: Array<{ __typename?: 'Minion', id: any, label?: string, lastCheckedTime: any, status?: string, systemId?: string, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> };
+export type FindMinionsByLocationIdQuery = { __typename?: 'Query', findMinionsByLocationId?: Array<{ __typename?: 'Minion', id: any, label?: string, lastCheckedTime: any, status?: string, systemId?: string, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> }
 
 export type CreateMonitorPolicyMutationVariables = Exact<{
   policy: MonitorPolicyInput;
-}>;
+}>
 
-
-export type CreateMonitorPolicyMutation = { __typename?: 'Mutation', createMonitorPolicy?: { __typename?: 'MonitorPolicy', id?: any } };
+export type CreateMonitorPolicyMutation = { __typename?: 'Mutation', createMonitorPolicy?: { __typename?: 'MonitorPolicy', id?: any } }
 
 export type DeletePolicyByIdMutationVariables = Exact<{
   id: Scalars['Long'];
-}>;
+}>
 
-
-export type DeletePolicyByIdMutation = { __typename?: 'Mutation', deletePolicyById?: boolean };
+export type DeletePolicyByIdMutation = { __typename?: 'Mutation', deletePolicyById?: boolean }
 
 export type DeleteRuleByIdMutationVariables = Exact<{
   id: Scalars['Long'];
-}>;
+}>
 
-
-export type DeleteRuleByIdMutation = { __typename?: 'Mutation', deleteRuleById?: boolean };
+export type DeleteRuleByIdMutation = { __typename?: 'Mutation', deleteRuleById?: boolean }
 
 export type AddNodeMutationVariables = Exact<{
   node: NodeCreateInput;
-}>;
+}>
 
-
-export type AddNodeMutation = { __typename?: 'Mutation', addNode?: { __typename?: 'Node', createTime: any, id: any, monitoringLocationId: any, nodeLabel?: string } };
+export type AddNodeMutation = { __typename?: 'Mutation', addNode?: { __typename?: 'Node', createTime: any, id: any, monitoringLocationId: any, nodeLabel?: string } }
 
 export type DeleteNodeMutationVariables = Exact<{
   id: Scalars['Long'];
-}>;
+}>
 
-
-export type DeleteNodeMutation = { __typename?: 'Mutation', deleteNode?: boolean };
+export type DeleteNodeMutation = { __typename?: 'Mutation', deleteNode?: boolean }
 
 export type AddTagsToNodesMutationVariables = Exact<{
   tags: TagListNodesAddInput;
-}>;
+}>
 
-
-export type AddTagsToNodesMutation = { __typename?: 'Mutation', addTagsToNodes?: Array<{ __typename?: 'Tag', id: any, name?: string }> };
+export type AddTagsToNodesMutation = { __typename?: 'Mutation', addTagsToNodes?: Array<{ __typename?: 'Tag', id: any, name?: string }> }
 
 export type RemoveTagsFromNodesMutationVariables = Exact<{
   tags: TagListNodesRemoveInput;
-}>;
+}>
 
-
-export type RemoveTagsFromNodesMutation = { __typename?: 'Mutation', removeTagsFromNodes?: boolean };
+export type RemoveTagsFromNodesMutation = { __typename?: 'Mutation', removeTagsFromNodes?: boolean }
 
 export type UpdateNodeMutationVariables = Exact<{
   node: NodeUpdateInput;
-}>;
+}>
 
+export type UpdateNodeMutation = { __typename?: 'Mutation', updateNode?: any }
 
-export type UpdateNodeMutation = { __typename?: 'Mutation', updateNode?: any };
+export type NodeStatusPartsFragment = { __typename?: 'Query', nodeStatus?: { __typename?: 'NodeStatus', id: any, status?: string } }
 
-export type NodeStatusPartsFragment = { __typename?: 'Query', nodeStatus?: { __typename?: 'NodeStatus', id: any, status?: string } };
-
-export type NodesPartsFragment = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', createTime: any, id: any, monitoringLocationId: any, nodeLabel?: string, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> };
+export type NodesPartsFragment = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', createTime: any, id: any, monitoringLocationId: any, nodeLabel?: string, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> }
 
 export type SavePagerDutyConfigMutationVariables = Exact<{
   config: PagerDutyConfigInput;
-}>;
+}>
 
+export type SavePagerDutyConfigMutation = { __typename?: 'Mutation', savePagerDutyConfig?: boolean }
 
-export type SavePagerDutyConfigMutation = { __typename?: 'Mutation', savePagerDutyConfig?: boolean };
+export type TagsPartsFragment = { __typename?: 'Query', tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }
 
-export type TagsPartsFragment = { __typename?: 'Query', tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> };
+export type ListTagsQueryVariables = Exact<{ [key: string]: never; }>
 
-export type ListTagsQueryVariables = Exact<{ [key: string]: never; }>;
+export type ListTagsQuery = { __typename?: 'Query', tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }
 
-
-export type ListTagsQuery = { __typename?: 'Query', tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> };
-
-export type TagsSearchPartsFragment = { __typename?: 'Query', tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> };
+export type TagsSearchPartsFragment = { __typename?: 'Query', tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }
 
 export type ListTagsSearchQueryVariables = Exact<{
   searchTerm?: InputMaybe<Scalars['String']>;
-}>;
+}>
 
-
-export type ListTagsSearchQuery = { __typename?: 'Query', tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> };
+export type ListTagsSearchQuery = { __typename?: 'Query', tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }
 
 export type ListTagsByNodeIdsQueryVariables = Exact<{
   nodeIds?: InputMaybe<Array<InputMaybe<Scalars['Long']>> | InputMaybe<Scalars['Long']>>;
-}>;
+}>
 
-
-export type ListTagsByNodeIdsQuery = { __typename?: 'Query', tagsByNodeIds?: Array<{ __typename?: 'NodeTags', nodeId: any, tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }> };
+export type ListTagsByNodeIdsQuery = { __typename?: 'Query', tagsByNodeIds?: Array<{ __typename?: 'NodeTags', nodeId: any, tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }> }
 
 export type ListAlertEventDefinitionsQueryVariables = Exact<{
   eventType?: InputMaybe<EventType>;
-}>;
+}>
 
+export type ListAlertEventDefinitionsQuery = { __typename?: 'Query', listAlertEventDefinitions?: Array<{ __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType }> }
 
-export type ListAlertEventDefinitionsQuery = { __typename?: 'Query', listAlertEventDefinitions?: Array<{ __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType }> };
+export type NodesTablePartsFragment = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string, createTime: any, monitoringLocationId: any, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', ipAddress?: string, snmpPrimary?: boolean }> }> }
 
-export type NodesTablePartsFragment = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string, createTime: any, monitoringLocationId: any, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', ipAddress?: string, snmpPrimary?: boolean }> }> };
+export type MinionsTablePartsFragment = { __typename?: 'Query', findAllMinions?: Array<{ __typename?: 'Minion', id: any, label?: string, lastCheckedTime: any, status?: string, systemId?: string, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> }
 
-export type MinionsTablePartsFragment = { __typename?: 'Query', findAllMinions?: Array<{ __typename?: 'Minion', id: any, label?: string, lastCheckedTime: any, status?: string, systemId?: string, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> };
+export type ListNodesForTableQueryVariables = Exact<{ [key: string]: never; }>
 
-export type ListNodesForTableQueryVariables = Exact<{ [key: string]: never; }>;
+export type ListNodesForTableQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string, createTime: any, monitoringLocationId: any, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', ipAddress?: string, snmpPrimary?: boolean }> }> }
 
+export type ListMinionsForTableQueryVariables = Exact<{ [key: string]: never; }>
 
-export type ListNodesForTableQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string, createTime: any, monitoringLocationId: any, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', ipAddress?: string, snmpPrimary?: boolean }> }> };
-
-export type ListMinionsForTableQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type ListMinionsForTableQuery = { __typename?: 'Query', findAllMinions?: Array<{ __typename?: 'Minion', id: any, label?: string, lastCheckedTime: any, status?: string, systemId?: string, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> };
+export type ListMinionsForTableQuery = { __typename?: 'Query', findAllMinions?: Array<{ __typename?: 'Minion', id: any, label?: string, lastCheckedTime: any, status?: string, systemId?: string, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> }
 
 export type ListMinionMetricsQueryVariables = Exact<{
   instance: Scalars['String'];
   monitor: Scalars['String'];
   timeRange: Scalars['Int'];
   timeRangeUnit: TimeRangeUnit;
-}>;
+}>
 
-
-export type ListMinionMetricsQuery = { __typename?: 'Query', minionLatency?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
+export type ListMinionMetricsQuery = { __typename?: 'Query', minionLatency?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
 export type ListNodeMetricsQueryVariables = Exact<{
   id: Scalars['Long'];
@@ -1377,24 +1280,21 @@ export type ListNodeMetricsQueryVariables = Exact<{
   instance: Scalars['String'];
   timeRange: Scalars['Int'];
   timeRangeUnit: TimeRangeUnit;
-}>;
+}>
 
+export type ListNodeMetricsQuery = { __typename?: 'Query', nodeLatency?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } }, nodeStatus?: { __typename?: 'NodeStatus', id: any, status?: string } }
 
-export type ListNodeMetricsQuery = { __typename?: 'Query', nodeLatency?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } }, nodeStatus?: { __typename?: 'NodeStatus', id: any, status?: string } };
+export type ListMinionsAndDevicesForTablesQueryVariables = Exact<{ [key: string]: never; }>
 
-export type ListMinionsAndDevicesForTablesQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type ListMinionsAndDevicesForTablesQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string, createTime: any, monitoringLocationId: any, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', ipAddress?: string, snmpPrimary?: boolean }> }>, findAllMinions?: Array<{ __typename?: 'Minion', id: any, label?: string, lastCheckedTime: any, status?: string, systemId?: string, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }>, findAllLocations?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number }> };
+export type ListMinionsAndDevicesForTablesQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string, createTime: any, monitoringLocationId: any, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', ipAddress?: string, snmpPrimary?: boolean }> }>, findAllMinions?: Array<{ __typename?: 'Minion', id: any, label?: string, lastCheckedTime: any, status?: string, systemId?: string, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }>, findAllLocations?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number }> }
 
 export type NetworkTrafficQueryVariables = Exact<{
   name: Scalars['String'];
   timeRange: Scalars['Int'];
   timeRangeUnit: TimeRangeUnit;
-}>;
+}>
 
-
-export type NetworkTrafficQuery = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
+export type NetworkTrafficQuery = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
 export type TopNNodesQueryVariables = Exact<{
   timeRange: Scalars['Int'];
@@ -1403,10 +1303,9 @@ export type TopNNodesQueryVariables = Exact<{
   pageSize?: InputMaybe<Scalars['Int']>;
   sortBy?: InputMaybe<Scalars['String']>;
   page?: InputMaybe<Scalars['Int']>;
-}>;
+}>
 
-
-export type TopNNodesQuery = { __typename?: 'Query', nodeCount?: number, topNNode?: Array<{ __typename?: 'TopNNode', nodeLabel?: string, location?: string, avgResponseTime: number, reachability: number }>, allNodeStatus?: Array<{ __typename?: 'NodeStatus', id: any, status?: string }> };
+export type TopNNodesQuery = { __typename?: 'Query', nodeCount?: number, topNNode?: Array<{ __typename?: 'TopNNode', nodeLabel?: string, location?: string, avgResponseTime: number, reachability: number }>, allNodeStatus?: Array<{ __typename?: 'NodeStatus', id: any, status?: string }> }
 
 export type DownloadTopNQueryVariables = Exact<{
   downloadFormat: DownloadFormat;
@@ -1414,41 +1313,35 @@ export type DownloadTopNQueryVariables = Exact<{
   timeRangeUnit: TimeRangeUnit;
   sortAscending: Scalars['Boolean'];
   sortBy?: InputMaybe<Scalars['String']>;
-}>;
+}>
 
+export type DownloadTopNQuery = { __typename?: 'Query', downloadTopN?: { __typename?: 'TopNResponse', topNBytes?: any } }
 
-export type DownloadTopNQuery = { __typename?: 'Query', downloadTopN?: { __typename?: 'TopNResponse', topNBytes?: any } };
+export type ListLocationsForDiscoveryQueryVariables = Exact<{ [key: string]: never; }>
 
-export type ListLocationsForDiscoveryQueryVariables = Exact<{ [key: string]: never; }>;
+export type ListLocationsForDiscoveryQuery = { __typename?: 'Query', findAllLocations?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number }> }
 
+export type ListDiscoveriesQueryVariables = Exact<{ [key: string]: never; }>
 
-export type ListLocationsForDiscoveryQuery = { __typename?: 'Query', findAllLocations?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string, address?: string, longitude?: number, latitude?: number }> };
-
-export type ListDiscoveriesQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type ListDiscoveriesQuery = { __typename?: 'Query', passiveDiscoveries?: Array<{ __typename?: 'PassiveDiscovery', id?: any, locationId?: string, name?: string, snmpCommunities?: Array<string>, snmpPorts?: Array<number>, toggle: boolean }>, listActiveDiscovery?: Array<{ __typename?: 'ActiveDiscovery', details?: any, discoveryType?: string }> };
+export type ListDiscoveriesQuery = { __typename?: 'Query', passiveDiscoveries?: Array<{ __typename?: 'PassiveDiscovery', id?: any, locationId?: string, name?: string, snmpCommunities?: Array<string>, snmpPorts?: Array<number>, toggle: boolean }>, listActiveDiscovery?: Array<{ __typename?: 'ActiveDiscovery', details?: any, discoveryType?: string }> }
 
 export type TagsByActiveDiscoveryIdQueryVariables = Exact<{
   discoveryId: Scalars['Long'];
-}>;
+}>
 
-
-export type TagsByActiveDiscoveryIdQuery = { __typename?: 'Query', tagsByActiveDiscoveryId?: Array<{ __typename?: 'Tag', id: any, name?: string }> };
+export type TagsByActiveDiscoveryIdQuery = { __typename?: 'Query', tagsByActiveDiscoveryId?: Array<{ __typename?: 'Tag', id: any, name?: string }> }
 
 export type TagsByPassiveDiscoveryIdQueryVariables = Exact<{
   discoveryId: Scalars['Long'];
-}>;
+}>
 
-
-export type TagsByPassiveDiscoveryIdQuery = { __typename?: 'Query', tagsByPassiveDiscoveryId?: Array<{ __typename?: 'Tag', id: any, name?: string }> };
+export type TagsByPassiveDiscoveryIdQuery = { __typename?: 'Query', tagsByPassiveDiscoveryId?: Array<{ __typename?: 'Tag', id: any, name?: string }> }
 
 export type GetMetricQueryVariables = Exact<{
   metric: Scalars['String'];
-}>;
+}>
 
-
-export type GetMetricQuery = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
+export type GetMetricQuery = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
 export type GetTimeSeriesMetricQueryVariables = Exact<{
   name: Scalars['String'];
@@ -1457,10 +1350,9 @@ export type GetTimeSeriesMetricQueryVariables = Exact<{
   timeRange: Scalars['Int'];
   timeRangeUnit: TimeRangeUnit;
   instance?: InputMaybe<Scalars['String']>;
-}>;
+}>
 
-
-export type GetTimeSeriesMetricQuery = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
+export type GetTimeSeriesMetricQuery = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
 export type GetTimeSeriesMetricsWithIfNameQueryVariables = Exact<{
   name: Scalars['String'];
@@ -1469,22 +1361,19 @@ export type GetTimeSeriesMetricsWithIfNameQueryVariables = Exact<{
   timeRange: Scalars['Int'];
   timeRangeUnit: TimeRangeUnit;
   ifName?: InputMaybe<Scalars['String']>;
-}>;
+}>
 
-
-export type GetTimeSeriesMetricsWithIfNameQuery = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } };
+export type GetTimeSeriesMetricsWithIfNameQuery = { __typename?: 'Query', metric?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } } }
 
 export type GetNodeForGraphsQueryVariables = Exact<{
   id?: InputMaybe<Scalars['Long']>;
-}>;
+}>
 
+export type GetNodeForGraphsQuery = { __typename?: 'Query', findNodeById?: { __typename?: 'Node', id: any, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', ipAddress?: string, snmpPrimary?: boolean }> } }
 
-export type GetNodeForGraphsQuery = { __typename?: 'Query', findNodeById?: { __typename?: 'Node', id: any, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', ipAddress?: string, snmpPrimary?: boolean }> } };
+export type NodesListQueryVariables = Exact<{ [key: string]: never; }>
 
-export type NodesListQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type NodesListQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', createTime: any, id: any, monitoringLocationId: any, nodeLabel?: string, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> };
+export type NodesListQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', createTime: any, id: any, monitoringLocationId: any, nodeLabel?: string, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> }
 
 export type NodeLatencyMetricQueryVariables = Exact<{
   id: Scalars['Long'];
@@ -1492,190 +1381,175 @@ export type NodeLatencyMetricQueryVariables = Exact<{
   instance: Scalars['String'];
   timeRange: Scalars['Int'];
   timeRangeUnit: TimeRangeUnit;
-}>;
+}>
 
-
-export type NodeLatencyMetricQuery = { __typename?: 'Query', nodeLatency?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } }, nodeStatus?: { __typename?: 'NodeStatus', id: any, status?: string } };
+export type NodeLatencyMetricQuery = { __typename?: 'Query', nodeLatency?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, values?: Array<Array<number>> }> } }, nodeStatus?: { __typename?: 'NodeStatus', id: any, status?: string } }
 
 export type FindAllNodesByNodeLabelSearchQueryVariables = Exact<{
   labelSearchTerm: Scalars['String'];
-}>;
+}>
 
-
-export type FindAllNodesByNodeLabelSearchQuery = { __typename?: 'Query', findAllNodesByNodeLabelSearch?: Array<{ __typename?: 'Node', id: any, monitoredState?: string, monitoringLocationId: any, nodeLabel?: string, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string }, tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }>, allMetrics?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', resultType?: string, result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number>, values?: Array<Array<number>> }> } } };
+export type FindAllNodesByNodeLabelSearchQuery = { __typename?: 'Query', findAllNodesByNodeLabelSearch?: Array<{ __typename?: 'Node', id: any, monitoredState?: string, monitoringLocationId: any, nodeLabel?: string, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string }, tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }>, allMetrics?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', resultType?: string, result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number>, values?: Array<Array<number>> }> } } }
 
 export type FindAllNodesByTagsQueryVariables = Exact<{
   tags?: InputMaybe<Array<InputMaybe<Scalars['String']>> | InputMaybe<Scalars['String']>>;
-}>;
+}>
 
-
-export type FindAllNodesByTagsQuery = { __typename?: 'Query', findAllNodesByTags?: Array<{ __typename?: 'Node', id: any, monitoredState?: string, monitoringLocationId: any, nodeLabel?: string, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string }, tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }>, allMetrics?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', resultType?: string, result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number>, values?: Array<Array<number>> }> } } };
+export type FindAllNodesByTagsQuery = { __typename?: 'Query', findAllNodesByTags?: Array<{ __typename?: 'Node', id: any, monitoredState?: string, monitoringLocationId: any, nodeLabel?: string, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string }, tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }>, allMetrics?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', resultType?: string, result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number>, values?: Array<Array<number>> }> } } }
 
 export type FindAllNodesByMonitoredStateQueryVariables = Exact<{
   monitoredState: Scalars['String'];
-}>;
+}>
 
+export type FindAllNodesByMonitoredStateQuery = { __typename?: 'Query', findAllNodesByMonitoredState?: Array<{ __typename?: 'Node', id: any, monitoringLocationId: any, nodeLabel?: string, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> }
 
-export type FindAllNodesByMonitoredStateQuery = { __typename?: 'Query', findAllNodesByMonitoredState?: Array<{ __typename?: 'Node', id: any, monitoringLocationId: any, nodeLabel?: string, scanType?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string } }> };
+export type BuildNetworkInventoryPageQueryVariables = Exact<{ [key: string]: never; }>
 
-export type BuildNetworkInventoryPageQueryVariables = Exact<{ [key: string]: never; }>;
+export type BuildNetworkInventoryPageQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, monitoredState?: string, monitoringLocationId: any, nodeLabel?: string, scanType?: string, nodeAlias?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string }, tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }>, allMetrics?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', resultType?: string, result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number>, values?: Array<Array<number>> }> } } }
 
+export type NodesForMapQueryVariables = Exact<{ [key: string]: never; }>
 
-export type BuildNetworkInventoryPageQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, monitoredState?: string, monitoringLocationId: any, nodeLabel?: string, scanType?: string, nodeAlias?: string, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, ipAddress?: string, nodeId: any, snmpPrimary?: boolean }>, location?: { __typename?: 'MonitoringLocation', id: any, location?: string }, tags?: Array<{ __typename?: 'Tag', id: any, name?: string }> }>, allMetrics?: { __typename?: 'TimeSeriesQueryResult', status?: string, data?: { __typename?: 'TSData', resultType?: string, result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number>, values?: Array<Array<number>> }> } } };
+export type NodesForMapQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string, location?: { __typename?: 'MonitoringLocation', latitude?: number, longitude?: number, location?: string } }> }
 
-export type NodesForMapQueryVariables = Exact<{ [key: string]: never; }>;
+export type MonitoringPolicyPartsFragment = { __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: ManagedObjectType, detectionMethod?: DetectionMethod, eventType?: EventType, thresholdMetricName?: string, alertConditions?: Array<{ __typename?: 'AlertCondition', id?: any, count?: number, overtime?: number, overtimeUnit?: string, severity?: string, clearEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType }, triggerEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType } }> }> }
 
+export type ListMonitoryPoliciesQueryVariables = Exact<{ [key: string]: never; }>
 
-export type NodesForMapQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string, location?: { __typename?: 'MonitoringLocation', latitude?: number, longitude?: number, location?: string } }> };
-
-export type MonitoringPolicyPartsFragment = { __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: ManagedObjectType, detectionMethod?: DetectionMethod, eventType?: EventType, thresholdMetricName?: string, alertConditions?: Array<{ __typename?: 'AlertCondition', id?: any, count?: number, overtime?: number, overtimeUnit?: string, severity?: string, clearEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType }, triggerEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType } }> }> };
-
-export type ListMonitoryPoliciesQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type ListMonitoryPoliciesQuery = { __typename?: 'Query', listMonitoryPolicies?: Array<{ __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: ManagedObjectType, detectionMethod?: DetectionMethod, eventType?: EventType, thresholdMetricName?: string, alertConditions?: Array<{ __typename?: 'AlertCondition', id?: any, count?: number, overtime?: number, overtimeUnit?: string, severity?: string, clearEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType }, triggerEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType } }> }> }>, defaultPolicy?: { __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: ManagedObjectType, detectionMethod?: DetectionMethod, eventType?: EventType, thresholdMetricName?: string, alertConditions?: Array<{ __typename?: 'AlertCondition', id?: any, count?: number, overtime?: number, overtimeUnit?: string, severity?: string, clearEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType }, triggerEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType } }> }> } };
+export type ListMonitoryPoliciesQuery = { __typename?: 'Query', listMonitoryPolicies?: Array<{ __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: ManagedObjectType, detectionMethod?: DetectionMethod, eventType?: EventType, thresholdMetricName?: string, alertConditions?: Array<{ __typename?: 'AlertCondition', id?: any, count?: number, overtime?: number, overtimeUnit?: string, severity?: string, clearEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType }, triggerEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType } }> }> }>, defaultPolicy?: { __typename?: 'MonitorPolicy', id?: any, memo?: string, name?: string, notifyByEmail?: boolean, notifyByPagerDuty?: boolean, notifyByWebhooks?: boolean, tags?: Array<string>, rules?: Array<{ __typename?: 'PolicyRule', id?: any, name?: string, componentType?: ManagedObjectType, detectionMethod?: DetectionMethod, eventType?: EventType, thresholdMetricName?: string, alertConditions?: Array<{ __typename?: 'AlertCondition', id?: any, count?: number, overtime?: number, overtimeUnit?: string, severity?: string, clearEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType }, triggerEvent?: { __typename?: 'AlertEventDefinition', id?: any, name?: string, eventType?: EventType } }> }> } }
 
 export type CountAlertByPolicyIdQueryVariables = Exact<{
   id: Scalars['Long'];
-}>;
+}>
 
-
-export type CountAlertByPolicyIdQuery = { __typename?: 'Query', countAlertByPolicyId?: any };
+export type CountAlertByPolicyIdQuery = { __typename?: 'Query', countAlertByPolicyId?: any }
 
 export type CountAlertByRuleIdQueryVariables = Exact<{
   id: Scalars['Long'];
-}>;
+}>
 
+export type CountAlertByRuleIdQuery = { __typename?: 'Query', countAlertByRuleId?: any }
 
-export type CountAlertByRuleIdQuery = { __typename?: 'Query', countAlertByRuleId?: any };
+export type EventsByNodeIdPartsFragment = { __typename?: 'Query', events?: Array<{ __typename?: 'Event', id: number, uei?: string, nodeId: number, ipAddress?: string, producedTime: any }> }
 
-export type EventsByNodeIdPartsFragment = { __typename?: 'Query', events?: Array<{ __typename?: 'Event', id: number, uei?: string, nodeId: number, ipAddress?: string, producedTime: any }> };
-
-export type NodeByIdPartsFragment = { __typename?: 'Query', node?: { __typename?: 'Node', id: any, nodeLabel?: string, nodeAlias?: string, objectId?: string, systemContact?: string, systemDescr?: string, systemLocation?: string, systemName?: string, scanType?: string, location?: { __typename?: 'MonitoringLocation', location?: string }, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, hostname?: string, ipAddress?: string, netmask?: string, nodeId: any, snmpPrimary?: boolean, azureInterfaceId?: any }>, snmpInterfaces?: Array<{ __typename?: 'SnmpInterface', id: any, ifAdminStatus?: string, ifAlias?: string, ifDescr?: string, ifIndex: number, ifName?: string, ifOperatorStatus?: string, ifSpeed: any, ifType: number, ipAddress?: string, nodeId: any, physicalAddr?: string }>, azureInterfaces?: Array<{ __typename?: 'AzureInterface', id: any, nodeId: any, interfaceName?: string, privateIpId?: string, publicIpAddress?: string, publicIpId?: string, location?: string }> } };
+export type NodeByIdPartsFragment = { __typename?: 'Query', node?: { __typename?: 'Node', id: any, nodeLabel?: string, nodeAlias?: string, objectId?: string, systemContact?: string, systemDescr?: string, systemLocation?: string, systemName?: string, scanType?: string, location?: { __typename?: 'MonitoringLocation', location?: string }, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, hostname?: string, ipAddress?: string, netmask?: string, nodeId: any, snmpPrimary?: boolean, azureInterfaceId?: any }>, snmpInterfaces?: Array<{ __typename?: 'SnmpInterface', id: any, ifAdminStatus?: string, ifAlias?: string, ifDescr?: string, ifIndex: number, ifName?: string, ifOperatorStatus?: string, ifSpeed: any, ifType: number, ipAddress?: string, nodeId: any, physicalAddr?: string }>, azureInterfaces?: Array<{ __typename?: 'AzureInterface', id: any, nodeId: any, interfaceName?: string, privateIpId?: string, publicIpAddress?: string, publicIpId?: string, location?: string }> } }
 
 export type ListNodeStatusQueryVariables = Exact<{
   id?: InputMaybe<Scalars['Long']>;
-}>;
+}>
 
-
-export type ListNodeStatusQuery = { __typename?: 'Query', events?: Array<{ __typename?: 'Event', id: number, uei?: string, nodeId: number, ipAddress?: string, producedTime: any }>, node?: { __typename?: 'Node', id: any, nodeLabel?: string, nodeAlias?: string, objectId?: string, systemContact?: string, systemDescr?: string, systemLocation?: string, systemName?: string, scanType?: string, location?: { __typename?: 'MonitoringLocation', location?: string }, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, hostname?: string, ipAddress?: string, netmask?: string, nodeId: any, snmpPrimary?: boolean, azureInterfaceId?: any }>, snmpInterfaces?: Array<{ __typename?: 'SnmpInterface', id: any, ifAdminStatus?: string, ifAlias?: string, ifDescr?: string, ifIndex: number, ifName?: string, ifOperatorStatus?: string, ifSpeed: any, ifType: number, ipAddress?: string, nodeId: any, physicalAddr?: string }>, azureInterfaces?: Array<{ __typename?: 'AzureInterface', id: any, nodeId: any, interfaceName?: string, privateIpId?: string, publicIpAddress?: string, publicIpId?: string, location?: string }> } };
+export type ListNodeStatusQuery = { __typename?: 'Query', events?: Array<{ __typename?: 'Event', id: number, uei?: string, nodeId: number, ipAddress?: string, producedTime: any }>, node?: { __typename?: 'Node', id: any, nodeLabel?: string, nodeAlias?: string, objectId?: string, systemContact?: string, systemDescr?: string, systemLocation?: string, systemName?: string, scanType?: string, location?: { __typename?: 'MonitoringLocation', location?: string }, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, hostname?: string, ipAddress?: string, netmask?: string, nodeId: any, snmpPrimary?: boolean, azureInterfaceId?: any }>, snmpInterfaces?: Array<{ __typename?: 'SnmpInterface', id: any, ifAdminStatus?: string, ifAlias?: string, ifDescr?: string, ifIndex: number, ifName?: string, ifOperatorStatus?: string, ifSpeed: any, ifType: number, ipAddress?: string, nodeId: any, physicalAddr?: string }>, azureInterfaces?: Array<{ __typename?: 'AzureInterface', id: any, nodeId: any, interfaceName?: string, privateIpId?: string, publicIpAddress?: string, publicIpId?: string, location?: string }> } }
 
 export type FindExportersForNodeStatusQueryVariables = Exact<{
   requestCriteria: RequestCriteriaInput;
-}>;
+}>
 
+export type FindExportersForNodeStatusQuery = { __typename?: 'Query', findExporters?: Array<{ __typename?: 'Exporter', snmpInterface?: { __typename?: 'SnmpInterface', ifIndex: number, ifName?: string }, ipInterface?: { __typename?: 'IpInterface', id: any, ipAddress?: string } }> }
 
-export type FindExportersForNodeStatusQuery = { __typename?: 'Query', findExporters?: Array<{ __typename?: 'Exporter', snmpInterface?: { __typename?: 'SnmpInterface', ifIndex: number, ifName?: string }, ipInterface?: { __typename?: 'IpInterface', id: any, ipAddress?: string } }> };
+export type FindLocationsForWelcomeQueryVariables = Exact<{ [key: string]: never; }>
 
-export type FindLocationsForWelcomeQueryVariables = Exact<{ [key: string]: never; }>;
+export type FindLocationsForWelcomeQuery = { __typename?: 'Query', findAllLocations?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string }> }
 
+export type FindDevicesForWelcomeQueryVariables = Exact<{ [key: string]: never; }>
 
-export type FindLocationsForWelcomeQuery = { __typename?: 'Query', findAllLocations?: Array<{ __typename?: 'MonitoringLocation', id: any, location?: string }> };
-
-export type FindDevicesForWelcomeQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type FindDevicesForWelcomeQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string, createTime: any, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, nodeId: any, ipAddress?: string, snmpPrimary?: boolean }> }> };
+export type FindDevicesForWelcomeQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string, createTime: any, ipInterfaces?: Array<{ __typename?: 'IpInterface', id: any, nodeId: any, ipAddress?: string, snmpPrimary?: boolean }> }> }
 
 export type FindMinionsForWelcomeQueryVariables = Exact<{
   locationId: Scalars['Long'];
-}>;
+}>
 
-
-export type FindMinionsForWelcomeQuery = { __typename?: 'Query', findMinionsByLocationId?: Array<{ __typename?: 'Minion', id: any }> };
+export type FindMinionsForWelcomeQuery = { __typename?: 'Query', findMinionsByLocationId?: Array<{ __typename?: 'Minion', id: any }> }
 
 export type DownloadMinionCertificateForWelcomeQueryVariables = Exact<{
   location?: InputMaybe<Scalars['Long']>;
-}>;
+}>
 
+export type DownloadMinionCertificateForWelcomeQuery = { __typename?: 'Query', getMinionCertificate?: { __typename?: 'CertificateResponse', password?: string, certificate?: any } }
 
-export type DownloadMinionCertificateForWelcomeQuery = { __typename?: 'Query', getMinionCertificate?: { __typename?: 'CertificateResponse', password?: string, certificate?: any } };
-
-export const AlertsPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"AlertsParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllAlerts"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"page"},"value":{"kind":"Variable","name":{"kind":"Name","value":"page"}}},{"kind":"Argument","name":{"kind":"Name","value":"pageSize"},"value":{"kind":"Variable","name":{"kind":"Name","value":"pageSize"}}},{"kind":"Argument","name":{"kind":"Name","value":"severities"},"value":{"kind":"Variable","name":{"kind":"Name","value":"severities"}}},{"kind":"Argument","name":{"kind":"Name","value":"sortAscending"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sortAscending"}}},{"kind":"Argument","name":{"kind":"Name","value":"sortBy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sortBy"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"nodeLabel"},"value":{"kind":"Variable","name":{"kind":"Name","value":"nodeLabel"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"lastPage"}},{"kind":"Field","name":{"kind":"Name","value":"nextPage"}},{"kind":"Field","name":{"kind":"Name","value":"totalAlerts"}},{"kind":"Field","name":{"kind":"Name","value":"alerts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"acknowledged"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"firstEventTimeMs"}},{"kind":"Field","name":{"kind":"Name","value":"lastUpdateTimeMs"}},{"kind":"Field","name":{"kind":"Name","value":"severity"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"nodeName"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"ruleNameList"}},{"kind":"Field","name":{"kind":"Name","value":"policyNameList"}}]}}]}}]}}]} as unknown as DocumentNode<AlertsPartsFragment, unknown>;
-export const LocationsPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"LocationsParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllLocations"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"address"}},{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}}]}}]} as unknown as DocumentNode<LocationsPartsFragment, unknown>;
-export const MetricPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MetricParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"TimeSeriesQueryResult"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"data"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"result"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"metric"}},{"kind":"Field","name":{"kind":"Name","value":"values"}}]}}]}}]}}]} as unknown as DocumentNode<MetricPartsFragment, unknown>;
-export const DeviceUptimePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"DeviceUptimeParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"deviceUptime"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"StringValue","value":"snmp_uptime_sec","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MetricParts"}}]}}]}}]} as unknown as DocumentNode<DeviceUptimePartsFragment, unknown>;
-export const DeviceLatencyPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"DeviceLatencyParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"deviceLatency"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"StringValue","value":"response_time_msec","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MetricParts"}}]}}]}}]} as unknown as DocumentNode<DeviceLatencyPartsFragment, unknown>;
-export const TimeSeriesMetricFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"TimeSeriesMetric"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"metric"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"metric"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MetricParts"}}]}}]}}]} as unknown as DocumentNode<TimeSeriesMetricFragment, unknown>;
-export const MinionUptimePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MinionUptimeParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"minionUptime"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"StringValue","value":"minion_uptime_sec","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MetricParts"}}]}}]}}]} as unknown as DocumentNode<MinionUptimePartsFragment, unknown>;
-export const MinionLatencyPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MinionLatencyParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"minionLatency"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"StringValue","value":"response_time_msec","block":false}},{"kind":"Argument","name":{"kind":"Name","value":"labels"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"instance"},"value":{"kind":"Variable","name":{"kind":"Name","value":"instance"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"monitor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}}}]}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"MetricParts"}}]}}]}}]} as unknown as DocumentNode<MinionLatencyPartsFragment, unknown>;
-export const NodeLatencyPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodeLatencyParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"nodeLatency"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"StringValue","value":"response_time_msec","block":false}},{"kind":"Argument","name":{"kind":"Name","value":"labels"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"node_id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"monitor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"instance"},"value":{"kind":"Variable","name":{"kind":"Name","value":"instance"}}}]}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"MetricParts"}}]}}]}}]} as unknown as DocumentNode<NodeLatencyPartsFragment, unknown>;
-export const NodeStatusPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodeStatusParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodeStatus"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}}]}}]}}]} as unknown as DocumentNode<NodeStatusPartsFragment, unknown>;
-export const NodesPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodesParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createTime"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}},{"kind":"Field","name":{"kind":"Name","value":"monitoringLocationId"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"scanType"}}]}}]}}]} as unknown as DocumentNode<NodesPartsFragment, unknown>;
-export const TagsPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"TagsParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<TagsPartsFragment, unknown>;
-export const TagsSearchPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"TagsSearchParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tags"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"searchTerm"},"value":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<TagsSearchPartsFragment, unknown>;
-export const NodesTablePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodesTableParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"createTime"}},{"kind":"Field","name":{"kind":"Name","value":"monitoringLocationId"}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}},{"kind":"Field","name":{"kind":"Name","value":"scanType"}}]}}]}}]} as unknown as DocumentNode<NodesTablePartsFragment, unknown>;
-export const MinionsTablePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MinionsTableParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllMinions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"lastCheckedTime"}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"systemId"}}]}}]}}]} as unknown as DocumentNode<MinionsTablePartsFragment, unknown>;
-export const MonitoringPolicyPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MonitoringPolicyParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"MonitorPolicy"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"memo"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"notifyByEmail"}},{"kind":"Field","name":{"kind":"Name","value":"notifyByPagerDuty"}},{"kind":"Field","name":{"kind":"Name","value":"notifyByWebhooks"}},{"kind":"Field","name":{"kind":"Name","value":"rules"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}},{"kind":"Field","name":{"kind":"Name","value":"detectionMethod"}},{"kind":"Field","name":{"kind":"Name","value":"eventType"}},{"kind":"Field","name":{"kind":"Name","value":"thresholdMetricName"}},{"kind":"Field","name":{"kind":"Name","value":"alertConditions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"count"}},{"kind":"Field","name":{"kind":"Name","value":"clearEvent"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"eventType"}}]}},{"kind":"Field","name":{"kind":"Name","value":"overtime"}},{"kind":"Field","name":{"kind":"Name","value":"overtimeUnit"}},{"kind":"Field","name":{"kind":"Name","value":"severity"}},{"kind":"Field","name":{"kind":"Name","value":"triggerEvent"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"eventType"}}]}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"tags"}}]}}]} as unknown as DocumentNode<MonitoringPolicyPartsFragment, unknown>;
-export const EventsByNodeIdPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"EventsByNodeIdParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"events"},"name":{"kind":"Name","value":"findEventsByNodeId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"uei"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"producedTime"}}]}}]}}]} as unknown as DocumentNode<EventsByNodeIdPartsFragment, unknown>;
-export const NodeByIdPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodeByIdParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"node"},"name":{"kind":"Name","value":"findNodeById"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"nodeAlias"}},{"kind":"Field","name":{"kind":"Name","value":"objectId"}},{"kind":"Field","name":{"kind":"Name","value":"systemContact"}},{"kind":"Field","name":{"kind":"Name","value":"systemDescr"}},{"kind":"Field","name":{"kind":"Name","value":"systemLocation"}},{"kind":"Field","name":{"kind":"Name","value":"systemName"}},{"kind":"Field","name":{"kind":"Name","value":"scanType"}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"location"}}]}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"hostname"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"netmask"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}},{"kind":"Field","name":{"kind":"Name","value":"azureInterfaceId"}}]}},{"kind":"Field","name":{"kind":"Name","value":"snmpInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ifAdminStatus"}},{"kind":"Field","name":{"kind":"Name","value":"ifAlias"}},{"kind":"Field","name":{"kind":"Name","value":"ifDescr"}},{"kind":"Field","name":{"kind":"Name","value":"ifIndex"}},{"kind":"Field","name":{"kind":"Name","value":"ifName"}},{"kind":"Field","name":{"kind":"Name","value":"ifOperatorStatus"}},{"kind":"Field","name":{"kind":"Name","value":"ifSpeed"}},{"kind":"Field","name":{"kind":"Name","value":"ifType"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"physicalAddr"}}]}},{"kind":"Field","name":{"kind":"Name","value":"azureInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"interfaceName"}},{"kind":"Field","name":{"kind":"Name","value":"privateIpId"}},{"kind":"Field","name":{"kind":"Name","value":"publicIpAddress"}},{"kind":"Field","name":{"kind":"Name","value":"publicIpId"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}}]}}]}}]} as unknown as DocumentNode<NodeByIdPartsFragment, unknown>;
-export const AcknowledgeAlertsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AcknowledgeAlerts"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"ids"}},"type":{"kind":"ListType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"acknowledgeAlert"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"ids"},"value":{"kind":"Variable","name":{"kind":"Name","value":"ids"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"alertList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"acknowledged"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}}]}},{"kind":"Field","name":{"kind":"Name","value":"alertErrorList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"databaseId"}},{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]}}]} as unknown as DocumentNode<AcknowledgeAlertsMutation, AcknowledgeAlertsMutationVariables>;
-export const ClearAlertsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ClearAlerts"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"ids"}},"type":{"kind":"ListType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"clearAlert"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"ids"},"value":{"kind":"Variable","name":{"kind":"Name","value":"ids"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"alertList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"acknowledged"}},{"kind":"Field","name":{"kind":"Name","value":"databaseId"}}]}},{"kind":"Field","name":{"kind":"Name","value":"alertErrorList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"databaseId"}},{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]}}]} as unknown as DocumentNode<ClearAlertsMutation, ClearAlertsMutationVariables>;
-export const AlertsListDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"AlertsList"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"page"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"pageSize"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"severities"}},"type":{"kind":"ListType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sortAscending"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sortBy"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRange"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"nodeLabel"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"AlertsParts"}}]}},...AlertsPartsFragmentDoc.definitions]} as unknown as DocumentNode<AlertsListQuery, AlertsListQueryVariables>;
-export const CountAlertsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"CountAlerts"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"severityFilters"}},"type":{"kind":"ListType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRange"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"countAlerts"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"severityFilters"},"value":{"kind":"Variable","name":{"kind":"Name","value":"severityFilters"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"count"}},{"kind":"Field","name":{"kind":"Name","value":"error"}}]}}]}}]} as unknown as DocumentNode<CountAlertsQuery, CountAlertsQueryVariables>;
-export const AlertCountsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"AlertCounts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"alertCounts"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"acknowledgedCount"}},{"kind":"Field","name":{"kind":"Name","value":"totalAlertCount"}},{"kind":"Field","name":{"kind":"Name","value":"countBySeverity"}}]}}]}}]} as unknown as DocumentNode<AlertCountsQuery, AlertCountsQueryVariables>;
-export const CreateAzureActiveDiscoveryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateAzureActiveDiscovery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"discovery"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AzureActiveDiscoveryCreateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createAzureActiveDiscovery"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"discovery"},"value":{"kind":"Variable","name":{"kind":"Name","value":"discovery"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createTimeMsec"}},{"kind":"Field","name":{"kind":"Name","value":"locationId"}},{"kind":"Field","name":{"kind":"Name","value":"subscriptionId"}},{"kind":"Field","name":{"kind":"Name","value":"clientId"}}]}}]}}]} as unknown as DocumentNode<CreateAzureActiveDiscoveryMutation, CreateAzureActiveDiscoveryMutationVariables>;
-export const CreateIcmpActiveDiscoveryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateIcmpActiveDiscovery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"request"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"IcmpActiveDiscoveryCreateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createIcmpActiveDiscovery"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"request"},"value":{"kind":"Variable","name":{"kind":"Name","value":"request"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddresses"}},{"kind":"Field","name":{"kind":"Name","value":"locationId"}},{"kind":"Field","name":{"kind":"Name","value":"snmpConfig"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ports"}},{"kind":"Field","name":{"kind":"Name","value":"readCommunities"}}]}}]}}]}}]} as unknown as DocumentNode<CreateIcmpActiveDiscoveryMutation, CreateIcmpActiveDiscoveryMutationVariables>;
-export const CreateOrUpdateActiveIcmpDiscoveryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateOrUpdateActiveIcmpDiscovery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"request"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"IcmpActiveDiscoveryCreateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"upsertIcmpActiveDiscovery"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"request"},"value":{"kind":"Variable","name":{"kind":"Name","value":"request"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddresses"}},{"kind":"Field","name":{"kind":"Name","value":"locationId"}},{"kind":"Field","name":{"kind":"Name","value":"snmpConfig"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ports"}},{"kind":"Field","name":{"kind":"Name","value":"readCommunities"}}]}}]}}]}}]} as unknown as DocumentNode<CreateOrUpdateActiveIcmpDiscoveryMutation, CreateOrUpdateActiveIcmpDiscoveryMutationVariables>;
-export const DeleteActiveIcmpDiscoveryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteActiveIcmpDiscovery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteIcmpActiveDiscovery"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteActiveIcmpDiscoveryMutation, DeleteActiveIcmpDiscoveryMutationVariables>;
-export const TogglePassiveDiscoveryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"TogglePassiveDiscovery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"toggle"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"PassiveDiscoveryToggleInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"togglePassiveDiscovery"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"toggle"},"value":{"kind":"Variable","name":{"kind":"Name","value":"toggle"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"toggle"}}]}}]}}]} as unknown as DocumentNode<TogglePassiveDiscoveryMutation, TogglePassiveDiscoveryMutationVariables>;
-export const UpsertPassiveDiscoveryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpsertPassiveDiscovery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"passiveDiscovery"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"PassiveDiscoveryUpsertInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"upsertPassiveDiscovery"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"discovery"},"value":{"kind":"Variable","name":{"kind":"Name","value":"passiveDiscovery"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"locationId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"snmpCommunities"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPorts"}},{"kind":"Field","name":{"kind":"Name","value":"toggle"}}]}}]}}]} as unknown as DocumentNode<UpsertPassiveDiscoveryMutation, UpsertPassiveDiscoveryMutationVariables>;
-export const DeletePassiveDiscoveryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeletePassiveDiscovery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deletePassiveDiscovery"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeletePassiveDiscoveryMutation, DeletePassiveDiscoveryMutationVariables>;
-export const FindApplicationSeriesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"findApplicationSeries"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"requestCriteria"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"RequestCriteriaInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findApplicationSeries"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"requestCriteria"},"value":{"kind":"Variable","name":{"kind":"Name","value":"requestCriteria"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"timestamp"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"direction"}}]}}]}}]} as unknown as DocumentNode<FindApplicationSeriesQuery, FindApplicationSeriesQueryVariables>;
-export const FindApplicationSummariesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"findApplicationSummaries"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"requestCriteria"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"RequestCriteriaInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findApplicationSummaries"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"requestCriteria"},"value":{"kind":"Variable","name":{"kind":"Name","value":"requestCriteria"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"bytesIn"}},{"kind":"Field","name":{"kind":"Name","value":"bytesOut"}}]}}]}}]} as unknown as DocumentNode<FindApplicationSummariesQuery, FindApplicationSummariesQueryVariables>;
-export const FindApplicationsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"findApplications"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"requestCriteria"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"RequestCriteriaInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findApplications"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"requestCriteria"},"value":{"kind":"Variable","name":{"kind":"Name","value":"requestCriteria"}}}]}]}}]} as unknown as DocumentNode<FindApplicationsQuery, FindApplicationsQueryVariables>;
-export const FindExportersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"findExporters"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"requestCriteria"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"RequestCriteriaInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findExporters"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"requestCriteria"},"value":{"kind":"Variable","name":{"kind":"Name","value":"requestCriteria"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"node"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}}]}},{"kind":"Field","name":{"kind":"Name","value":"ipInterface"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}}]}}]}}]}}]} as unknown as DocumentNode<FindExportersQuery, FindExportersQueryVariables>;
-export const CreateLocationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateLocation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"location"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"MonitoringLocationCreateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createLocation"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"location"},"value":{"kind":"Variable","name":{"kind":"Name","value":"location"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"address"}},{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}}]}}]} as unknown as DocumentNode<CreateLocationMutation, CreateLocationMutationVariables>;
-export const UpdateLocationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateLocation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"location"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"MonitoringLocationUpdateInput"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateLocation"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"location"},"value":{"kind":"Variable","name":{"kind":"Name","value":"location"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"address"}},{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}}]}}]} as unknown as DocumentNode<UpdateLocationMutation, UpdateLocationMutationVariables>;
-export const DeleteLocationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteLocation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteLocation"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteLocationMutation, DeleteLocationMutationVariables>;
-export const RevokeMinionCertificateDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"revokeMinionCertificate"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"locationId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"revokeMinionCertificate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"locationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"locationId"}}}]}]}}]} as unknown as DocumentNode<RevokeMinionCertificateMutation, RevokeMinionCertificateMutationVariables>;
-export const LocationsListDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"LocationsList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"LocationsParts"}}]}},...LocationsPartsFragmentDoc.definitions]} as unknown as DocumentNode<LocationsListQuery, LocationsListQueryVariables>;
-export const SearchLocationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"SearchLocation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"searchLocation"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"searchTerm"},"value":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"address"}},{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"latitude"}}]}}]}}]} as unknown as DocumentNode<SearchLocationQuery, SearchLocationQueryVariables>;
-export const GetMinionCertificateDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"getMinionCertificate"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"location"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getMinionCertificate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"locationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"location"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"password"}},{"kind":"Field","name":{"kind":"Name","value":"certificate"}}]}}]}}]} as unknown as DocumentNode<GetMinionCertificateQuery, GetMinionCertificateQueryVariables>;
-export const DeleteMinionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteMinion"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteMinion"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteMinionMutation, DeleteMinionMutationVariables>;
-export const FindMinionsByLocationIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindMinionsByLocationId"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"locationId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findMinionsByLocationId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"locationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"locationId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"lastCheckedTime"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"systemId"}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}}]}}]}}]} as unknown as DocumentNode<FindMinionsByLocationIdQuery, FindMinionsByLocationIdQueryVariables>;
-export const CreateMonitorPolicyDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateMonitorPolicy"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"policy"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"MonitorPolicyInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createMonitorPolicy"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"policy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"policy"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<CreateMonitorPolicyMutation, CreateMonitorPolicyMutationVariables>;
-export const DeletePolicyByIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeletePolicyById"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deletePolicyById"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeletePolicyByIdMutation, DeletePolicyByIdMutationVariables>;
-export const DeleteRuleByIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteRuleById"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteRuleById"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteRuleByIdMutation, DeleteRuleByIdMutationVariables>;
-export const AddNodeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddNode"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"node"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"NodeCreateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addNode"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"node"},"value":{"kind":"Variable","name":{"kind":"Name","value":"node"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createTime"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"monitoringLocationId"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}}]}}]}}]} as unknown as DocumentNode<AddNodeMutation, AddNodeMutationVariables>;
-export const DeleteNodeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteNode"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteNode"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteNodeMutation, DeleteNodeMutationVariables>;
-export const AddTagsToNodesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddTagsToNodes"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"tags"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TagListNodesAddInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addTagsToNodes"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"tags"},"value":{"kind":"Variable","name":{"kind":"Name","value":"tags"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<AddTagsToNodesMutation, AddTagsToNodesMutationVariables>;
-export const RemoveTagsFromNodesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RemoveTagsFromNodes"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"tags"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TagListNodesRemoveInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"removeTagsFromNodes"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"tags"},"value":{"kind":"Variable","name":{"kind":"Name","value":"tags"}}}]}]}}]} as unknown as DocumentNode<RemoveTagsFromNodesMutation, RemoveTagsFromNodesMutationVariables>;
-export const UpdateNodeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateNode"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"node"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"NodeUpdateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateNode"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"node"},"value":{"kind":"Variable","name":{"kind":"Name","value":"node"}}}]}]}}]} as unknown as DocumentNode<UpdateNodeMutation, UpdateNodeMutationVariables>;
-export const SavePagerDutyConfigDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SavePagerDutyConfig"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"config"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"PagerDutyConfigInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"savePagerDutyConfig"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"config"},"value":{"kind":"Variable","name":{"kind":"Name","value":"config"}}}]}]}}]} as unknown as DocumentNode<SavePagerDutyConfigMutation, SavePagerDutyConfigMutationVariables>;
-export const ListTagsDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListTags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"TagsParts"}}]}},...TagsPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListTagsQuery, ListTagsQueryVariables>;
-export const ListTagsSearchDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListTagsSearch"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"searchTerm"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"TagsSearchParts"}}]}},...TagsSearchPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListTagsSearchQuery, ListTagsSearchQueryVariables>;
-export const ListTagsByNodeIdsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListTagsByNodeIds"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"nodeIds"}},"type":{"kind":"ListType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tagsByNodeIds"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"nodeIds"},"value":{"kind":"Variable","name":{"kind":"Name","value":"nodeIds"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"tags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<ListTagsByNodeIdsQuery, ListTagsByNodeIdsQueryVariables>;
-export const ListAlertEventDefinitionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListAlertEventDefinitions"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"eventType"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"EventType"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"listAlertEventDefinitions"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"eventType"},"value":{"kind":"Variable","name":{"kind":"Name","value":"eventType"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"eventType"}}]}}]}}]} as unknown as DocumentNode<ListAlertEventDefinitionsQuery, ListAlertEventDefinitionsQueryVariables>;
-export const ListNodesForTableDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListNodesForTable"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodesTableParts"}}]}},...NodesTablePartsFragmentDoc.definitions]} as unknown as DocumentNode<ListNodesForTableQuery, ListNodesForTableQueryVariables>;
-export const ListMinionsForTableDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListMinionsForTable"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MinionsTableParts"}}]}},...MinionsTablePartsFragmentDoc.definitions]} as unknown as DocumentNode<ListMinionsForTableQuery, ListMinionsForTableQueryVariables>;
-export const ListMinionMetricsDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListMinionMetrics"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"instance"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MinionLatencyParts"}}]}},...MinionLatencyPartsFragmentDoc.definitions,...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListMinionMetricsQuery, ListMinionMetricsQueryVariables>;
-export const ListNodeMetricsDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListNodeMetrics"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"instance"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodeLatencyParts"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodeStatusParts"}}]}},...NodeLatencyPartsFragmentDoc.definitions,...MetricPartsFragmentDoc.definitions,...NodeStatusPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListNodeMetricsQuery, ListNodeMetricsQueryVariables>;
-export const ListMinionsAndDevicesForTablesDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListMinionsAndDevicesForTables"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodesTableParts"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"MinionsTableParts"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"LocationsParts"}}]}},...NodesTablePartsFragmentDoc.definitions,...MinionsTablePartsFragmentDoc.definitions,...LocationsPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListMinionsAndDevicesForTablesQuery, ListMinionsAndDevicesForTablesQueryVariables>;
-export const NetworkTrafficDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"NetworkTraffic"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"MetricParts"}}]}}]}},...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<NetworkTrafficQuery, NetworkTrafficQueryVariables>;
-export const TopNNodesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TopNNodes"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sortAscending"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"pageSize"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sortBy"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"page"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"topNNode"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}},{"kind":"Argument","name":{"kind":"Name","value":"sortAscending"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sortAscending"}}},{"kind":"Argument","name":{"kind":"Name","value":"pageSize"},"value":{"kind":"Variable","name":{"kind":"Name","value":"pageSize"}}},{"kind":"Argument","name":{"kind":"Name","value":"sortBy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sortBy"}}},{"kind":"Argument","name":{"kind":"Name","value":"page"},"value":{"kind":"Variable","name":{"kind":"Name","value":"page"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"avgResponseTime"}},{"kind":"Field","name":{"kind":"Name","value":"reachability"}}]}},{"kind":"Field","name":{"kind":"Name","value":"allNodeStatus"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}}]}},{"kind":"Field","name":{"kind":"Name","value":"nodeCount"}}]}}]} as unknown as DocumentNode<TopNNodesQuery, TopNNodesQueryVariables>;
-export const DownloadTopNDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"DownloadTopN"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"downloadFormat"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DownloadFormat"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sortAscending"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Boolean"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"sortBy"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"downloadTopN"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}},{"kind":"Argument","name":{"kind":"Name","value":"sortAscending"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sortAscending"}}},{"kind":"Argument","name":{"kind":"Name","value":"sortBy"},"value":{"kind":"Variable","name":{"kind":"Name","value":"sortBy"}}},{"kind":"Argument","name":{"kind":"Name","value":"downloadFormat"},"value":{"kind":"Variable","name":{"kind":"Name","value":"downloadFormat"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"topNBytes"}}]}}]}}]} as unknown as DocumentNode<DownloadTopNQuery, DownloadTopNQueryVariables>;
-export const ListLocationsForDiscoveryDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListLocationsForDiscovery"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"LocationsParts"}}]}},...LocationsPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListLocationsForDiscoveryQuery, ListLocationsForDiscoveryQueryVariables>;
-export const ListDiscoveriesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListDiscoveries"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"passiveDiscoveries"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"locationId"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"snmpCommunities"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPorts"}},{"kind":"Field","name":{"kind":"Name","value":"toggle"}}]}},{"kind":"Field","name":{"kind":"Name","value":"listActiveDiscovery"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"details"}},{"kind":"Field","name":{"kind":"Name","value":"discoveryType"}}]}}]}}]} as unknown as DocumentNode<ListDiscoveriesQuery, ListDiscoveriesQueryVariables>;
-export const TagsByActiveDiscoveryIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TagsByActiveDiscoveryId"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"discoveryId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tagsByActiveDiscoveryId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"activeDiscoveryId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"discoveryId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<TagsByActiveDiscoveryIdQuery, TagsByActiveDiscoveryIdQueryVariables>;
-export const TagsByPassiveDiscoveryIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TagsByPassiveDiscoveryId"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"discoveryId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tagsByPassiveDiscoveryId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"passiveDiscoveryId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"discoveryId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<TagsByPassiveDiscoveryIdQuery, TagsByPassiveDiscoveryIdQueryVariables>;
-export const GetMetricDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMetric"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"metric"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"TimeSeriesMetric"}}]}},...TimeSeriesMetricFragmentDoc.definitions,...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<GetMetricQuery, GetMetricQueryVariables>;
-export const GetTimeSeriesMetricDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetTimeSeriesMetric"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"nodeId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"instance"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"metric"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"labels"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"monitor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"node_id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"nodeId"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"instance"},"value":{"kind":"Variable","name":{"kind":"Name","value":"instance"}}}]}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MetricParts"}}]}}]}},...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<GetTimeSeriesMetricQuery, GetTimeSeriesMetricQueryVariables>;
-export const GetTimeSeriesMetricsWithIfNameDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetTimeSeriesMetricsWithIfName"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"nodeId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"ifName"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"metric"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"labels"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"monitor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"node_id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"nodeId"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"if_name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"ifName"}}}]}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MetricParts"}}]}}]}},...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<GetTimeSeriesMetricsWithIfNameQuery, GetTimeSeriesMetricsWithIfNameQueryVariables>;
-export const GetNodeForGraphsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetNodeForGraphs"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findNodeById"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}},{"kind":"Field","name":{"kind":"Name","value":"scanType"}}]}}]}}]} as unknown as DocumentNode<GetNodeForGraphsQuery, GetNodeForGraphsQueryVariables>;
-export const NodesListDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"NodesList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodesParts"}}]}},...NodesPartsFragmentDoc.definitions]} as unknown as DocumentNode<NodesListQuery, NodesListQueryVariables>;
-export const NodeLatencyMetricDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"NodeLatencyMetric"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"instance"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodeLatencyParts"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodeStatusParts"}}]}},...NodeLatencyPartsFragmentDoc.definitions,...MetricPartsFragmentDoc.definitions,...NodeStatusPartsFragmentDoc.definitions]} as unknown as DocumentNode<NodeLatencyMetricQuery, NodeLatencyMetricQueryVariables>;
-export const FindAllNodesByNodeLabelSearchDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindAllNodesByNodeLabelSearch"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"labelSearchTerm"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodesByNodeLabelSearch"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"labelSearchTerm"},"value":{"kind":"Variable","name":{"kind":"Name","value":"labelSearchTerm"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}},{"kind":"Field","name":{"kind":"Name","value":"tags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"monitoredState"}},{"kind":"Field","name":{"kind":"Name","value":"monitoringLocationId"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"scanType"}}]}},{"kind":"Field","alias":{"kind":"Name","value":"allMetrics"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"StringValue","value":"response_time_msec","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"data"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"resultType"}},{"kind":"Field","name":{"kind":"Name","value":"result"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"metric"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"values"}}]}}]}}]}}]}}]} as unknown as DocumentNode<FindAllNodesByNodeLabelSearchQuery, FindAllNodesByNodeLabelSearchQueryVariables>;
-export const FindAllNodesByTagsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindAllNodesByTags"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"tags"}},"type":{"kind":"ListType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodesByTags"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"tags"},"value":{"kind":"Variable","name":{"kind":"Name","value":"tags"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}},{"kind":"Field","name":{"kind":"Name","value":"tags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"monitoredState"}},{"kind":"Field","name":{"kind":"Name","value":"monitoringLocationId"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"scanType"}}]}},{"kind":"Field","alias":{"kind":"Name","value":"allMetrics"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"StringValue","value":"response_time_msec","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"data"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"resultType"}},{"kind":"Field","name":{"kind":"Name","value":"result"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"metric"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"values"}}]}}]}}]}}]}}]} as unknown as DocumentNode<FindAllNodesByTagsQuery, FindAllNodesByTagsQueryVariables>;
-export const FindAllNodesByMonitoredStateDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindAllNodesByMonitoredState"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"monitoredState"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodesByMonitoredState"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"monitoredState"},"value":{"kind":"Variable","name":{"kind":"Name","value":"monitoredState"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}},{"kind":"Field","name":{"kind":"Name","value":"monitoringLocationId"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"scanType"}}]}}]}}]} as unknown as DocumentNode<FindAllNodesByMonitoredStateQuery, FindAllNodesByMonitoredStateQueryVariables>;
-export const BuildNetworkInventoryPageDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"BuildNetworkInventoryPage"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}},{"kind":"Field","name":{"kind":"Name","value":"tags"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"monitoredState"}},{"kind":"Field","name":{"kind":"Name","value":"monitoringLocationId"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"scanType"}},{"kind":"Field","name":{"kind":"Name","value":"nodeAlias"}}]}},{"kind":"Field","alias":{"kind":"Name","value":"allMetrics"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"StringValue","value":"response_time_msec","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"data"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"resultType"}},{"kind":"Field","name":{"kind":"Name","value":"result"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"metric"}},{"kind":"Field","name":{"kind":"Name","value":"value"}},{"kind":"Field","name":{"kind":"Name","value":"values"}}]}}]}}]}}]}}]} as unknown as DocumentNode<BuildNetworkInventoryPageQuery, BuildNetworkInventoryPageQueryVariables>;
-export const NodesForMapDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"NodesForMap"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"latitude"}},{"kind":"Field","name":{"kind":"Name","value":"longitude"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}}]}}]}}]} as unknown as DocumentNode<NodesForMapQuery, NodesForMapQueryVariables>;
-export const ListMonitoryPoliciesDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListMonitoryPolicies"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"listMonitoryPolicies"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MonitoringPolicyParts"}}]}},{"kind":"Field","name":{"kind":"Name","value":"defaultPolicy"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"MonitoringPolicyParts"}}]}}]}},...MonitoringPolicyPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListMonitoryPoliciesQuery, ListMonitoryPoliciesQueryVariables>;
-export const CountAlertByPolicyIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"CountAlertByPolicyId"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"countAlertByPolicyId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<CountAlertByPolicyIdQuery, CountAlertByPolicyIdQueryVariables>;
-export const CountAlertByRuleIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"CountAlertByRuleId"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"countAlertByRuleId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<CountAlertByRuleIdQuery, CountAlertByRuleIdQueryVariables>;
-export const ListNodeStatusDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListNodeStatus"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"EventsByNodeIdParts"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodeByIdParts"}}]}},...EventsByNodeIdPartsFragmentDoc.definitions,...NodeByIdPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListNodeStatusQuery, ListNodeStatusQueryVariables>;
-export const FindExportersForNodeStatusDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"findExportersForNodeStatus"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"requestCriteria"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"RequestCriteriaInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findExporters"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"requestCriteria"},"value":{"kind":"Variable","name":{"kind":"Name","value":"requestCriteria"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"snmpInterface"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ifIndex"}},{"kind":"Field","name":{"kind":"Name","value":"ifName"}}]}},{"kind":"Field","name":{"kind":"Name","value":"ipInterface"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}}]}}]}}]}}]} as unknown as DocumentNode<FindExportersForNodeStatusQuery, FindExportersForNodeStatusQueryVariables>;
-export const FindLocationsForWelcomeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindLocationsForWelcome"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllLocations"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}}]}}]}}]} as unknown as DocumentNode<FindLocationsForWelcomeQuery, FindLocationsForWelcomeQueryVariables>;
-export const FindDevicesForWelcomeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindDevicesForWelcome"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"createTime"}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}}]}}]}}]} as unknown as DocumentNode<FindDevicesForWelcomeQuery, FindDevicesForWelcomeQueryVariables>;
-export const FindMinionsForWelcomeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindMinionsForWelcome"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"locationId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findMinionsByLocationId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"locationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"locationId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<FindMinionsForWelcomeQuery, FindMinionsForWelcomeQueryVariables>;
-export const DownloadMinionCertificateForWelcomeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"DownloadMinionCertificateForWelcome"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"location"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getMinionCertificate"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"locationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"location"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"password"}},{"kind":"Field","name":{"kind":"Name","value":"certificate"}}]}}]}}]} as unknown as DocumentNode<DownloadMinionCertificateForWelcomeQuery, DownloadMinionCertificateForWelcomeQueryVariables>;
+export const AlertsPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'AlertsParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllAlerts'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'page'},'value':{'kind':'Variable','name':{'kind':'Name','value':'page'}}},{'kind':'Argument','name':{'kind':'Name','value':'pageSize'},'value':{'kind':'Variable','name':{'kind':'Name','value':'pageSize'}}},{'kind':'Argument','name':{'kind':'Name','value':'severities'},'value':{'kind':'Variable','name':{'kind':'Name','value':'severities'}}},{'kind':'Argument','name':{'kind':'Name','value':'sortAscending'},'value':{'kind':'Variable','name':{'kind':'Name','value':'sortAscending'}}},{'kind':'Argument','name':{'kind':'Name','value':'sortBy'},'value':{'kind':'Variable','name':{'kind':'Name','value':'sortBy'}}},{'kind':'Argument','name':{'kind':'Name','value':'timeRange'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}}},{'kind':'Argument','name':{'kind':'Name','value':'nodeLabel'},'value':{'kind':'Variable','name':{'kind':'Name','value':'nodeLabel'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'lastPage'}},{'kind':'Field','name':{'kind':'Name','value':'nextPage'}},{'kind':'Field','name':{'kind':'Name','value':'totalAlerts'}},{'kind':'Field','name':{'kind':'Name','value':'alerts'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'acknowledged'}},{'kind':'Field','name':{'kind':'Name','value':'description'}},{'kind':'Field','name':{'kind':'Name','value':'firstEventTimeMs'}},{'kind':'Field','name':{'kind':'Name','value':'lastUpdateTimeMs'}},{'kind':'Field','name':{'kind':'Name','value':'severity'}},{'kind':'Field','name':{'kind':'Name','value':'label'}},{'kind':'Field','name':{'kind':'Name','value':'nodeName'}},{'kind':'Field','name':{'kind':'Name','value':'databaseId'}},{'kind':'Field','name':{'kind':'Name','value':'location'}},{'kind':'Field','name':{'kind':'Name','value':'ruleNameList'}},{'kind':'Field','name':{'kind':'Name','value':'policyNameList'}}]}}]}}]}}]} as unknown as DocumentNode<AlertsPartsFragment, unknown>
+export const LocationsPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'LocationsParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllLocations'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}},{'kind':'Field','name':{'kind':'Name','value':'address'}},{'kind':'Field','name':{'kind':'Name','value':'longitude'}},{'kind':'Field','name':{'kind':'Name','value':'latitude'}}]}}]}}]} as unknown as DocumentNode<LocationsPartsFragment, unknown>
+export const MetricPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'MetricParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'TimeSeriesQueryResult'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'data'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'result'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'metric'}},{'kind':'Field','name':{'kind':'Name','value':'values'}}]}}]}}]}}]} as unknown as DocumentNode<MetricPartsFragment, unknown>
+export const DeviceUptimePartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'DeviceUptimeParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','alias':{'kind':'Name','value':'deviceUptime'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'StringValue','value':'snmp_uptime_sec','block':false}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'MetricParts'}}]}}]}}]} as unknown as DocumentNode<DeviceUptimePartsFragment, unknown>
+export const DeviceLatencyPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'DeviceLatencyParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','alias':{'kind':'Name','value':'deviceLatency'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'StringValue','value':'response_time_msec','block':false}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'MetricParts'}}]}}]}}]} as unknown as DocumentNode<DeviceLatencyPartsFragment, unknown>
+export const TimeSeriesMetricFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'TimeSeriesMetric'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','alias':{'kind':'Name','value':'metric'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'Variable','name':{'kind':'Name','value':'metric'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'MetricParts'}}]}}]}}]} as unknown as DocumentNode<TimeSeriesMetricFragment, unknown>
+export const MinionUptimePartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'MinionUptimeParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','alias':{'kind':'Name','value':'minionUptime'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'StringValue','value':'minion_uptime_sec','block':false}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'MetricParts'}}]}}]}}]} as unknown as DocumentNode<MinionUptimePartsFragment, unknown>
+export const MinionLatencyPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'MinionLatencyParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','alias':{'kind':'Name','value':'minionLatency'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'StringValue','value':'response_time_msec','block':false}},{'kind':'Argument','name':{'kind':'Name','value':'labels'},'value':{'kind':'ObjectValue','fields':[{'kind':'ObjectField','name':{'kind':'Name','value':'instance'},'value':{'kind':'Variable','name':{'kind':'Name','value':'instance'}}},{'kind':'ObjectField','name':{'kind':'Name','value':'monitor'},'value':{'kind':'Variable','name':{'kind':'Name','value':'monitor'}}}]}},{'kind':'Argument','name':{'kind':'Name','value':'timeRange'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}}},{'kind':'Argument','name':{'kind':'Name','value':'timeRangeUnit'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'status'}},{'kind':'FragmentSpread','name':{'kind':'Name','value':'MetricParts'}}]}}]}}]} as unknown as DocumentNode<MinionLatencyPartsFragment, unknown>
+export const NodeLatencyPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'NodeLatencyParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','alias':{'kind':'Name','value':'nodeLatency'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'StringValue','value':'response_time_msec','block':false}},{'kind':'Argument','name':{'kind':'Name','value':'labels'},'value':{'kind':'ObjectValue','fields':[{'kind':'ObjectField','name':{'kind':'Name','value':'node_id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}},{'kind':'ObjectField','name':{'kind':'Name','value':'monitor'},'value':{'kind':'Variable','name':{'kind':'Name','value':'monitor'}}},{'kind':'ObjectField','name':{'kind':'Name','value':'instance'},'value':{'kind':'Variable','name':{'kind':'Name','value':'instance'}}}]}},{'kind':'Argument','name':{'kind':'Name','value':'timeRange'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}}},{'kind':'Argument','name':{'kind':'Name','value':'timeRangeUnit'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'status'}},{'kind':'FragmentSpread','name':{'kind':'Name','value':'MetricParts'}}]}}]}}]} as unknown as DocumentNode<NodeLatencyPartsFragment, unknown>
+export const NodeStatusPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'NodeStatusParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'nodeStatus'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'status'}}]}}]}}]} as unknown as DocumentNode<NodeStatusPartsFragment, unknown>
+export const NodesPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'NodesParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllNodes'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'createTime'}},{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPrimary'}}]}},{'kind':'Field','name':{'kind':'Name','value':'location'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}},{'kind':'Field','name':{'kind':'Name','value':'monitoringLocationId'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}},{'kind':'Field','name':{'kind':'Name','value':'scanType'}}]}}]}}]} as unknown as DocumentNode<NodesPartsFragment, unknown>
+export const TagsPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'TagsParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'tags'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}}]}}]}}]} as unknown as DocumentNode<TagsPartsFragment, unknown>
+export const TagsSearchPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'TagsSearchParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'tags'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'searchTerm'},'value':{'kind':'Variable','name':{'kind':'Name','value':'searchTerm'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}}]}}]}}]} as unknown as DocumentNode<TagsSearchPartsFragment, unknown>
+export const NodesTablePartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'NodesTableParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllNodes'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}},{'kind':'Field','name':{'kind':'Name','value':'createTime'}},{'kind':'Field','name':{'kind':'Name','value':'monitoringLocationId'}},{'kind':'Field','name':{'kind':'Name','value':'ipInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPrimary'}}]}},{'kind':'Field','name':{'kind':'Name','value':'scanType'}}]}}]}}]} as unknown as DocumentNode<NodesTablePartsFragment, unknown>
+export const MinionsTablePartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'MinionsTableParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllMinions'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'label'}},{'kind':'Field','name':{'kind':'Name','value':'lastCheckedTime'}},{'kind':'Field','name':{'kind':'Name','value':'location'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}},{'kind':'Field','name':{'kind':'Name','value':'status'}},{'kind':'Field','name':{'kind':'Name','value':'systemId'}}]}}]}}]} as unknown as DocumentNode<MinionsTablePartsFragment, unknown>
+export const MonitoringPolicyPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'MonitoringPolicyParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'MonitorPolicy'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'memo'}},{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'notifyByEmail'}},{'kind':'Field','name':{'kind':'Name','value':'notifyByPagerDuty'}},{'kind':'Field','name':{'kind':'Name','value':'notifyByWebhooks'}},{'kind':'Field','name':{'kind':'Name','value':'rules'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'componentType'}},{'kind':'Field','name':{'kind':'Name','value':'detectionMethod'}},{'kind':'Field','name':{'kind':'Name','value':'eventType'}},{'kind':'Field','name':{'kind':'Name','value':'thresholdMetricName'}},{'kind':'Field','name':{'kind':'Name','value':'alertConditions'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'count'}},{'kind':'Field','name':{'kind':'Name','value':'clearEvent'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'eventType'}}]}},{'kind':'Field','name':{'kind':'Name','value':'overtime'}},{'kind':'Field','name':{'kind':'Name','value':'overtimeUnit'}},{'kind':'Field','name':{'kind':'Name','value':'severity'}},{'kind':'Field','name':{'kind':'Name','value':'triggerEvent'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'eventType'}}]}}]}}]}},{'kind':'Field','name':{'kind':'Name','value':'tags'}}]}}]} as unknown as DocumentNode<MonitoringPolicyPartsFragment, unknown>
+export const EventsByNodeIdPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'EventsByNodeIdParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','alias':{'kind':'Name','value':'events'},'name':{'kind':'Name','value':'findEventsByNodeId'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'uei'}},{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'producedTime'}}]}}]}}]} as unknown as DocumentNode<EventsByNodeIdPartsFragment, unknown>
+export const NodeByIdPartsFragmentDoc = {'kind':'Document','definitions':[{'kind':'FragmentDefinition','name':{'kind':'Name','value':'NodeByIdParts'},'typeCondition':{'kind':'NamedType','name':{'kind':'Name','value':'Query'}},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','alias':{'kind':'Name','value':'node'},'name':{'kind':'Name','value':'findNodeById'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}},{'kind':'Field','name':{'kind':'Name','value':'nodeAlias'}},{'kind':'Field','name':{'kind':'Name','value':'objectId'}},{'kind':'Field','name':{'kind':'Name','value':'systemContact'}},{'kind':'Field','name':{'kind':'Name','value':'systemDescr'}},{'kind':'Field','name':{'kind':'Name','value':'systemLocation'}},{'kind':'Field','name':{'kind':'Name','value':'systemName'}},{'kind':'Field','name':{'kind':'Name','value':'scanType'}},{'kind':'Field','name':{'kind':'Name','value':'location'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'location'}}]}},{'kind':'Field','name':{'kind':'Name','value':'ipInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'hostname'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'netmask'}},{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPrimary'}},{'kind':'Field','name':{'kind':'Name','value':'azureInterfaceId'}}]}},{'kind':'Field','name':{'kind':'Name','value':'snmpInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ifAdminStatus'}},{'kind':'Field','name':{'kind':'Name','value':'ifAlias'}},{'kind':'Field','name':{'kind':'Name','value':'ifDescr'}},{'kind':'Field','name':{'kind':'Name','value':'ifIndex'}},{'kind':'Field','name':{'kind':'Name','value':'ifName'}},{'kind':'Field','name':{'kind':'Name','value':'ifOperatorStatus'}},{'kind':'Field','name':{'kind':'Name','value':'ifSpeed'}},{'kind':'Field','name':{'kind':'Name','value':'ifType'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'physicalAddr'}}]}},{'kind':'Field','name':{'kind':'Name','value':'azureInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'interfaceName'}},{'kind':'Field','name':{'kind':'Name','value':'privateIpId'}},{'kind':'Field','name':{'kind':'Name','value':'publicIpAddress'}},{'kind':'Field','name':{'kind':'Name','value':'publicIpId'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}}]}}]}}]} as unknown as DocumentNode<NodeByIdPartsFragment, unknown>
+export const AcknowledgeAlertsDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'AcknowledgeAlerts'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'ids'}},'type':{'kind':'ListType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'acknowledgeAlert'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'ids'},'value':{'kind':'Variable','name':{'kind':'Name','value':'ids'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'alertList'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'acknowledged'}},{'kind':'Field','name':{'kind':'Name','value':'databaseId'}}]}},{'kind':'Field','name':{'kind':'Name','value':'alertErrorList'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'databaseId'}},{'kind':'Field','name':{'kind':'Name','value':'error'}}]}}]}}]}}]} as unknown as DocumentNode<AcknowledgeAlertsMutation, AcknowledgeAlertsMutationVariables>
+export const ClearAlertsDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'ClearAlerts'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'ids'}},'type':{'kind':'ListType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'clearAlert'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'ids'},'value':{'kind':'Variable','name':{'kind':'Name','value':'ids'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'alertList'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'acknowledged'}},{'kind':'Field','name':{'kind':'Name','value':'databaseId'}}]}},{'kind':'Field','name':{'kind':'Name','value':'alertErrorList'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'databaseId'}},{'kind':'Field','name':{'kind':'Name','value':'error'}}]}}]}}]}}]} as unknown as DocumentNode<ClearAlertsMutation, ClearAlertsMutationVariables>
+export const AlertsListDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'AlertsList'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'page'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'pageSize'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'severities'}},'type':{'kind':'ListType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'sortAscending'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Boolean'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'sortBy'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TimeRange'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'nodeLabel'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'AlertsParts'}}]}},...AlertsPartsFragmentDoc.definitions]} as unknown as DocumentNode<AlertsListQuery, AlertsListQueryVariables>
+export const CountAlertsDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'CountAlerts'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'severityFilters'}},'type':{'kind':'ListType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TimeRange'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'countAlerts'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'severityFilters'},'value':{'kind':'Variable','name':{'kind':'Name','value':'severityFilters'}}},{'kind':'Argument','name':{'kind':'Name','value':'timeRange'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'count'}},{'kind':'Field','name':{'kind':'Name','value':'error'}}]}}]}}]} as unknown as DocumentNode<CountAlertsQuery, CountAlertsQueryVariables>
+export const AlertCountsDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'AlertCounts'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'alertCounts'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'acknowledgedCount'}},{'kind':'Field','name':{'kind':'Name','value':'totalAlertCount'}},{'kind':'Field','name':{'kind':'Name','value':'countBySeverity'}}]}}]}}]} as unknown as DocumentNode<AlertCountsQuery, AlertCountsQueryVariables>
+export const CreateAzureActiveDiscoveryDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'CreateAzureActiveDiscovery'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'discovery'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'AzureActiveDiscoveryCreateInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'createAzureActiveDiscovery'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'discovery'},'value':{'kind':'Variable','name':{'kind':'Name','value':'discovery'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'createTimeMsec'}},{'kind':'Field','name':{'kind':'Name','value':'locationId'}},{'kind':'Field','name':{'kind':'Name','value':'subscriptionId'}},{'kind':'Field','name':{'kind':'Name','value':'clientId'}}]}}]}}]} as unknown as DocumentNode<CreateAzureActiveDiscoveryMutation, CreateAzureActiveDiscoveryMutationVariables>
+export const CreateIcmpActiveDiscoveryDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'CreateIcmpActiveDiscovery'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'request'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'IcmpActiveDiscoveryCreateInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'createIcmpActiveDiscovery'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'request'},'value':{'kind':'Variable','name':{'kind':'Name','value':'request'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddresses'}},{'kind':'Field','name':{'kind':'Name','value':'locationId'}},{'kind':'Field','name':{'kind':'Name','value':'snmpConfig'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'ports'}},{'kind':'Field','name':{'kind':'Name','value':'readCommunities'}}]}}]}}]}}]} as unknown as DocumentNode<CreateIcmpActiveDiscoveryMutation, CreateIcmpActiveDiscoveryMutationVariables>
+export const CreateOrUpdateActiveIcmpDiscoveryDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'CreateOrUpdateActiveIcmpDiscovery'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'request'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'IcmpActiveDiscoveryCreateInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'upsertIcmpActiveDiscovery'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'request'},'value':{'kind':'Variable','name':{'kind':'Name','value':'request'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddresses'}},{'kind':'Field','name':{'kind':'Name','value':'locationId'}},{'kind':'Field','name':{'kind':'Name','value':'snmpConfig'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'ports'}},{'kind':'Field','name':{'kind':'Name','value':'readCommunities'}}]}}]}}]}}]} as unknown as DocumentNode<CreateOrUpdateActiveIcmpDiscoveryMutation, CreateOrUpdateActiveIcmpDiscoveryMutationVariables>
+export const DeleteActiveIcmpDiscoveryDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'DeleteActiveIcmpDiscovery'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'deleteIcmpActiveDiscovery'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}]}]}}]} as unknown as DocumentNode<DeleteActiveIcmpDiscoveryMutation, DeleteActiveIcmpDiscoveryMutationVariables>
+export const TogglePassiveDiscoveryDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'TogglePassiveDiscovery'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'toggle'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'PassiveDiscoveryToggleInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'togglePassiveDiscovery'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'toggle'},'value':{'kind':'Variable','name':{'kind':'Name','value':'toggle'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'toggle'}}]}}]}}]} as unknown as DocumentNode<TogglePassiveDiscoveryMutation, TogglePassiveDiscoveryMutationVariables>
+export const UpsertPassiveDiscoveryDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'UpsertPassiveDiscovery'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'passiveDiscovery'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'PassiveDiscoveryUpsertInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'upsertPassiveDiscovery'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'discovery'},'value':{'kind':'Variable','name':{'kind':'Name','value':'passiveDiscovery'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'locationId'}},{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'snmpCommunities'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPorts'}},{'kind':'Field','name':{'kind':'Name','value':'toggle'}}]}}]}}]} as unknown as DocumentNode<UpsertPassiveDiscoveryMutation, UpsertPassiveDiscoveryMutationVariables>
+export const DeletePassiveDiscoveryDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'DeletePassiveDiscovery'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'deletePassiveDiscovery'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}]}]}}]} as unknown as DocumentNode<DeletePassiveDiscoveryMutation, DeletePassiveDiscoveryMutationVariables>
+export const FindApplicationSeriesDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'findApplicationSeries'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'requestCriteria'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'RequestCriteriaInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findApplicationSeries'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'requestCriteria'},'value':{'kind':'Variable','name':{'kind':'Name','value':'requestCriteria'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'timestamp'}},{'kind':'Field','name':{'kind':'Name','value':'label'}},{'kind':'Field','name':{'kind':'Name','value':'value'}},{'kind':'Field','name':{'kind':'Name','value':'direction'}}]}}]}}]} as unknown as DocumentNode<FindApplicationSeriesQuery, FindApplicationSeriesQueryVariables>
+export const FindApplicationSummariesDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'findApplicationSummaries'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'requestCriteria'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'RequestCriteriaInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findApplicationSummaries'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'requestCriteria'},'value':{'kind':'Variable','name':{'kind':'Name','value':'requestCriteria'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'label'}},{'kind':'Field','name':{'kind':'Name','value':'bytesIn'}},{'kind':'Field','name':{'kind':'Name','value':'bytesOut'}}]}}]}}]} as unknown as DocumentNode<FindApplicationSummariesQuery, FindApplicationSummariesQueryVariables>
+export const FindApplicationsDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'findApplications'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'requestCriteria'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'RequestCriteriaInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findApplications'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'requestCriteria'},'value':{'kind':'Variable','name':{'kind':'Name','value':'requestCriteria'}}}]}]}}]} as unknown as DocumentNode<FindApplicationsQuery, FindApplicationsQueryVariables>
+export const FindExportersDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'findExporters'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'requestCriteria'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'RequestCriteriaInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findExporters'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'requestCriteria'},'value':{'kind':'Variable','name':{'kind':'Name','value':'requestCriteria'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'node'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}}]}},{'kind':'Field','name':{'kind':'Name','value':'ipInterface'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}}]}}]}}]}}]} as unknown as DocumentNode<FindExportersQuery, FindExportersQueryVariables>
+export const CreateLocationDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'CreateLocation'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'location'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'MonitoringLocationCreateInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'createLocation'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'location'},'value':{'kind':'Variable','name':{'kind':'Name','value':'location'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}},{'kind':'Field','name':{'kind':'Name','value':'address'}},{'kind':'Field','name':{'kind':'Name','value':'longitude'}},{'kind':'Field','name':{'kind':'Name','value':'latitude'}}]}}]}}]} as unknown as DocumentNode<CreateLocationMutation, CreateLocationMutationVariables>
+export const UpdateLocationDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'UpdateLocation'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'location'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'MonitoringLocationUpdateInput'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'updateLocation'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'location'},'value':{'kind':'Variable','name':{'kind':'Name','value':'location'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}},{'kind':'Field','name':{'kind':'Name','value':'address'}},{'kind':'Field','name':{'kind':'Name','value':'longitude'}},{'kind':'Field','name':{'kind':'Name','value':'latitude'}}]}}]}}]} as unknown as DocumentNode<UpdateLocationMutation, UpdateLocationMutationVariables>
+export const DeleteLocationDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'DeleteLocation'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'deleteLocation'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}]}]}}]} as unknown as DocumentNode<DeleteLocationMutation, DeleteLocationMutationVariables>
+export const RevokeMinionCertificateDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'revokeMinionCertificate'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'locationId'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'revokeMinionCertificate'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'locationId'},'value':{'kind':'Variable','name':{'kind':'Name','value':'locationId'}}}]}]}}]} as unknown as DocumentNode<RevokeMinionCertificateMutation, RevokeMinionCertificateMutationVariables>
+export const LocationsListDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'LocationsList'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'LocationsParts'}}]}},...LocationsPartsFragmentDoc.definitions]} as unknown as DocumentNode<LocationsListQuery, LocationsListQueryVariables>
+export const SearchLocationDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'SearchLocation'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'searchTerm'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'searchLocation'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'searchTerm'},'value':{'kind':'Variable','name':{'kind':'Name','value':'searchTerm'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}},{'kind':'Field','name':{'kind':'Name','value':'address'}},{'kind':'Field','name':{'kind':'Name','value':'longitude'}},{'kind':'Field','name':{'kind':'Name','value':'latitude'}}]}}]}}]} as unknown as DocumentNode<SearchLocationQuery, SearchLocationQueryVariables>
+export const GetMinionCertificateDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'getMinionCertificate'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'location'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'getMinionCertificate'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'locationId'},'value':{'kind':'Variable','name':{'kind':'Name','value':'location'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'password'}},{'kind':'Field','name':{'kind':'Name','value':'certificate'}}]}}]}}]} as unknown as DocumentNode<GetMinionCertificateQuery, GetMinionCertificateQueryVariables>
+export const DeleteMinionDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'DeleteMinion'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'deleteMinion'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}]}]}}]} as unknown as DocumentNode<DeleteMinionMutation, DeleteMinionMutationVariables>
+export const FindMinionsByLocationIdDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'FindMinionsByLocationId'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'locationId'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findMinionsByLocationId'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'locationId'},'value':{'kind':'Variable','name':{'kind':'Name','value':'locationId'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'label'}},{'kind':'Field','name':{'kind':'Name','value':'lastCheckedTime'}},{'kind':'Field','name':{'kind':'Name','value':'status'}},{'kind':'Field','name':{'kind':'Name','value':'systemId'}},{'kind':'Field','name':{'kind':'Name','value':'location'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}}]}}]}}]} as unknown as DocumentNode<FindMinionsByLocationIdQuery, FindMinionsByLocationIdQueryVariables>
+export const CreateMonitorPolicyDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'CreateMonitorPolicy'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'policy'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'MonitorPolicyInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'createMonitorPolicy'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'policy'},'value':{'kind':'Variable','name':{'kind':'Name','value':'policy'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}}]}}]}}]} as unknown as DocumentNode<CreateMonitorPolicyMutation, CreateMonitorPolicyMutationVariables>
+export const DeletePolicyByIdDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'DeletePolicyById'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'deletePolicyById'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}]}]}}]} as unknown as DocumentNode<DeletePolicyByIdMutation, DeletePolicyByIdMutationVariables>
+export const DeleteRuleByIdDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'DeleteRuleById'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'deleteRuleById'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}]}]}}]} as unknown as DocumentNode<DeleteRuleByIdMutation, DeleteRuleByIdMutationVariables>
+export const AddNodeDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'AddNode'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'node'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'NodeCreateInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'addNode'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'node'},'value':{'kind':'Variable','name':{'kind':'Name','value':'node'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'createTime'}},{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'monitoringLocationId'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}}]}}]}}]} as unknown as DocumentNode<AddNodeMutation, AddNodeMutationVariables>
+export const DeleteNodeDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'DeleteNode'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'deleteNode'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}]}]}}]} as unknown as DocumentNode<DeleteNodeMutation, DeleteNodeMutationVariables>
+export const AddTagsToNodesDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'AddTagsToNodes'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'tags'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TagListNodesAddInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'addTagsToNodes'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'tags'},'value':{'kind':'Variable','name':{'kind':'Name','value':'tags'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}}]}}]}}]} as unknown as DocumentNode<AddTagsToNodesMutation, AddTagsToNodesMutationVariables>
+export const RemoveTagsFromNodesDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'RemoveTagsFromNodes'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'tags'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TagListNodesRemoveInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'removeTagsFromNodes'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'tags'},'value':{'kind':'Variable','name':{'kind':'Name','value':'tags'}}}]}]}}]} as unknown as DocumentNode<RemoveTagsFromNodesMutation, RemoveTagsFromNodesMutationVariables>
+export const UpdateNodeDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'UpdateNode'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'node'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'NodeUpdateInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'updateNode'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'node'},'value':{'kind':'Variable','name':{'kind':'Name','value':'node'}}}]}]}}]} as unknown as DocumentNode<UpdateNodeMutation, UpdateNodeMutationVariables>
+export const SavePagerDutyConfigDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'mutation','name':{'kind':'Name','value':'SavePagerDutyConfig'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'config'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'PagerDutyConfigInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'savePagerDutyConfig'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'config'},'value':{'kind':'Variable','name':{'kind':'Name','value':'config'}}}]}]}}]} as unknown as DocumentNode<SavePagerDutyConfigMutation, SavePagerDutyConfigMutationVariables>
+export const ListTagsDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListTags'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'TagsParts'}}]}},...TagsPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListTagsQuery, ListTagsQueryVariables>
+export const ListTagsSearchDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListTagsSearch'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'searchTerm'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'TagsSearchParts'}}]}},...TagsSearchPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListTagsSearchQuery, ListTagsSearchQueryVariables>
+export const ListTagsByNodeIdsDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListTagsByNodeIds'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'nodeIds'}},'type':{'kind':'ListType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'tagsByNodeIds'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'nodeIds'},'value':{'kind':'Variable','name':{'kind':'Name','value':'nodeIds'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'tags'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}}]}}]}}]}}]} as unknown as DocumentNode<ListTagsByNodeIdsQuery, ListTagsByNodeIdsQueryVariables>
+export const ListAlertEventDefinitionsDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListAlertEventDefinitions'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'eventType'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'EventType'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'listAlertEventDefinitions'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'eventType'},'value':{'kind':'Variable','name':{'kind':'Name','value':'eventType'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'eventType'}}]}}]}}]} as unknown as DocumentNode<ListAlertEventDefinitionsQuery, ListAlertEventDefinitionsQueryVariables>
+export const ListNodesForTableDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListNodesForTable'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'NodesTableParts'}}]}},...NodesTablePartsFragmentDoc.definitions]} as unknown as DocumentNode<ListNodesForTableQuery, ListNodesForTableQueryVariables>
+export const ListMinionsForTableDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListMinionsForTable'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'MinionsTableParts'}}]}},...MinionsTablePartsFragmentDoc.definitions]} as unknown as DocumentNode<ListMinionsForTableQuery, ListMinionsForTableQueryVariables>
+export const ListMinionMetricsDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListMinionMetrics'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'instance'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'monitor'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TimeRangeUnit'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'MinionLatencyParts'}}]}},...MinionLatencyPartsFragmentDoc.definitions,...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListMinionMetricsQuery, ListMinionMetricsQueryVariables>
+export const ListNodeMetricsDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListNodeMetrics'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'monitor'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'instance'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TimeRangeUnit'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'NodeLatencyParts'}},{'kind':'FragmentSpread','name':{'kind':'Name','value':'NodeStatusParts'}}]}},...NodeLatencyPartsFragmentDoc.definitions,...MetricPartsFragmentDoc.definitions,...NodeStatusPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListNodeMetricsQuery, ListNodeMetricsQueryVariables>
+export const ListMinionsAndDevicesForTablesDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListMinionsAndDevicesForTables'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'NodesTableParts'}},{'kind':'FragmentSpread','name':{'kind':'Name','value':'MinionsTableParts'}},{'kind':'FragmentSpread','name':{'kind':'Name','value':'LocationsParts'}}]}},...NodesTablePartsFragmentDoc.definitions,...MinionsTablePartsFragmentDoc.definitions,...LocationsPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListMinionsAndDevicesForTablesQuery, ListMinionsAndDevicesForTablesQueryVariables>
+export const NetworkTrafficDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'NetworkTraffic'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'name'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TimeRangeUnit'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'Variable','name':{'kind':'Name','value':'name'}}},{'kind':'Argument','name':{'kind':'Name','value':'timeRange'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}}},{'kind':'Argument','name':{'kind':'Name','value':'timeRangeUnit'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'status'}},{'kind':'FragmentSpread','name':{'kind':'Name','value':'MetricParts'}}]}}]}},...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<NetworkTrafficQuery, NetworkTrafficQueryVariables>
+export const TopNNodesDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'TopNNodes'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TimeRangeUnit'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'sortAscending'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Boolean'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'pageSize'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'sortBy'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'page'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'topNNode'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'timeRange'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}}},{'kind':'Argument','name':{'kind':'Name','value':'timeRangeUnit'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}}},{'kind':'Argument','name':{'kind':'Name','value':'sortAscending'},'value':{'kind':'Variable','name':{'kind':'Name','value':'sortAscending'}}},{'kind':'Argument','name':{'kind':'Name','value':'pageSize'},'value':{'kind':'Variable','name':{'kind':'Name','value':'pageSize'}}},{'kind':'Argument','name':{'kind':'Name','value':'sortBy'},'value':{'kind':'Variable','name':{'kind':'Name','value':'sortBy'}}},{'kind':'Argument','name':{'kind':'Name','value':'page'},'value':{'kind':'Variable','name':{'kind':'Name','value':'page'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}},{'kind':'Field','name':{'kind':'Name','value':'location'}},{'kind':'Field','name':{'kind':'Name','value':'avgResponseTime'}},{'kind':'Field','name':{'kind':'Name','value':'reachability'}}]}},{'kind':'Field','name':{'kind':'Name','value':'allNodeStatus'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'status'}}]}},{'kind':'Field','name':{'kind':'Name','value':'nodeCount'}}]}}]} as unknown as DocumentNode<TopNNodesQuery, TopNNodesQueryVariables>
+export const DownloadTopNDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'DownloadTopN'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'downloadFormat'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'DownloadFormat'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TimeRangeUnit'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'sortAscending'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Boolean'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'sortBy'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'downloadTopN'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'timeRange'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}}},{'kind':'Argument','name':{'kind':'Name','value':'timeRangeUnit'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}}},{'kind':'Argument','name':{'kind':'Name','value':'sortAscending'},'value':{'kind':'Variable','name':{'kind':'Name','value':'sortAscending'}}},{'kind':'Argument','name':{'kind':'Name','value':'sortBy'},'value':{'kind':'Variable','name':{'kind':'Name','value':'sortBy'}}},{'kind':'Argument','name':{'kind':'Name','value':'downloadFormat'},'value':{'kind':'Variable','name':{'kind':'Name','value':'downloadFormat'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'topNBytes'}}]}}]}}]} as unknown as DocumentNode<DownloadTopNQuery, DownloadTopNQueryVariables>
+export const ListLocationsForDiscoveryDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListLocationsForDiscovery'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'LocationsParts'}}]}},...LocationsPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListLocationsForDiscoveryQuery, ListLocationsForDiscoveryQueryVariables>
+export const ListDiscoveriesDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListDiscoveries'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'passiveDiscoveries'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'locationId'}},{'kind':'Field','name':{'kind':'Name','value':'name'}},{'kind':'Field','name':{'kind':'Name','value':'snmpCommunities'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPorts'}},{'kind':'Field','name':{'kind':'Name','value':'toggle'}}]}},{'kind':'Field','name':{'kind':'Name','value':'listActiveDiscovery'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'details'}},{'kind':'Field','name':{'kind':'Name','value':'discoveryType'}}]}}]}}]} as unknown as DocumentNode<ListDiscoveriesQuery, ListDiscoveriesQueryVariables>
+export const TagsByActiveDiscoveryIdDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'TagsByActiveDiscoveryId'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'discoveryId'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'tagsByActiveDiscoveryId'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'activeDiscoveryId'},'value':{'kind':'Variable','name':{'kind':'Name','value':'discoveryId'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}}]}}]}}]} as unknown as DocumentNode<TagsByActiveDiscoveryIdQuery, TagsByActiveDiscoveryIdQueryVariables>
+export const TagsByPassiveDiscoveryIdDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'TagsByPassiveDiscoveryId'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'discoveryId'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'tagsByPassiveDiscoveryId'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'passiveDiscoveryId'},'value':{'kind':'Variable','name':{'kind':'Name','value':'discoveryId'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}}]}}]}}]} as unknown as DocumentNode<TagsByPassiveDiscoveryIdQuery, TagsByPassiveDiscoveryIdQueryVariables>
+export const GetMetricDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'GetMetric'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'metric'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'TimeSeriesMetric'}}]}},...TimeSeriesMetricFragmentDoc.definitions,...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<GetMetricQuery, GetMetricQueryVariables>
+export const GetTimeSeriesMetricDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'GetTimeSeriesMetric'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'name'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'monitor'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'nodeId'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TimeRangeUnit'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'instance'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','alias':{'kind':'Name','value':'metric'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'Variable','name':{'kind':'Name','value':'name'}}},{'kind':'Argument','name':{'kind':'Name','value':'labels'},'value':{'kind':'ObjectValue','fields':[{'kind':'ObjectField','name':{'kind':'Name','value':'monitor'},'value':{'kind':'Variable','name':{'kind':'Name','value':'monitor'}}},{'kind':'ObjectField','name':{'kind':'Name','value':'node_id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'nodeId'}}},{'kind':'ObjectField','name':{'kind':'Name','value':'instance'},'value':{'kind':'Variable','name':{'kind':'Name','value':'instance'}}}]}},{'kind':'Argument','name':{'kind':'Name','value':'timeRange'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}}},{'kind':'Argument','name':{'kind':'Name','value':'timeRangeUnit'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'MetricParts'}}]}}]}},...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<GetTimeSeriesMetricQuery, GetTimeSeriesMetricQueryVariables>
+export const GetTimeSeriesMetricsWithIfNameDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'GetTimeSeriesMetricsWithIfName'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'name'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'monitor'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'nodeId'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TimeRangeUnit'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'ifName'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','alias':{'kind':'Name','value':'metric'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'Variable','name':{'kind':'Name','value':'name'}}},{'kind':'Argument','name':{'kind':'Name','value':'labels'},'value':{'kind':'ObjectValue','fields':[{'kind':'ObjectField','name':{'kind':'Name','value':'monitor'},'value':{'kind':'Variable','name':{'kind':'Name','value':'monitor'}}},{'kind':'ObjectField','name':{'kind':'Name','value':'node_id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'nodeId'}}},{'kind':'ObjectField','name':{'kind':'Name','value':'if_name'},'value':{'kind':'Variable','name':{'kind':'Name','value':'ifName'}}}]}},{'kind':'Argument','name':{'kind':'Name','value':'timeRange'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}}},{'kind':'Argument','name':{'kind':'Name','value':'timeRangeUnit'},'value':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'MetricParts'}}]}}]}},...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<GetTimeSeriesMetricsWithIfNameQuery, GetTimeSeriesMetricsWithIfNameQueryVariables>
+export const GetNodeForGraphsDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'GetNodeForGraphs'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findNodeById'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPrimary'}}]}},{'kind':'Field','name':{'kind':'Name','value':'scanType'}}]}}]}}]} as unknown as DocumentNode<GetNodeForGraphsQuery, GetNodeForGraphsQueryVariables>
+export const NodesListDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'NodesList'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'NodesParts'}}]}},...NodesPartsFragmentDoc.definitions]} as unknown as DocumentNode<NodesListQuery, NodesListQueryVariables>
+export const NodeLatencyMetricDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'NodeLatencyMetric'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'monitor'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'instance'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRange'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Int'}}}},{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'timeRangeUnit'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'TimeRangeUnit'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'NodeLatencyParts'}},{'kind':'FragmentSpread','name':{'kind':'Name','value':'NodeStatusParts'}}]}},...NodeLatencyPartsFragmentDoc.definitions,...MetricPartsFragmentDoc.definitions,...NodeStatusPartsFragmentDoc.definitions]} as unknown as DocumentNode<NodeLatencyMetricQuery, NodeLatencyMetricQueryVariables>
+export const FindAllNodesByNodeLabelSearchDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'FindAllNodesByNodeLabelSearch'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'labelSearchTerm'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllNodesByNodeLabelSearch'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'labelSearchTerm'},'value':{'kind':'Variable','name':{'kind':'Name','value':'labelSearchTerm'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPrimary'}}]}},{'kind':'Field','name':{'kind':'Name','value':'location'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}},{'kind':'Field','name':{'kind':'Name','value':'tags'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}}]}},{'kind':'Field','name':{'kind':'Name','value':'monitoredState'}},{'kind':'Field','name':{'kind':'Name','value':'monitoringLocationId'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}},{'kind':'Field','name':{'kind':'Name','value':'scanType'}}]}},{'kind':'Field','alias':{'kind':'Name','value':'allMetrics'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'StringValue','value':'response_time_msec','block':false}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'status'}},{'kind':'Field','name':{'kind':'Name','value':'data'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'resultType'}},{'kind':'Field','name':{'kind':'Name','value':'result'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'metric'}},{'kind':'Field','name':{'kind':'Name','value':'value'}},{'kind':'Field','name':{'kind':'Name','value':'values'}}]}}]}}]}}]}}]} as unknown as DocumentNode<FindAllNodesByNodeLabelSearchQuery, FindAllNodesByNodeLabelSearchQueryVariables>
+export const FindAllNodesByTagsDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'FindAllNodesByTags'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'tags'}},'type':{'kind':'ListType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllNodesByTags'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'tags'},'value':{'kind':'Variable','name':{'kind':'Name','value':'tags'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPrimary'}}]}},{'kind':'Field','name':{'kind':'Name','value':'location'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}},{'kind':'Field','name':{'kind':'Name','value':'tags'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}}]}},{'kind':'Field','name':{'kind':'Name','value':'monitoredState'}},{'kind':'Field','name':{'kind':'Name','value':'monitoringLocationId'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}},{'kind':'Field','name':{'kind':'Name','value':'scanType'}}]}},{'kind':'Field','alias':{'kind':'Name','value':'allMetrics'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'StringValue','value':'response_time_msec','block':false}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'status'}},{'kind':'Field','name':{'kind':'Name','value':'data'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'resultType'}},{'kind':'Field','name':{'kind':'Name','value':'result'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'metric'}},{'kind':'Field','name':{'kind':'Name','value':'value'}},{'kind':'Field','name':{'kind':'Name','value':'values'}}]}}]}}]}}]}}]} as unknown as DocumentNode<FindAllNodesByTagsQuery, FindAllNodesByTagsQueryVariables>
+export const FindAllNodesByMonitoredStateDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'FindAllNodesByMonitoredState'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'monitoredState'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'String'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllNodesByMonitoredState'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'monitoredState'},'value':{'kind':'Variable','name':{'kind':'Name','value':'monitoredState'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPrimary'}}]}},{'kind':'Field','name':{'kind':'Name','value':'location'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}},{'kind':'Field','name':{'kind':'Name','value':'monitoringLocationId'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}},{'kind':'Field','name':{'kind':'Name','value':'scanType'}}]}}]}}]} as unknown as DocumentNode<FindAllNodesByMonitoredStateQuery, FindAllNodesByMonitoredStateQueryVariables>
+export const BuildNetworkInventoryPageDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'BuildNetworkInventoryPage'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllNodes'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPrimary'}}]}},{'kind':'Field','name':{'kind':'Name','value':'location'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}},{'kind':'Field','name':{'kind':'Name','value':'tags'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'name'}}]}},{'kind':'Field','name':{'kind':'Name','value':'monitoredState'}},{'kind':'Field','name':{'kind':'Name','value':'monitoringLocationId'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}},{'kind':'Field','name':{'kind':'Name','value':'scanType'}},{'kind':'Field','name':{'kind':'Name','value':'nodeAlias'}}]}},{'kind':'Field','alias':{'kind':'Name','value':'allMetrics'},'name':{'kind':'Name','value':'metric'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'name'},'value':{'kind':'StringValue','value':'response_time_msec','block':false}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'status'}},{'kind':'Field','name':{'kind':'Name','value':'data'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'resultType'}},{'kind':'Field','name':{'kind':'Name','value':'result'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'metric'}},{'kind':'Field','name':{'kind':'Name','value':'value'}},{'kind':'Field','name':{'kind':'Name','value':'values'}}]}}]}}]}}]}}]} as unknown as DocumentNode<BuildNetworkInventoryPageQuery, BuildNetworkInventoryPageQueryVariables>
+export const NodesForMapDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'NodesForMap'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllNodes'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}},{'kind':'Field','name':{'kind':'Name','value':'location'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'latitude'}},{'kind':'Field','name':{'kind':'Name','value':'longitude'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}}]}}]}}]} as unknown as DocumentNode<NodesForMapQuery, NodesForMapQueryVariables>
+export const ListMonitoryPoliciesDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListMonitoryPolicies'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'listMonitoryPolicies'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'MonitoringPolicyParts'}}]}},{'kind':'Field','name':{'kind':'Name','value':'defaultPolicy'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'MonitoringPolicyParts'}}]}}]}},...MonitoringPolicyPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListMonitoryPoliciesQuery, ListMonitoryPoliciesQueryVariables>
+export const CountAlertByPolicyIdDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'CountAlertByPolicyId'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'countAlertByPolicyId'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}]}]}}]} as unknown as DocumentNode<CountAlertByPolicyIdQuery, CountAlertByPolicyIdQueryVariables>
+export const CountAlertByRuleIdDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'CountAlertByRuleId'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'countAlertByRuleId'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'id'},'value':{'kind':'Variable','name':{'kind':'Name','value':'id'}}}]}]}}]} as unknown as DocumentNode<CountAlertByRuleIdQuery, CountAlertByRuleIdQueryVariables>
+export const ListNodeStatusDocument = {'kind':'Document', 'definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'ListNodeStatus'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'id'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'FragmentSpread','name':{'kind':'Name','value':'EventsByNodeIdParts'}},{'kind':'FragmentSpread','name':{'kind':'Name','value':'NodeByIdParts'}}]}},...EventsByNodeIdPartsFragmentDoc.definitions,...NodeByIdPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListNodeStatusQuery, ListNodeStatusQueryVariables>
+export const FindExportersForNodeStatusDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'findExportersForNodeStatus'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'requestCriteria'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'RequestCriteriaInput'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findExporters'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'requestCriteria'},'value':{'kind':'Variable','name':{'kind':'Name','value':'requestCriteria'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'snmpInterface'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'ifIndex'}},{'kind':'Field','name':{'kind':'Name','value':'ifName'}}]}},{'kind':'Field','name':{'kind':'Name','value':'ipInterface'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}}]}}]}}]}}]} as unknown as DocumentNode<FindExportersForNodeStatusQuery, FindExportersForNodeStatusQueryVariables>
+export const FindLocationsForWelcomeDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'FindLocationsForWelcome'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllLocations'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'location'}}]}}]}}]} as unknown as DocumentNode<FindLocationsForWelcomeQuery, FindLocationsForWelcomeQueryVariables>
+export const FindDevicesForWelcomeDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'FindDevicesForWelcome'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findAllNodes'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'nodeLabel'}},{'kind':'Field','name':{'kind':'Name','value':'createTime'}},{'kind':'Field','name':{'kind':'Name','value':'ipInterfaces'},'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}},{'kind':'Field','name':{'kind':'Name','value':'nodeId'}},{'kind':'Field','name':{'kind':'Name','value':'ipAddress'}},{'kind':'Field','name':{'kind':'Name','value':'snmpPrimary'}}]}}]}}]}}]} as unknown as DocumentNode<FindDevicesForWelcomeQuery, FindDevicesForWelcomeQueryVariables>
+export const FindMinionsForWelcomeDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'FindMinionsForWelcome'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'locationId'}},'type':{'kind':'NonNullType','type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'findMinionsByLocationId'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'locationId'},'value':{'kind':'Variable','name':{'kind':'Name','value':'locationId'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'id'}}]}}]}}]} as unknown as DocumentNode<FindMinionsForWelcomeQuery, FindMinionsForWelcomeQueryVariables>
+export const DownloadMinionCertificateForWelcomeDocument = {'kind':'Document','definitions':[{'kind':'OperationDefinition','operation':'query','name':{'kind':'Name','value':'DownloadMinionCertificateForWelcome'},'variableDefinitions':[{'kind':'VariableDefinition','variable':{'kind':'Variable','name':{'kind':'Name','value':'location'}},'type':{'kind':'NamedType','name':{'kind':'Name','value':'Long'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'getMinionCertificate'},'arguments':[{'kind':'Argument','name':{'kind':'Name','value':'locationId'},'value':{'kind':'Variable','name':{'kind':'Name','value':'location'}}}],'selectionSet':{'kind':'SelectionSet','selections':[{'kind':'Field','name':{'kind':'Name','value':'password'}},{'kind':'Field','name':{'kind':'Name','value':'certificate'}}]}}]}}]} as unknown as DocumentNode<DownloadMinionCertificateForWelcomeQuery, DownloadMinionCertificateForWelcomeQueryVariables>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -1,6 +1,5 @@
 import { SORT } from '@featherds/table'
 import { PointerAlignment, PopoverPlacement } from '@featherds/popover'
-// import { ComputedRef } from 'vue'
 
 export * from './flows.d'
 export * from './inventory.d'

--- a/ui/src/types/inventory.d.ts
+++ b/ui/src/types/inventory.d.ts
@@ -32,6 +32,7 @@ interface NewInventoryNode {
   tags: [{id:number, name: string}],
   nodeAlias: string
 }
+
 interface RawMetric {
   metric: {
     __name__:string,
@@ -53,18 +54,16 @@ interface RawMetrics {
   }
 }
 
-
 export interface InventoryItem extends NewInventoryNode{
-    metrics?: RawMetric
-}
-export interface InventoryPage {
-    nodes: Array<InventoryItem>;
+  metrics?: RawMetric
 }
 
+export interface InventoryPage {
+  nodes: Array<InventoryItem>;
+}
 
 export const enum MonitoredStates {
   MONITORED = 'MONITORED',
   UNMONITORED = 'UNMONITORED',
   DETECTED = 'DETECTED'
 }
-

--- a/ui/src/types/locations.d.ts
+++ b/ui/src/types/locations.d.ts
@@ -1,5 +1,4 @@
 import { MonitoringLocation } from '@/types/graphql'
-import { ContextMenuItem } from '@/types'
 
 // temp
 export interface LocationTemp extends MonitoringLocation {

--- a/ui/tests/Common/collapsingCard.test.ts
+++ b/ui/tests/Common/collapsingCard.test.ts
@@ -4,13 +4,12 @@ import CollapsingCard from '@/components/Common/CollapsingCard.vue'
 let wrapper: any
 
 describe('CollapsingCard', () => {
-    beforeAll(() => {
-        wrapper = mount(CollapsingCard as any, { shallow: true, props: { title: '', open: false, headerClicked: () => ({}) } })
-    })
+  beforeAll(() => {
+    wrapper = mount(CollapsingCard as any, { shallow: true, props: { title: '', open: false, headerClicked: () => ({}) } })
+  })
 
-    test('Mount component', () => {
-        const cmp = wrapper.get('[data-test="collapsing-card-wrapper"]')
-        expect(cmp.exists()).toBeTruthy()
-    })
-
+  test('Mount component', () => {
+    const cmp = wrapper.get('[data-test="collapsing-card-wrapper"]')
+    expect(cmp.exists()).toBeTruthy()
+  })
 })

--- a/ui/tests/Common/collapsingWrapper.test.ts
+++ b/ui/tests/Common/collapsingWrapper.test.ts
@@ -4,13 +4,12 @@ import CollapsingWrapper from '@/components/Common/CollapsingWrapper.vue'
 let wrapper: any
 
 describe('CollapsingWrapper', () => {
-    beforeAll(() => {
-        wrapper = mount(CollapsingWrapper as any, { shallow: false, props: { open: false }, slots: { default: '<div></div>' } })
-    })
+  beforeAll(() => {
+    wrapper = mount(CollapsingWrapper as any, { shallow: false, props: { open: false }, slots: { default: '<div></div>' } })
+  })
 
-    test('Mount component', () => {
-        const cmp = wrapper.get('[data-test="collapsing-wrapper-wrapper"]')
-        expect(cmp.exists()).toBeTruthy()
-    })
-
+  test('Mount component', () => {
+    const cmp = wrapper.get('[data-test="collapsing-wrapper-wrapper"]')
+    expect(cmp.exists()).toBeTruthy()
+  })
 })

--- a/ui/tests/Common/itemPreview.test.ts
+++ b/ui/tests/Common/itemPreview.test.ts
@@ -4,24 +4,23 @@ import ItemPreview from '@/components/Common/ItemPreview.vue'
 let wrapper: any
 
 describe('ItemPreview', () => {
-    beforeAll(() => {
-        wrapper = mount(ItemPreview, { 
-            shallow: true,
-            props: {
-                loading: false,
-                loadingCopy: '',
-                title: '',
-                itemTitle: '',
-                itemSubtitle: '',
-                bottomCopy: '',
-                itemStatuses: []
-            }
-        })
+  beforeAll(() => {
+    wrapper = mount(ItemPreview, { 
+      shallow: true,
+      props: {
+        loading: false,
+        loadingCopy: '',
+        title: '',
+        itemTitle: '',
+        itemSubtitle: '',
+        bottomCopy: '',
+        itemStatuses: []
+      }
     })
+  })
 
-    test('Mount component', () => {
-        const cmp = wrapper.get('[data-test="item-preview"]')
-        expect(cmp.exists()).toBeTruthy()
-    })
-
+  test('Mount component', () => {
+    const cmp = wrapper.get('[data-test="item-preview"]')
+    expect(cmp.exists()).toBeTruthy()
+  })
 })

--- a/ui/tests/Common/logoDarkIcon.test.ts
+++ b/ui/tests/Common/logoDarkIcon.test.ts
@@ -4,13 +4,12 @@ import LogoDarkIcon from '@/components/Common/LogoDarkIcon.vue'
 let wrapper: any
 
 describe('LogoDarkIcon', () => {
-    beforeAll(() => {
-        wrapper = mount(LogoDarkIcon, { shallow: true })
-    })
+  beforeAll(() => {
+    wrapper = mount(LogoDarkIcon, { shallow: true })
+  })
 
-    test('Mount component', () => {
-        const cmp = wrapper.get('[data-test="logo-dark-icon"]')
-        expect(cmp.exists()).toBeTruthy()
-    })
-
+  test('Mount component', () => {
+    const cmp = wrapper.get('[data-test="logo-dark-icon"]')
+    expect(cmp.exists()).toBeTruthy()
+  })
 })

--- a/ui/tests/Dashboard/dashboardEmptyState.test.ts
+++ b/ui/tests/Dashboard/dashboardEmptyState.test.ts
@@ -12,7 +12,7 @@ describe('Dashboard EmptyState component', () => {
       props: {
         texts: dashboardTexts.NetworkTraffic,
         redirectLink: 'Inventory'
-      },
+      }
     })
   })
   afterAll(() => {

--- a/ui/tests/Discovery/discovery.test.ts
+++ b/ui/tests/Discovery/discovery.test.ts
@@ -2,10 +2,9 @@ import Discovery from '@/containers/Discovery.vue'
 import mount from 'tests/mountWithPiniaVillus'
 import router from '@/router'
 import { useDiscoveryStore } from '@/store/Views/discoveryStore'
-import { useDiscoveryQueries } from '@/store/Queries/discoveryQueries'
-import { DiscoveryType } from '@/components/Discovery/discovery.constants'
 
 let wrapper: any
+
 describe('DiscoveryPage', () => {
   beforeAll(() => {
     wrapper = mount({
@@ -16,6 +15,7 @@ describe('DiscoveryPage', () => {
       stubActions: false
     })
   })
+
   afterAll(() => {
     wrapper.unmount()
   })
@@ -62,6 +62,7 @@ describe('DiscoveryPage', () => {
     const store = useDiscoveryStore()
     store.selectedDiscovery.meta = undefined as any
     store.setMetaSelectedDiscoveryValue('communityStrings', 'public')
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     expect(store.selectedDiscovery.meta.communityStrings).toBe('public')
   })
@@ -78,6 +79,7 @@ describe('DiscoveryPage', () => {
     expect(store.selectedDiscovery.locations).toBeFalsy()
 
     store.applyDefaultLocation(locationsSingle, defaultLocation)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(store.selectedDiscovery.locations![0].location).toBe('Default')
   })
 })

--- a/ui/tests/Graphs/graphs.test.ts
+++ b/ui/tests/Graphs/graphs.test.ts
@@ -12,8 +12,10 @@ const mockCanvas = {
   offsetWidth: 100,
   offsetHeight: 100,
   toDataURL: () => '',
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getContext: (...p: any) => {
     return {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
       drawImage: (...p: any) => {}
     } as CanvasRenderingContext2D
   }
@@ -34,10 +36,12 @@ vi.mock('jspdf', () => {
         }
       }
     }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     addImage() {}
     getImageProperties() {
       return { width: 100, height: 100 }
     }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     save() {}
   }
 

--- a/ui/tests/Inventory/inventoryFilter.test.ts
+++ b/ui/tests/Inventory/inventoryFilter.test.ts
@@ -20,7 +20,7 @@ describe('InventoryFilter.vue', () => {
 
   describe('Required components', () => {
     const requiredComponents = [
-      'tag-manager-ctrl',
+      'tag-manager-ctrl'
     ]
 
     it.each(requiredComponents)('should have "%s" component', (item) => {

--- a/ui/tests/Inventory/inventoryTabContent.test.ts
+++ b/ui/tests/Inventory/inventoryTabContent.test.ts
@@ -1,6 +1,6 @@
 import mount from '../mountWithPiniaVillus'
 import InventoryTabContent from '@/components/Inventory/InventoryTabContent.vue'
-import { InventoryItem, InventoryNode, MonitoredStates, TimeUnit } from '@/types'
+import { InventoryItem, MonitoredStates } from '@/types'
 
 const tabContent: InventoryItem[] = [
   {
@@ -35,6 +35,7 @@ describe('InventoryTabContent.vue', () => {
       }
     })
   })
+
   afterAll(() => {
     if (wrapper && wrapper.unmount){
       wrapper.unmount()
@@ -42,6 +43,7 @@ describe('InventoryTabContent.vue', () => {
   })
 
   const tabComponents = ['heading', 'text-anchor-list']
+
   it.each(tabComponents)('should have "%s" components', (cmp) => {
     expect(wrapper.get(`[data-test="${cmp}"]`).exists()).toBe(true)
   })

--- a/ui/tests/Locations/locationsList.test.ts
+++ b/ui/tests/Locations/locationsList.test.ts
@@ -48,7 +48,7 @@ describe('LocationsList', () => {
   })
 
   test('Should have a header', () => {
-    let elem = wrapper.get('[data-test="header"]')
+    const elem = wrapper.get('[data-test="header"]')
     expect(elem.exists()).toBeTruthy()
   })
 

--- a/ui/tests/MonitoringPolicies/monitoringPolicies.test.ts
+++ b/ui/tests/MonitoringPolicies/monitoringPolicies.test.ts
@@ -89,11 +89,13 @@ describe('Monitoring Policies', () => {
     const store = useMonitoringPoliciesStore()
     const saveRuleBtn = wrapper.get('[data-test="save-rule-btn"]')
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(store.selectedPolicy!.rules?.length).toBe(0)
     await wrapper.get('[data-test="rule-name-input"] .feather-input').setValue('Rule1')
     await saveRuleBtn.trigger('click')
 
     expect(store.saveRule).toHaveBeenCalledTimes(1)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(store.selectedPolicy!.rules?.length).toBe(1)
   })
 
@@ -121,7 +123,9 @@ describe('Monitoring Policies', () => {
     const editPolicyBtn = wrapper.get('[data-test="policy-edit-btn"]')
     await editPolicyBtn.trigger('click')
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(store.selectedPolicy!.id).toBe(1)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(store.selectedPolicy!.name).toBe('Policy1')
   })
 

--- a/ui/tests/Utils/validationService.test.ts
+++ b/ui/tests/Utils/validationService.test.ts
@@ -1,10 +1,9 @@
 import { validationErrorsToStringRecord } from '@/services/validationService'
 import { ValidationError } from 'yup'
 
-
 describe('Validation Service Tests', () => {
-    test('The Validation Service properly transforms an error message', () => {
-        const errors = validationErrorsToStringRecord({ inner: [{ path: 'name', message: 'error with name' }] } as ValidationError)
-        expect(errors).toEqual({ name: 'error with name' })
-    })
-});
+  test('The Validation Service properly transforms an error message', () => {
+    const errors = validationErrorsToStringRecord({ inner: [{ path: 'name', message: 'error with name' }] } as ValidationError)
+    expect(errors).toEqual({ name: 'error with name' })
+  })
+})

--- a/ui/tests/Welcome/welcome.test.ts
+++ b/ui/tests/Welcome/welcome.test.ts
@@ -5,30 +5,29 @@ import router from '@/router'
 let wrapper: any
 
 describe('WelcomeGuide', () => {
-    beforeAll(() => {
-        wrapper = mount({
-            component: Welcome,
-            global: {
-                plugins: [router]
-            }
-        })
+  beforeAll(() => {
+    wrapper = mount({
+      component: Welcome,
+      global: {
+        plugins: [router]
+      }
     })
-    afterAll(() => {
-        wrapper.unmount()
-    })
+  })
+  afterAll(() => {
+    wrapper.unmount()
+  })
 
-    test('Mount', () => {
-        expect(wrapper).toBeTruthy()
-    })
+  test('Mount', () => {
+    expect(wrapper).toBeTruthy()
+  })
 
-    test('Should have a logo', () => {
-        const elem = wrapper.get('[data-test="welcome-logo"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have a logo', () => {
+    const elem = wrapper.get('[data-test="welcome-logo"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-    test('Should have a gradient background', () => {
-        const elem = wrapper.get('[data-test="gradient-bg"]')
-        expect(elem.exists()).toBeTruthy()
-    })
-
+  test('Should have a gradient background', () => {
+    const elem = wrapper.get('[data-test="gradient-bg"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 })

--- a/ui/tests/Welcome/welcomeSlideOne.test.ts
+++ b/ui/tests/Welcome/welcomeSlideOne.test.ts
@@ -4,36 +4,35 @@ import WelcomeSlideOne from '@/components/Welcome/WelcomeSlideOne.vue'
 let wrapper: any
 
 describe('WelcomeSlideOne', () => {
-    beforeAll(() => {
-        wrapper = mount({
-            component: WelcomeSlideOne,
-            shallow: false
-        })
+  beforeAll(() => {
+    wrapper = mount({
+      component: WelcomeSlideOne,
+      shallow: false
     })
-    afterAll(() => {
-        wrapper.unmount()
-    })
+  })
 
-    test('Mount', () => {
-        expect(wrapper).toBeTruthy()
-    })
+  afterAll(() => {
+    wrapper.unmount()
+  })
 
-    test('Should have a title', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-one-title"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Mount', () => {
+    expect(wrapper).toBeTruthy()
+  })
 
-    test('Should have a requirements table', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-one-toggler"]')
-        elem.trigger('click');
-        const elem1 = wrapper.get('[data-test="welcome-system-requirements-table"]')
-        expect(elem1.exists()).toBeTruthy()
-    })
+  test('Should have a title', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-one-title"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-    test('Should have a button to advance to the next slide', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-one-setup-button"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have a requirements table', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-one-toggler"]')
+    elem.trigger('click')
+    const elem1 = wrapper.get('[data-test="welcome-system-requirements-table"]')
+    expect(elem1.exists()).toBeTruthy()
+  })
 
+  test('Should have a button to advance to the next slide', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-one-setup-button"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 })
-

--- a/ui/tests/Welcome/welcomeSlideThree.test.ts
+++ b/ui/tests/Welcome/welcomeSlideThree.test.ts
@@ -4,57 +4,57 @@ import WelcomeSlideThree from '@/components/Welcome/WelcomeSlideThree.vue'
 let wrapper: any
 
 describe.skip('WelcomeSlideTwo', () => {
-    beforeAll(() => {
-        wrapper = mount({
-            component: WelcomeSlideThree,
-        })
+  beforeAll(() => {
+    wrapper = mount({
+      component: WelcomeSlideThree
     })
-    afterAll(() => {
-        wrapper.unmount()
-    })
+  })
 
-    test('Mount', () => {
-        expect(wrapper).toBeTruthy()
-    })
+  afterAll(() => {
+    wrapper.unmount()
+  })
 
-    test('Should have a title', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-three-title"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Mount', () => {
+    expect(wrapper).toBeTruthy()
+  })
 
-    test('Should have a name field', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-three-name-input"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have a title', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-three-title"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-    test('Should have an ip field', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-three-ip-input"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have a name field', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-three-name-input"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-    test('Should have a community string field ', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-three-communityString-input"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have an ip field', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-three-ip-input"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-    test('Should have a port field ', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-three-port-input"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have a community string field ', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-three-communityString-input"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-    test('Should have a start discovery button', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-three-start-discovery-button"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have a port field ', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-three-port-input"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-    test('Should have a skip button', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-three-skip-button"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have a start discovery button', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-three-start-discovery-button"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-    test('Should have a continue button', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-two-continue-button"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have a skip button', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-three-skip-button"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
+  test('Should have a continue button', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-two-continue-button"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 })

--- a/ui/tests/Welcome/welcomeSlideTwo.test.ts
+++ b/ui/tests/Welcome/welcomeSlideTwo.test.ts
@@ -5,54 +5,53 @@ import WelcomeSlideTwo from '@/components/Welcome/WelcomeSlideTwo.vue'
 let wrapper: any
 
 describe.skip('WelcomeSlideTwo', () => {
-    beforeAll(() => {
-        wrapper = mount({
-            component: WelcomeSlideTwo,
-        })
+  beforeAll(() => {
+    wrapper = mount({
+      component: WelcomeSlideTwo
     })
-    afterAll(() => {
-        wrapper.unmount()
-    })
+  })
 
-    test('Mount', () => {
-        expect(wrapper).toBeTruthy()
-    })
+  afterAll(() => {
+    wrapper.unmount()
+  })
 
-    test('Should have a title', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-two-title"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Mount', () => {
+    expect(wrapper).toBeTruthy()
+  })
 
-    test('Should have a location information callout', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-two-callout"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have a title', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-two-title"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-    test('Welcome Slide Two Download Button Works', async () => {
+  test('Should have a location information callout', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-two-callout"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-        const welcomeStore = useWelcomeStore();
-        const elem = wrapper.get('[data-test="welcome-slide-two-download-button"]')
-        await elem.trigger('click');
-        const hiddenElem = wrapper.get('[data-test="welcome-slide-two-internal"]')
-        expect(hiddenElem).toBeDefined();
-        expect(welcomeStore.minionStatusLoading).toBeTruthy()
-    })
-    test('Welcome Slide Two Minion Detector is working', async () => {
+  test('Welcome Slide Two Download Button Works', async () => {
+    const welcomeStore = useWelcomeStore()
+    const elem = wrapper.get('[data-test="welcome-slide-two-download-button"]')
+    await elem.trigger('click')
+    const hiddenElem = wrapper.get('[data-test="welcome-slide-two-internal"]')
+    expect(hiddenElem).toBeDefined()
+    expect(welcomeStore.minionStatusLoading).toBeTruthy()
+  })
 
-        const welcomeStore = useWelcomeStore();
-        const elem = wrapper.get('[data-test="welcome-slide-two-download-button"]')
-        await elem.trigger('click');
-        expect(welcomeStore.minionStatusLoading).toBeTruthy()
-    })
+  test('Welcome Slide Two Minion Detector is working', async () => {
+    const welcomeStore = useWelcomeStore()
+    const elem = wrapper.get('[data-test="welcome-slide-two-download-button"]')
+    await elem.trigger('click')
+    expect(welcomeStore.minionStatusLoading).toBeTruthy()
+  })
 
-    test('Should have a back button', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-two-back-button"]')
-        expect(elem.exists()).toBeTruthy()
-    })
+  test('Should have a back button', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-two-back-button"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 
-    test('Should have a continue button', () => {
-        const elem = wrapper.get('[data-test="welcome-slide-two-continue-button"]')
-        expect(elem.exists()).toBeTruthy()
-    })
-
+  test('Should have a continue button', () => {
+    const elem = wrapper.get('[data-test="welcome-slide-two-continue-button"]')
+    expect(elem.exists()).toBeTruthy()
+  })
 })

--- a/ui/tests/app.test.ts
+++ b/ui/tests/app.test.ts
@@ -6,16 +6,15 @@ import { useWelcomeStore } from '@/store/Views/welcomeStore'
 let wrapper: any
 
 describe('AppTest', () => {
-    beforeAll(() => {
-        createTestingPinia()
-        const welcomeStore = useWelcomeStore();
-        welcomeStore.ready = true;
-        wrapper = mount(App, { shallow: true })
-    })
+  beforeAll(() => {
+    createTestingPinia()
+    const welcomeStore = useWelcomeStore()
+    welcomeStore.ready = true
+    wrapper = mount(App, { shallow: true })
+  })
 
-    test('Mount component', () => {
-        const cmp = wrapper.get('[data-test="main-content"]')
-        expect(cmp.exists()).toBeTruthy()
-    })
-
+  test('Mount component', () => {
+    const cmp = wrapper.get('[data-test="main-content"]')
+    expect(cmp.exists()).toBeTruthy()
+  })
 })

--- a/ui/tests/fixture/data/alerts.ts
+++ b/ui/tests/fixture/data/alerts.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import casual from 'casual'
 import { rndSeverity } from '../../helpers/random'

--- a/ui/tests/fixture/events.ts
+++ b/ui/tests/fixture/events.ts
@@ -7,6 +7,7 @@ const mockData: Event = {
   ipAddress: '127.0.0.1',
   producedTime: '2022-09-20T09:25:44Z'
 }
+
 const eventsFixture = (props: Partial<Event> = {}) => ({
   events: [{ ...mockData, ...props }]
 })

--- a/ui/tests/fixture/locations.ts
+++ b/ui/tests/fixture/locations.ts
@@ -7,6 +7,7 @@ const mockLocation: MonitoringLocation = {
   latitude: 0.0,
   longitude: 0.0 
 }
+
 const locationsFixture = (props: Partial<MonitoringLocation> = {}): MonitoringLocation[] => [{ ...mockLocation, ...props }]
 
 const expectedLocations = [
@@ -18,5 +19,4 @@ const expectedLocations = [
     longitude: 0.0 
   }
 ]
-
 export { locationsFixture, expectedLocations }

--- a/ui/tests/fixture/metrics.ts
+++ b/ui/tests/fixture/metrics.ts
@@ -12,6 +12,7 @@ const mockMinionLatency: TsResult = {
   },
   value: [1662670391.864, 2]
 }
+
 const minionLatencyFixture = (props: Partial<TsResult> = {}): TimeSeriesQueryResult => ({
   data: {
     result: [{ ...mockMinionLatency, ...props }]
@@ -27,6 +28,7 @@ const mockMinionUptime: TsResult = {
   },
   value: [1662670391.861, 97419]
 }
+
 const minionUptimeFixture = (props: Partial<TsResult> = {}): TimeSeriesQueryResult => ({
   data: {
     result: [{ ...mockMinionUptime, ...props }]
@@ -42,6 +44,7 @@ const mockDeviceLatency: TsResult = {
   },
   value: [1662657451.683, 0.17]
 }
+
 const deviceLatencyFixture = (props: Partial<TsResult> = {}): TimeSeriesQueryResult => ({
   data: {
     result: [{ ...mockDeviceLatency, ...props }]
@@ -49,6 +52,7 @@ const deviceLatencyFixture = (props: Partial<TsResult> = {}): TimeSeriesQueryRes
 })
 
 const mockDeviceUptime: TsResult = {}
+
 const deviceUptimeFixture = (props: Partial<TsResult> = {}): TimeSeriesQueryResult => ({
   data: {
     result: Object.keys(mockDeviceUptime).length ? [{ ...mockDeviceUptime, ...props }] : []

--- a/ui/tests/fixture/welcome.ts
+++ b/ui/tests/fixture/welcome.ts
@@ -1,40 +1,40 @@
 export const defaultNodeDetails = (dateN: number) => ({
-    ListNodesForTable: {
-        findAllNodes: [
-            {
-                id: 1,
-                nodeLabel: '192.168.1.1',
-                createTime: dateN,
-                monitoringLocationId: 1,
-                ipInterfaces: [{ ipAddress: '192.168.1.1', snmpPrimary: true }], scanType: 'DISCOVERY_SCAN'
-            }]
+  ListNodesForTable: {
+    findAllNodes: [
+      {
+        id: 1,
+        nodeLabel: '192.168.1.1',
+        createTime: dateN,
+        monitoringLocationId: 1,
+        ipInterfaces: [{ ipAddress: '192.168.1.1', snmpPrimary: true }], scanType: 'DISCOVERY_SCAN'
+      }]
+  },
+  ListNodeMetrics: {
+    nodeLatency: {
+      'status': 'success',
+      'data': {
+        'result': [
+          {
+            'metric': {
+              'instance': '192.168.1.1',
+              'location_id': '2',
+              'monitor': 'ICMP',
+              'node_id': '1',
+              'system_id': 'default'
+            },
+            'values': [
+              [
+                1687795918.388,
+                7.129
+              ]
+            ]
+          }
+        ]
+      }
     },
-    ListNodeMetrics: {
-        nodeLatency: {
-            "status": "success",
-            "data": {
-                "result": [
-                    {
-                        "metric": {
-                            "instance": "192.168.1.1",
-                            "location_id": "2",
-                            "monitor": "ICMP",
-                            "node_id": "1",
-                            "system_id": "default"
-                        },
-                        "values": [
-                            [
-                                1687795918.388,
-                                7.129
-                            ]
-                        ]
-                    }
-                ]
-            }
-        },
-        nodeStatus: {
-            "id": 1,
-            "status": "UP"
-        }
+    nodeStatus: {
+      'id': 1,
+      'status': 'UP'
     }
+  }
 })

--- a/ui/tests/mountWithPiniaVillus.ts
+++ b/ui/tests/mountWithPiniaVillus.ts
@@ -43,7 +43,7 @@ const wrapper = (mountingOption: Record<string, any>): any => {
         [VILLUS_CLIENT as unknown as string]: createClient({
           url: 'https://test/graphql'
         }),
-        ...provide,
+        ...provide
       },
       directives: { ...directives }
     },

--- a/ui/tests/store/Queries/welcomeQueries.test.ts
+++ b/ui/tests/store/Queries/welcomeQueries.test.ts
@@ -5,101 +5,101 @@ import { createTestingPinia } from '@pinia/testing'
 import { useWelcomeQueries } from '@/store/Queries/welcomeQueries'
 import { defaultNodeDetails } from 'tests/fixture/welcome'
 
-
 describe('Welcome Queries', () => {
-    beforeEach(() => {
-        createTestingPinia({ stubActions: false })
+  beforeEach(() => {
+    createTestingPinia({ stubActions: false })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('perform store init', async () => {
+    global.fetch = buildFetchList({
+      FindLocationsForWelcome: { findAllLocations: [{ id: 1, location: 'default' }] },
+      ListMinionsForTable: { findAllMinions: [{ id: 1, label: 'DEFAULT', lastCheckedTime: Date.now(), location: { id: 2, location: 'default' } }] }
     })
 
-    afterEach(() => {
-        vi.restoreAllMocks()
+    setActiveClient(useClient({ url: 'http://test/graphql' }))
+
+    const welcomeStore = useWelcomeStore()
+    await welcomeStore.init()
+    expect(welcomeStore.firstLocation).toStrictEqual({ id: -1, location: '' })
+  })
+
+  it('get all welcome minions', async () => {
+    const dateN = Date.now()
+
+    global.fetch = buildFetchList({
+      ListMinionsForTable: { findAllMinions: [{ id: 1, label: 'DEFAULT', lastCheckedTime: dateN, location: { id: 2, location: 'default' } }] }
+    })
+    setActiveClient(useClient({ url: 'http://test/graphql' }))
+
+    const welcomeStore = useWelcomeQueries()
+    const minions = await welcomeStore.getAllMinions()
+    expect(minions).toStrictEqual([{ id: 1, label: 'DEFAULT', lastCheckedTime: dateN, location: { id: 2, location: 'default' } }])
+  })
+
+  it('get all welcome locations', async () => {
+    global.fetch = buildFetchList({
+      FindLocationsForWelcome: { findAllLocations: [{ id: 1, location: 'default' }] }
+    })
+    setActiveClient(useClient({ url: 'http://test/graphql' }))
+
+    const welcomeStore = useWelcomeQueries()
+    const locations = await welcomeStore.getLocationsForWelcome()
+    expect(locations).toStrictEqual([{ id: 1, location: 'default' }])
+  })
+
+  it('get welcome minion certificate', async () => {
+    global.fetch = buildFetchList({
+      getMinionCertificate: { getMinionCertificate: { password: 'tempPassword', certificate: '234234098098' } }
+    })
+    setActiveClient(useClient({ url: 'http://test/graphql' }))
+
+    const welcomeStore = useWelcomeQueries()
+    const minionCert = await welcomeStore.getMinionCertificate(1)
+    expect(minionCert).toStrictEqual({ password: 'tempPassword', certificate: '234234098098' })
+  })
+
+  it('get welcome node details', async () => {
+    const dateN = Date.now()
+
+    global.fetch = buildFetchList({
+      ...defaultNodeDetails(dateN)
     })
 
-    it('perform store init', async () => {
+    setActiveClient(useClient({ url: 'http://test/graphql' }))
 
-        global.fetch = buildFetchList({
-            FindLocationsForWelcome: { findAllLocations: [{ id: 1, location: 'default' }] },
-            ListMinionsForTable: { findAllMinions: [{ id: 1, label: 'DEFAULT', lastCheckedTime: Date.now(), location: { id: 2, location: 'default' } }] }
-        })
-        setActiveClient(useClient({ url: 'http://test/graphql' }))
+    const welcomeStore = useWelcomeQueries()
+    const minionCert = await welcomeStore.getNodeDetails('default')
 
-        const welcomeStore = useWelcomeStore()
-        await welcomeStore.init();
-        expect(welcomeStore.firstLocation).toStrictEqual({ id: -1, location: '' })
+    expect(minionCert).toStrictEqual({
+      detail: {
+        id: 1,
+        nodeLabel: '192.168.1.1',
+        createTime: dateN,
+        monitoringLocationId: 1,
+        ipInterfaces: [{ ipAddress: '192.168.1.1', snmpPrimary: true }], scanType: 'DISCOVERY_SCAN'
+      },
+      metrics: {
+        nodeLatency: {
+          status: 'success', data: {
+            result: [{
+              metric: {
+                instance: '192.168.1.1',
+                location_id: '2',
+                monitor: 'ICMP',
+                node_id: '1',
+                system_id: 'default'
+              }, values: [
+                [1687795918.388, 7.129]
+              ]
+            }]
+          }
+        },
+        nodeStatus: { id: 1, status: 'UP' }
+      }
     })
-
-    it('get all welcome minions', async () => {
-
-        const dateN = Date.now()
-        global.fetch = buildFetchList({
-            ListMinionsForTable: { findAllMinions: [{ id: 1, label: 'DEFAULT', lastCheckedTime: dateN, location: { id: 2, location: 'default' } }] }
-        })
-        setActiveClient(useClient({ url: 'http://test/graphql' }))
-
-        const welcomeStore = useWelcomeQueries()
-        const minions = await welcomeStore.getAllMinions();
-        expect(minions).toStrictEqual([{ id: 1, label: 'DEFAULT', lastCheckedTime: dateN, location: { id: 2, location: 'default' } }])
-    })
-
-    it('get all welcome locations', async () => {
-        const dateN = Date.now()
-        global.fetch = buildFetchList({
-            FindLocationsForWelcome: { findAllLocations: [{ id: 1, location: 'default' }] },
-        })
-        setActiveClient(useClient({ url: 'http://test/graphql' }))
-
-        const welcomeStore = useWelcomeQueries()
-        const locations = await welcomeStore.getLocationsForWelcome();
-        expect(locations).toStrictEqual([{ id: 1, location: 'default' }])
-    })
-
-    it('get welcome minion certificate', async () => {
-        global.fetch = buildFetchList({
-            getMinionCertificate: { getMinionCertificate: { password: 'tempPassword', certificate: '234234098098' } },
-        })
-        setActiveClient(useClient({ url: 'http://test/graphql' }))
-
-        const welcomeStore = useWelcomeQueries()
-        const minionCert = await welcomeStore.getMinionCertificate(1)
-        expect(minionCert).toStrictEqual({ password: 'tempPassword', certificate: '234234098098' })
-    })
-
-    it('get welcome node details', async () => {
-        const dateN = Date.now()
-        global.fetch = buildFetchList({
-            ...defaultNodeDetails(dateN)
-        })
-
-        setActiveClient(useClient({ url: 'http://test/graphql' }))
-
-        const welcomeStore = useWelcomeQueries()
-        const minionCert = await welcomeStore.getNodeDetails('default');
-        expect(minionCert).toStrictEqual({
-            detail: {
-                id: 1,
-                nodeLabel: '192.168.1.1',
-                createTime: dateN,
-                monitoringLocationId: 1,
-                ipInterfaces: [{ ipAddress: '192.168.1.1', snmpPrimary: true }], scanType: 'DISCOVERY_SCAN'
-            },
-            metrics: {
-                nodeLatency: {
-                    status: 'success', data: {
-                        result: [{
-                            metric: {
-                                instance: '192.168.1.1',
-                                location_id: '2',
-                                monitor: 'ICMP',
-                                node_id: '1',
-                                system_id: 'default'
-                            }, values: [
-                                [1687795918.388, 7.129]
-                            ]
-                        }]
-                    }
-                },
-                nodeStatus: { id: 1, status: 'UP' }
-            }
-        })
-    })
+  })
 })

--- a/ui/tests/store/Views/nodeStatusStore.test.ts
+++ b/ui/tests/store/Views/nodeStatusStore.test.ts
@@ -30,6 +30,7 @@ describe('Node Status Store', () => {
     await store.fetchExporters(1)
 
     expect(queries.fetchExporters).toHaveBeenCalledOnce()
+
     expect(queries.fetchExporters).toHaveBeenCalledWith({
       exporter: [
         {

--- a/ui/tests/store/Views/welcomeStore.test.ts
+++ b/ui/tests/store/Views/welcomeStore.test.ts
@@ -3,135 +3,139 @@ import { setActiveClient, useClient } from 'villus'
 import { buildFetchList } from 'tests/utils'
 import { createTestingPinia } from '@pinia/testing'
 
-
 describe('Welcome Store', () => {
-    beforeEach(() => {
-        createTestingPinia({ stubActions: false })
+  beforeEach(() => {
+    createTestingPinia({ stubActions: false })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('perform store init', async () => {
+    global.fetch = buildFetchList({
+      FindLocationsForWelcome: { findAllLocations: [{ id: 1, location: 'default' }] },
+      ListMinionsForTable: { findAllMinions: [{ id: 1, label: 'DEFAULT', lastCheckedTime: Date.now(), location: { id: 2, location: 'default' } }] }
     })
 
-    afterEach(() => {
-        vi.restoreAllMocks()
+    setActiveClient(useClient({ url: 'http://test/graphql' }))
+
+    const welcomeStore = useWelcomeStore()
+    await welcomeStore.init()
+    expect(welcomeStore.firstLocation).toStrictEqual({ id: -1, location: '' })
+  })
+
+  it('can build an item status ', async () => {
+    const welcomeStore = useWelcomeStore()
+    const itemStatus = welcomeStore.buildItemStatus({ title: 'Hello', condition: true, status: 'ok' })
+    expect(itemStatus).toStrictEqual({ title: 'Hello', status: 'ok', statusColor: 'var(--feather-success)', statusText: 'var(--feather-primary-text-on-color)' })
+  })
+
+  it('can create a default location', async () => {
+    global.fetch = buildFetchList({
+      FindLocationsForWelcome: { findAllLocations: [{ id: 1, location: 'default' }] }
+    })
+    setActiveClient(useClient({ url: 'http://test/graphql' }))
+
+    const welcomeStore = useWelcomeStore()
+    await welcomeStore.createDefaultLocation()
+    expect(welcomeStore.firstLocation).toStrictEqual({ id: 1, location: 'default' })
+  })
+
+  it('can click on the download button', async () => {
+    global.fetch = buildFetchList({
+      getMinionCertificate: { getMinionCertificate: { password: 'tempPassword', certificate: '234234098098' } },
+      ListMinionsForTable: { findAllMinions: [{ id: 1, label: 'DEFAULT', lastCheckedTime: Date.now(), location: { id: 2, location: 'default' } }] }
     })
 
-    it('perform store init', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    global.window.atob = (data: string) => {
+      return '' as any
+    }
 
-        global.fetch = buildFetchList({
-            FindLocationsForWelcome: { findAllLocations: [{ id: 1, location: 'default' }] },
-            ListMinionsForTable: { findAllMinions: [{ id: 1, label: 'DEFAULT', lastCheckedTime: Date.now(), location: { id: 2, location: 'default' } }] }
-        })
-        setActiveClient(useClient({ url: 'http://test/graphql' }))
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    global.URL.createObjectURL = (o: any) => {
+      return 'http://'
+    }
 
-        const welcomeStore = useWelcomeStore()
-        await welcomeStore.init();
-        expect(welcomeStore.firstLocation).toStrictEqual({ id: -1, location: '' })
+    const welcomeStore = useWelcomeStore()
+    await welcomeStore.downloadClick()
+    expect(welcomeStore.minionStatusStarted).toBeTruthy()
+  })
+
+  it('can get the failure status', () => {
+    const welcomeStore = useWelcomeStore()
+    const status = welcomeStore.getFailureStatus()
+
+    expect(status).toEqual({
+      statusColor: 'var(--feather-error)',
+      statusText: 'var(--feather-primary-text-on-color)'
     })
+  })
 
-    it('can build an item status ', async () => {
+  it('can get the failure status', () => {
+    const welcomeStore = useWelcomeStore()
+    const status = welcomeStore.getFailureStatus()
 
-        const welcomeStore = useWelcomeStore()
-        const itemStatus = welcomeStore.buildItemStatus({ title: 'Hello', condition: true, status: 'ok' })
-        expect(itemStatus).toStrictEqual({ title: 'Hello', status: 'ok', statusColor: 'var(--feather-success)', statusText: 'var(--feather-primary-text-on-color)' })
+    expect(status).toEqual({
+      statusColor: 'var(--feather-error)',
+      statusText: 'var(--feather-primary-text-on-color)'
     })
+  })
 
-    it('can create a default location', async () => {
+  it('can get the success status', () => {
+    const welcomeStore = useWelcomeStore()
+    const status = welcomeStore.getSuccessStatus()
 
-        global.fetch = buildFetchList({
-            FindLocationsForWelcome: { findAllLocations: [{ id: 1, location: 'default' }] },
-        })
-        setActiveClient(useClient({ url: 'http://test/graphql' }))
-
-        const welcomeStore = useWelcomeStore()
-        await welcomeStore.createDefaultLocation();
-        expect(welcomeStore.firstLocation).toStrictEqual({ id: 1, location: 'default' })
+    expect(status).toEqual({
+      statusColor: 'var(--feather-success)',
+      statusText: 'var(--feather-primary-text-on-color)'
     })
+  })
 
-    it('can click on the download button', async () => {
-        global.fetch = buildFetchList({
-            getMinionCertificate: { getMinionCertificate: { password: 'tempPassword', certificate: '234234098098' } },
-            ListMinionsForTable: { findAllMinions: [{ id: 1, label: 'DEFAULT', lastCheckedTime: Date.now(), location: { id: 2, location: 'default' } }] }
-        })
-        global.window.atob = (data: string) => {
-            return '' as any
-        }
-        global.URL.createObjectURL = (o: any) => {
-            return 'http://'
-        }
-        const welcomeStore = useWelcomeStore()
-        await welcomeStore.downloadClick();
-        expect(welcomeStore.minionStatusStarted).toBeTruthy()
-    })
+  it('can make the device preview start loading', () => {
+    const welcomeStore = useWelcomeStore()
+    welcomeStore.loadDevicePreview()
+    expect(welcomeStore.devicePreview.loading).toEqual(true)
+  })
 
-    it('can get the failure status', () => {
+  it('can advance slides', () => {
+    const welcomeStore = useWelcomeStore()
+    welcomeStore.nextSlide()
+    expect(welcomeStore.slide).toBe(2)
+  })
 
-        const welcomeStore = useWelcomeStore()
-        const status = welcomeStore.getFailureStatus()
-        expect(status).toEqual({
-            statusColor: 'var(--feather-error)',
-            statusText: 'var(--feather-primary-text-on-color)'
-        })
-    })
+  it('can to the previous slide', () => {
+    const welcomeStore = useWelcomeStore()
+    welcomeStore.nextSlide()
+    welcomeStore.prevSlide()
+    expect(welcomeStore.slide).toBe(1)
+  })
 
-    it('can get the failure status', () => {
-        const welcomeStore = useWelcomeStore()
-        const status = welcomeStore.getFailureStatus()
-        expect(status).toEqual({
-            statusColor: 'var(--feather-error)',
-            statusText: 'var(--feather-primary-text-on-color)'
-        })
-    })
+  it('can set the device preview', () => {
+    const welcomeStore = useWelcomeStore()
+    const ip = '192.168.1.1'
+    welcomeStore.setDevicePreview({ nodeLabel: ip, createTime: 1234 }, {}, 25)
+    expect(welcomeStore.devicePreview.title).toBe('Minion Gateway')
+    expect(welcomeStore.devicePreview.itemTitle).toBe(ip)
+  })
 
-    it('can get the success status', () => {
-        const welcomeStore = useWelcomeStore()
-        const status = welcomeStore.getSuccessStatus()
-        expect(status).toEqual({
-            statusColor: 'var(--feather-success)',
-            statusText: 'var(--feather-primary-text-on-color)'
-        })
-    })
+  it('can toggle a slide collapse', () => {
+    const welcomeStore = useWelcomeStore()
+    welcomeStore.toggleSlideOneCollapse()
+    expect(welcomeStore.slideOneCollapseVisible).toBe(false)
+  })
 
-    it('can make the device preview start loading', () => {
-        const welcomeStore = useWelcomeStore()
-        welcomeStore.loadDevicePreview()
-        expect(welcomeStore.devicePreview.loading).toEqual(true)
-    })
+  it('can validate on keyup', async () => {
+    const welcomeStore = useWelcomeStore()
+    welcomeStore.validateOnKeyup = true
+    await welcomeStore.updateFirstDiscovery('name', '')
+    expect(welcomeStore.firstDiscoveryErrors.name).toBe('')
+  })
 
-    it('can advance slides', () => {
-        const welcomeStore = useWelcomeStore()
-        welcomeStore.nextSlide();
-        expect(welcomeStore.slide).toBe(2)
-    })
-
-    it('can to the previous slide', () => {
-        const welcomeStore = useWelcomeStore()
-        welcomeStore.nextSlide();
-        welcomeStore.prevSlide();
-        expect(welcomeStore.slide).toBe(1);
-    })
-
-    it('can set the device preview', () => {
-        const welcomeStore = useWelcomeStore()
-        const ip = '192.168.1.1'
-        welcomeStore.setDevicePreview({ nodeLabel: ip, createTime: 1234 }, {}, 25)
-        expect(welcomeStore.devicePreview.title).toBe('Minion Gateway');
-        expect(welcomeStore.devicePreview.itemTitle).toBe(ip);
-    })
-
-    it('can toggle a slide collapse', () => {
-        const welcomeStore = useWelcomeStore()
-        welcomeStore.toggleSlideOneCollapse();
-        expect(welcomeStore.slideOneCollapseVisible).toBe(false)
-    })
-
-    it('can validate on keyup', async () => {
-        const welcomeStore = useWelcomeStore()
-        welcomeStore.validateOnKeyup = true;
-        await welcomeStore.updateFirstDiscovery('name', '');
-        expect(welcomeStore.firstDiscoveryErrors.name).toBe('')
-    })
-
-    it('can update minion status copy', async () => {
-        const welcomeStore = useWelcomeStore()
-        welcomeStore.updateMinionStatusCopy();
-        expect(welcomeStore.minionStatusCopy).toBe('Waiting for the Docker Install Command to be complete.')
-    })
+  it('can update minion status copy', async () => {
+    const welcomeStore = useWelcomeStore()
+    welcomeStore.updateMinionStatusCopy()
+    expect(welcomeStore.minionStatusCopy).toBe('Waiting for the Docker Install Command to be complete.')
+  })
 })

--- a/ui/tests/utils.ts
+++ b/ui/tests/utils.ts
@@ -6,8 +6,9 @@ export const findByText = (wrap: any, selector: string, text: string) => {
 }
 export const buildFetchList = (items: Record<string, any>) => {
   return (_: any, c: any) => {
-    const keys = Object.keys(items);
-    let foundKey = keys.find((d) => c?.body?.includes(d)) || ''
+    const keys = Object.keys(items)
+    const foundKey = keys.find((d) => c?.body?.includes(d)) || ''
+
     return Promise.resolve({ json: () => Promise.resolve({ data: items[foundKey] ?? {} }), ok: true }) as any
   }
 } 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -641,7 +641,7 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz#8cfaf2ff603e9aabb910e9c0558c26cf32744061"
   integrity sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==
 
-"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.3.0":
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.3.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
@@ -1653,6 +1653,50 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
+"@stylistic/eslint-plugin-js@1.6.1", "@stylistic/eslint-plugin-js@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.6.1.tgz#e4b45cf5addb0e2e92f2af5b199de01da8e57273"
+  integrity sha512-gHRxkbA5p8S1fnChE7Yf5NFltRZCzbCuQOcoTe93PSKBC4GqVjZmlWUSLz9pJKHvDAUTjWkfttWHIOaFYPEhRQ==
+  dependencies:
+    acorn "^8.11.3"
+    escape-string-regexp "^4.0.0"
+    eslint-visitor-keys "^3.4.3"
+    espree "^9.6.1"
+
+"@stylistic/eslint-plugin-jsx@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.6.1.tgz#9ac17d1d0600038f03222a1c52c6677ebd523790"
+  integrity sha512-uJQcg3iqrhm3EH15ZjxmZ1YmXXexkLKFEgxkWA3RYjgAVTx8k7xGJwClK/JnjKDGdbFRiDQPjxt964R1vsaFaQ==
+  dependencies:
+    "@stylistic/eslint-plugin-js" "^1.6.1"
+    estraverse "^5.3.0"
+    picomatch "^3.0.1"
+
+"@stylistic/eslint-plugin-plus@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.6.1.tgz#e04e7b130911cac5a9067f57fa790057ba66a532"
+  integrity sha512-nYIXfdYN+pBVmm0vPCKQFg/IK35tf3ZGz+0WENUL6ww1+jKM6/i36FalRFculiHzO+wOpJ3/yXWJC3PCbwGFZQ==
+  dependencies:
+    "@typescript-eslint/utils" "^6.20.0"
+
+"@stylistic/eslint-plugin-ts@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.6.1.tgz#9cd20bdfd60441daf2b3d14dcab7f94374fdc556"
+  integrity sha512-eZxrFaLhPJVUQmtsRXKiuzSou0nlHevKc1WsfhxUJ9p8juv3G3YlbbGeYg4AP1fNlEmWs/lZQAP2WfzQOdBNvQ==
+  dependencies:
+    "@stylistic/eslint-plugin-js" "1.6.1"
+    "@typescript-eslint/utils" "^6.20.0"
+
+"@stylistic/eslint-plugin@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin/-/eslint-plugin-1.6.1.tgz#011e408ad9a1dddfe9517ace9dd3b6ce9ef4b17b"
+  integrity sha512-De7Sw86OtIf7SsMgjLCf4bTeI3085Plyh4l0Rg1V42BTFo/Q6Pz7Cbu31rEk/UHFiEna/YO8Hxj80jFP3ObrQw==
+  dependencies:
+    "@stylistic/eslint-plugin-js" "1.6.1"
+    "@stylistic/eslint-plugin-jsx" "1.6.1"
+    "@stylistic/eslint-plugin-plus" "1.6.1"
+    "@stylistic/eslint-plugin-ts" "1.6.1"
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -1920,6 +1964,11 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
   integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
+"@types/json-schema@^7.0.12":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
 "@types/json-schema@^7.0.9":
   version "7.0.12"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
@@ -1966,6 +2015,11 @@
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
   integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
+
+"@types/semver@^7.5.0":
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
+  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
 
 "@types/splitpanes@^2.2.1":
   version "2.2.1"
@@ -2020,6 +2074,14 @@
     "@typescript-eslint/types" "5.59.11"
     "@typescript-eslint/visitor-keys" "5.59.11"
 
+"@typescript-eslint/scope-manager@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz#ea8a9bfc8f1504a6ac5d59a6df308d3a0630a2b1"
+  integrity sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+
 "@typescript-eslint/type-utils@5.59.11":
   version "5.59.11"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.11.tgz#5eb67121808a84cb57d65a15f48f5bdda25f2346"
@@ -2035,6 +2097,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.11.tgz#1a9018fe3c565ba6969561f2a49f330cf1fe8db1"
   integrity sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==
 
+"@typescript-eslint/types@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.21.0.tgz#205724c5123a8fef7ecd195075fa6e85bac3436d"
+  integrity sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==
+
 "@typescript-eslint/typescript-estree@5.59.11":
   version "5.59.11"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz#b2caaa31725e17c33970c1197bcd54e3c5f42b9f"
@@ -2047,6 +2114,20 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz#c47ae7901db3b8bddc3ecd73daff2d0895688c46"
+  integrity sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    minimatch "9.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
 
 "@typescript-eslint/utils@5.59.11":
   version "5.59.11"
@@ -2062,6 +2143,19 @@
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
+"@typescript-eslint/utils@^6.20.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.21.0.tgz#4714e7a6b39e773c1c8e97ec587f520840cd8134"
+  integrity sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@types/json-schema" "^7.0.12"
+    "@types/semver" "^7.5.0"
+    "@typescript-eslint/scope-manager" "6.21.0"
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/typescript-estree" "6.21.0"
+    semver "^7.5.4"
+
 "@typescript-eslint/visitor-keys@5.59.11":
   version "5.59.11"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz#dca561ddad169dc27d62396d64f45b2d2c3ecc56"
@@ -2069,6 +2163,14 @@
   dependencies:
     "@typescript-eslint/types" "5.59.11"
     eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz#87a99d077aa507e20e238b11d56cc26ade45fe47"
+  integrity sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    eslint-visitor-keys "^3.4.1"
 
 "@vitejs/plugin-vue@^4.0.0":
   version "4.2.3"
@@ -2388,6 +2490,11 @@ acorn-walk@^8.1.1, acorn-walk@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.11.3:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 acorn@^8.4.1, acorn@^8.8.0, acorn@^8.8.2:
   version "8.9.0"
@@ -3637,6 +3744,11 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
   integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
+eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
 eslint@^8.32.0:
   version "8.43.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.43.0.tgz#3e8c6066a57097adfd9d390b8fc93075f257a094"
@@ -3691,6 +3803,15 @@ espree@^9.3.1, espree@^9.5.2:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
+espree@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
+  integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
+  dependencies:
+    acorn "^8.9.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.4.1"
+
 esquery@^1.4.0, esquery@^1.4.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
@@ -3710,7 +3831,7 @@ estraverse@^4.1.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -4720,6 +4841,13 @@ minimatch@4.2.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -5077,6 +5205,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-3.0.1.tgz#817033161def55ec9638567a2f3bbc876b3e7516"
+  integrity sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==
+
 pinia@^2.0.29:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.1.4.tgz#a642adfe6208e10c36d3dc16184a91064788142a"
@@ -5389,6 +5522,13 @@ semver@^7.3.5, semver@^7.3.6, semver@^7.3.7, semver@^7.3.8:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.4:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
+
 sentence-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
@@ -5677,6 +5817,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+ts-api-utils@^1.0.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.2.1.tgz#f716c7e027494629485b21c0df6180f4d08f5e8b"
+  integrity sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==
 
 ts-log@^2.2.3:
   version "2.2.5"


### PR DESCRIPTION
## Description

Migrate eslint formatting-related rules to ESLint Stylistic. This affects only files in the `ui` project.

`eslint` formatting related rules have been deprecated in v9.0.0 and most/all have moved to the ESLint Stylistic project.

This PR also fixes all lint errors and warnings.

May add a couple more rules, but this gets things up to date.

See the [Migration Guide](https://eslint.style/guide/migration).

Also fixes the `package.json` `license` to be a valid SPDX expression, since this emitted a warning on every build.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2300

