### PR TITLE
LOK-2315: Reinstate previous Node page

### DIFF
--- a/ui/src/components/Inventory/InventoryIconActionList.vue
+++ b/ui/src/components/Inventory/InventoryIconActionList.vue
@@ -3,6 +3,9 @@
     <li v-if="node.monitoredState === 'MONITORED'" @click="onLineChart" data-test="line-chart" class="pointer">
       <Icon :icon="lineChartIcon" />
     </li>
+    <li @click="onNodeStatus" data-test="node-status" class="pointer">
+      <Icon :icon="infoIcon" />
+    </li>
     <li @click="onWarning" data-test="warning" class="pointer">
       <Icon :icon="warningIcon" />
     </li>
@@ -28,6 +31,7 @@
 <script lang="ts" setup>
 import Warning from '@featherds/icon/notification/Warning'
 import Delete from '@featherds/icon/action/Delete'
+import Info from '@featherds/icon/action/Info'
 import GraphIcon from '@/components/Common/GraphIcon.vue'
 import { IIcon, InventoryItem } from '@/types'
 import { ModalPrimary } from '@/types/modal'
@@ -62,6 +66,19 @@ const lineChartIcon: IIcon = {
   cursorHover: true
 }
 
+const onNodeStatus = () => {
+  router.push({
+    name: 'Node Status',
+    params: { id: props.node.id }
+  })
+}
+const infoIcon: IIcon = {
+  image: markRaw(Info),
+  tooltip: 'Node Status',
+  size: 1.5,
+  cursorHover: true
+}
+
 const onWarning = () => {
   router.push({
     name: 'Node',
@@ -70,7 +87,7 @@ const onWarning = () => {
 }
 const warningIcon: IIcon = {
   image: markRaw(Warning),
-  tooltip: 'Events/Alerts',
+  tooltip: 'Node Details',
   size: 1.5,
   cursorHover: true
 }

--- a/ui/src/components/Inventory/InventoryTabContent.vue
+++ b/ui/src/components/Inventory/InventoryTabContent.vue
@@ -2,7 +2,7 @@
   <div class="cards">
     <div v-for="node in tabContent" :key="node.id" class="card" :data-test="state">
       <section class="node-header">
-        <h5 data-test="heading" class="node-label">{{ node?.nodeAlias || node?.nodeLabel }}</h5>
+        <h5 data-test="heading" class="node-label pointer" @click="() => onNodeClick(node.id)">{{ node?.nodeAlias || node?.nodeLabel }}</h5>
         <div class="card-chip-list">
           <div class="text-badge-row" v-if="state === MonitoredStates.MONITORED">
             <div v-for="badge, index in metricsAsTextBadges(node?.metrics)" :key="index">
@@ -49,6 +49,7 @@ defineProps({
 const tagStore = useTagStore()
 const inventoryStore = useInventoryStore()
 const isTagManagerReset = computed(() => inventoryStore.isTagManagerReset)
+const router = useRouter()
 
 watch(isTagManagerReset, (isReset) => {
   if (isReset) {
@@ -61,6 +62,13 @@ const resetState = () => {
   tagStore.setTagEditMode(false)
   inventoryStore.resetSelectedNode()
   inventoryStore.isTagManagerReset = false
+}
+
+const onNodeClick = (id: number) => {
+  router.push({
+    name: 'Node Status',
+    params: { id }
+  })
 }
 
 const openModalForDeletingTags = (node: NewInventoryNode) => {

--- a/ui/src/containers/NodeDetails.vue
+++ b/ui/src/containers/NodeDetails.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="full-page-container">
+    <div class="header">
+      <div class="pre-title">Node Details</div>
+      <div class="page-headline">
+        {{ nodeStatusStore.node.nodeAlias || nodeStatusStore.node.nodeLabel }}
+        <FeatherButton
+          icon="Edit"
+          @click="openModal"
+        >
+          <FeatherIcon :icon="EditIcon" />
+        </FeatherButton>
+      </div>
+      <div
+        class="post-title"
+        v-if="nodeStatusStore.node.nodeAlias"
+      >
+        {{ nodeStatusStore.node.nodeLabel }}
+      </div>
+    </div>
+    <NodeInfoTable />
+    <SNMPInterfacesTable v-if="!nodeStatusStore.isAzure" />
+    <IPInterfacesTable />
+    <EventsTable />
+  </div>
+  <EditModal
+    :isVisible="isVisible"
+    :closeModal="() => closeModal()"
+    :handler="(newAlias: string) => nodeStatusStore.updateNodeAlias(newAlias)"
+    :callback="() => queries.fetchNodeStatus()"
+    title="Edit Node Name"
+    inputLabel="Type a new name"
+    :currentValue="nodeStatusStore.node.nodeAlias || ''"
+  />
+</template>
+
+<script setup lang="ts">
+import useModal from '@/composables/useModal'
+import { useNodeStatusStore } from '@/store/Views/nodeStatusStore'
+import { useNodeStatusQueries } from '@/store/Queries/nodeStatusQueries'
+import EditIcon from '@featherds/icon/action/EditMode'
+
+const nodeStatusStore = useNodeStatusStore()
+const queries = useNodeStatusQueries()
+const route = useRoute()
+const { openModal, closeModal, isVisible } = useModal()
+
+onBeforeMount(() => {
+  const nodeId = Number(route.params.id)
+  nodeStatusStore.setNodeId(nodeId)
+  nodeStatusStore.fetchExporters(nodeId)
+})
+</script>
+
+<style lang="scss" scoped>
+@use '@featherds/styles/mixins/typography';
+@use '@featherds/styles/themes/variables';
+
+.header {
+  margin-top: 40px;
+  margin-bottom: 40px;
+  display: flex;
+  flex-direction: column;
+
+  .pre-title {
+    @include typography.button;
+    color: var(variables.$secondary-variant);
+  }
+
+  .page-headline {
+    @include typography.headline1;
+  }
+
+  .post-title {
+    @include typography.caption;
+  }
+}
+</style>

--- a/ui/src/containers/NodeStatus.vue
+++ b/ui/src/containers/NodeStatus.vue
@@ -2,7 +2,7 @@
   <div class="full-page-container">
     <div class="header-wrapper">
       <div class="header">
-        <div class="pre-title">Network Inventory</div>
+        <div class="pre-title">Node Status</div>
         <div class="page-headline">
           {{ nodeStatusStore.node.nodeAlias || nodeStatusStore.node.nodeLabel }}
           <FeatherButton

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import NodeDetails from '@/containers/NodeDetails.vue'
 import NodeStatus from '@/containers/NodeStatus.vue'
 
 const router = createRouter({
@@ -50,8 +51,14 @@ const router = createRouter({
       component: () => import('@/containers/Locations.vue')
     },
     {
+      // older node page
       path: '/node/:id',
       name: 'Node',
+      component: NodeDetails
+    },
+    {
+      path: '/node-status/:id',
+      name: 'Node Status',
       component: NodeStatus
     },
     {

--- a/ui/src/store/Views/discoveryStore.ts
+++ b/ui/src/store/Views/discoveryStore.ts
@@ -227,7 +227,8 @@ export const useDiscoveryStore = defineStore('discoveryStore', {
       const discoveryMutations = useDiscoveryMutations()
       this.loading = true
       const isValid = await this.validateDiscovery()
-      if (isValid){
+
+      if (isValid) {
         if (this.selectedDiscovery.type === DiscoveryType.SyslogSNMPTraps){
           await discoveryMutations.upsertPassiveDiscovery({passiveDiscovery:discoveryFromClientToServer(this.selectedDiscovery)})
         } else if (this.selectedDiscovery.type === DiscoveryType.Azure) {
@@ -245,21 +246,21 @@ export const useDiscoveryStore = defineStore('discoveryStore', {
         }
 
         this.validateOnKeyUp = false
-      }else {
+      } else {
         if (toRaw(this.validationErrors).name) {
           this.setSelectedDiscoveryValue('name', '')
         }
         if (toRaw(this.validationErrors).clientId) {
-          this.setMetaSelectedDiscoveryValue('clientId', '');
+          this.setMetaSelectedDiscoveryValue('clientId', '')
         }
         if (toRaw(this.validationErrors).clientSecret) {
-          this.setMetaSelectedDiscoveryValue('clientSecret', '');
+          this.setMetaSelectedDiscoveryValue('clientSecret', '')
         }
         if (toRaw(this.validationErrors).directoryId) {
-          this.setMetaSelectedDiscoveryValue('directoryId', '');
+          this.setMetaSelectedDiscoveryValue('directoryId', '')
         }
         if (toRaw(this.validationErrors).subscriptionId) {
-          this.setMetaSelectedDiscoveryValue('subscriptionId', '');
+          this.setMetaSelectedDiscoveryValue('subscriptionId', '')
         }
         this.validateOnKeyUp = true
       }


### PR DESCRIPTION
## Description

Reinstate the previous Node / Node Details page. However please note all functionality on that page should be present in the Node Status page, just in different tabs.

Added "info" icon to Inventory items to navigate to new Node Status. Add clickable Inventory node label which also navigates to the Node Status page. The "warning" icon navigates to the old node details page; updated the tooltip.

Once the new Node Status page is done, we should redirect `/node` to that, and remove the old node page.

Also, fixed linting issues.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2315
