### PR TITLE
LOK-2165:Text for currently selected item not visible

### DIFF
--- a/ui/src/components/Layout/NavigationRail.vue
+++ b/ui/src/components/Layout/NavigationRail.vue
@@ -118,4 +118,8 @@ const content = 'mainContent'
 svg[aria-label='Map'] {
   margin-top: -5px;
 }
+
+a.feather-vertical-app-bar-item.selected:visited {
+  color: var(--feather-surface-dark) !important;
+}
 </style>


### PR DESCRIPTION
## Description
When the main/left navigation bar is expanded, the item currently selected is not readable.  This occurs regardless of light/dark modes.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2165

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
