### PR TITLE
LOK-2301: Don't allow blank names for discovery

### DIFF
--- a/ui/src/containers/Discovery.vue
+++ b/ui/src/containers/Discovery.vue
@@ -90,6 +90,7 @@
             >
             <ButtonWithSpinner
               text
+              v-if="discoveryStore.selectedDiscovery.name"
               :disabled="isOverallDisabled"
               :click="discoveryStore.saveSelectedDiscovery"
               :isFetching="discoveryStore.loading"
@@ -105,7 +106,7 @@
           :modelValue="discoveryStore.selectedDiscovery.name"
           :error="discoveryStore.validationErrors.name"
           :disabled="isOverallDisabled"
-          @update:model-value="(name: any) => discoveryStore.setSelectedDiscoveryValue('name', name)"
+          @update:model-value="(name: any) => discoveryStore.setSelectedDiscoveryValue('name', name.trim())"
         />
 
         <div class="auto-with-chips">
@@ -238,6 +239,7 @@
 
             <ButtonWithSpinner
               primary
+              v-if="discoveryStore.selectedDiscovery.name"
               :disabled="isOverallDisabled"
               :click="discoveryStore.saveSelectedDiscovery"
               :isFetching="discoveryStore.loading"

--- a/ui/src/dtos/discovery.dto.ts
+++ b/ui/src/dtos/discovery.dto.ts
@@ -111,8 +111,8 @@ export const discoveryFromServerToClient = (dataIn: ServerDiscoveries, locations
 }
 
 const activeDiscoveryValidation = yup.object().shape({
-  name: yup.string().required('Please enter a name.'),
-  locationId:yup.string().required('Location required.'),
+  name: yup.string().trim().required('Please enter a name.'),
+  locationId:yup.string().trim().required('Location required.'),
   ipAddresses: yup.array().min(1,'Please enter an ip address.').of(yup.string().required('Please enter an IP address.')
     .test('validate-ip',
       (ip, ctx) => {
@@ -138,8 +138,8 @@ const activeDiscoveryValidation = yup.object().shape({
 }).required()
 
 const passiveDiscoveryValidation = yup.object().shape({
-  name: yup.string().required('Please enter a name.'),
-  locationId:yup.string().required('Location required.'),
+  name: yup.string().trim().required('Please enter a name.'),
+  locationId:yup.string().trim().required('Location required.'),
   snmpConfig: yup.object({
     communityStrings: yup.array().of(yup.string().required('Please enter a community string.')),
     udpPorts: yup.array().of(yup.number())
@@ -147,12 +147,12 @@ const passiveDiscoveryValidation = yup.object().shape({
 }).required()
 
 const azureDiscoveryValidation = yup.object().shape({
-  name: yup.string().required('Please enter a name.'),
-  locationId:yup.string().required('Location required.'),
-  clientId: yup.string().required('Client ID is required.'),
-  subscriptionId: yup.string().required('Client subscription ID is required.'),
-  directoryId: yup.string().required('Directory ID is required.'),
-  clientSecret: yup.string().required('Client secret is required.')
+  name: yup.string().trim().required('Please enter a name.'),
+  locationId:yup.string().trim().required('Location required.'),
+  clientId: yup.string().trim().required('Client ID is required.'),
+  subscriptionId: yup.string().trim().required('Client subscription ID is required.'),
+  directoryId: yup.string().trim().required('Directory ID is required.'),
+  clientSecret: yup.string().trim().required('Client secret is required.')
 }).required()
 
 const validatorMap: Record<string,yup.Schema> = {

--- a/ui/src/store/Views/discoveryStore.ts
+++ b/ui/src/store/Views/discoveryStore.ts
@@ -246,6 +246,21 @@ export const useDiscoveryStore = defineStore('discoveryStore', {
 
         this.validateOnKeyUp = false
       }else {
+        if (toRaw(this.validationErrors).name) {
+          this.setSelectedDiscoveryValue('name', '')
+        }
+        if (toRaw(this.validationErrors).clientId) {
+          this.setMetaSelectedDiscoveryValue('clientId', '');
+        }
+        if (toRaw(this.validationErrors).clientSecret) {
+          this.setMetaSelectedDiscoveryValue('clientSecret', '');
+        }
+        if (toRaw(this.validationErrors).directoryId) {
+          this.setMetaSelectedDiscoveryValue('directoryId', '');
+        }
+        if (toRaw(this.validationErrors).subscriptionId) {
+          this.setMetaSelectedDiscoveryValue('subscriptionId', '');
+        }
         this.validateOnKeyUp = true
       }
       this.loading = false


### PR DESCRIPTION
## Description
Don’t allow blank names for ICMP/Passive/Azure discovery pages.

Save button shouldn’t appear if we have blank name.

Names should be trimmed before sending to BE.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2301

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
