### PR TITLE
LOK-2303: Don't allow blank in Monitor policy and rule names

### DIFF
--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesPolicyForm.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesPolicyForm.vue
@@ -41,14 +41,14 @@
         </div>
 
         <FeatherInput
-          v-model="store.selectedPolicy.name"
+          v-model.trim="store.selectedPolicy.name"
           label="New Policy Name"
           v-focus
           data-test="policy-name-input"
           :readonly="store.selectedPolicy.isDefault"
         />
         <FeatherTextarea
-          v-model="store.selectedPolicy.memo"
+          v-model.trim="store.selectedPolicy.memo"
           label="Memo"
           :maxlength="100"
           :disabled="store.selectedPolicy.isDefault"

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
@@ -39,7 +39,7 @@
           <div class="col">
             <div class="subtitle">New Rule Name</div>
             <FeatherInput
-              v-model="store.selectedRule.name"
+              v-model.trim="store.selectedRule.name"
               label=""
               hideLabel
               v-focus


### PR DESCRIPTION
## Description
UI should prevent blank names being added to policy and rule names.

Names should be trimmed before sending to BE.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2303

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
