### PR TITLE
LOK-2241: Fix Alerts page pagination, fix Spinner reactivity

### DIFF
--- a/ui/src/components/Common/Spinner.vue
+++ b/ui/src/components/Common/Spinner.vue
@@ -8,7 +8,7 @@
 
 <script setup lang="ts">
 import useSpinner from '@/composables/useSpinner'
-const { isActive } = useSpinner()
+const { isActive } = toRefs(useSpinner())
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/store/Queries/alertsQueries.ts
+++ b/ui/src/store/Queries/alertsQueries.ts
@@ -4,12 +4,22 @@ import {
   AlertCountsDocument,
   AlertsListDocument,
   CountAlertsDocument,
+  ListAlertResponse,
   TimeRange
 } from '@/types/graphql'
 import { AlertsFilters, Pagination } from '@/types/alerts'
 
+export const defaultListAlertResponse = () => {
+  return {
+    alerts: [],
+    lastPage: 0,
+    nextPage: 0,
+    totalAlerts: 0
+  } as ListAlertResponse
+}
+
 export const useAlertsQueries = defineStore('alertsQueries', () => {
-  const fetchAlertsData = ref({})
+  const fetchAlertsData = ref({} as ListAlertResponse)
   const fetchCountAlertsData = ref(0)
 
   const fetchAlerts = async (alertsFilters: AlertsFilters, pagination: Pagination) => {
@@ -30,7 +40,11 @@ export const useAlertsQueries = defineStore('alertsQueries', () => {
 
     await execute()
 
-    fetchAlertsData.value = data.value?.findAllAlerts || {}
+    if (data.value?.findAllAlerts) {
+      fetchAlertsData.value = { ...data.value.findAllAlerts } as ListAlertResponse
+    } else {
+      fetchAlertsData.value = defaultListAlertResponse()
+    }
   }
 
   const fetchCountAlerts = async (severityFilters = [] as string[], timeRange = TimeRange.All) => {

--- a/ui/src/store/Views/alertsStore.ts
+++ b/ui/src/store/Views/alertsStore.ts
@@ -1,10 +1,9 @@
-import { defineStore } from 'pinia'
-import { TimeRange } from '@/types/graphql'
-import { useAlertsQueries } from '../Queries/alertsQueries'
-import { useAlertsMutations } from '../Mutations/alertsMutations'
-import { Alert } from '@/types/graphql'
-import { AlertsFilters } from '@/types/alerts'
 import { cloneDeep } from 'lodash'
+import { defineStore } from 'pinia'
+import { useAlertsMutations } from '../Mutations/alertsMutations'
+import { defaultListAlertResponse, useAlertsQueries } from '../Queries/alertsQueries'
+import { AlertsFilters, Pagination } from '@/types/alerts'
+import { Alert, ListAlertResponse, TimeRange } from '@/types/graphql'
 
 const alertsFilterDefault: AlertsFilters = {
   timeRange: TimeRange.All,
@@ -14,44 +13,50 @@ const alertsFilterDefault: AlertsFilters = {
   sortBy: 'lastEventTime'
 }
 
-const alertsPaginationDefault = {
-  page: 1, // FE pagination component has base 1 (first page)
+const alertsPaginationDefault: Pagination = {
+  page: 1, // reset to first page. FE pagination component uses base 1 for page
   pageSize: 10,
   total: 0
 }
 
 export const useAlertsStore = defineStore('alertsStore', () => {
-  const alertsList = ref()
+  // Current page of alert data
+  const alertsList = ref<ListAlertResponse>(defaultListAlertResponse())
+
   const alertsFilter = ref(cloneDeep(alertsFilterDefault))
   const alertsPagination = ref(cloneDeep(alertsPaginationDefault))
-  const alertsSelected = ref([] as number[] | undefined)
-  const isAlertsListEmpty = ref(true)
+  const alertsSelected = ref(new Set<number>())
 
   const alertsQueries = useAlertsQueries()
   const alertsMutations = useAlertsMutations()
 
-  const fetchAlerts = async () => {
-    // Api has base 0 and FE pagination has base 1
-    // If above 0, always subtract 1 before sending request.
-    let page = 0
-    if (alertsPagination.value.page > 0) {
-      page = alertsPagination.value.page - 1
-    }
+  const isAlertsListEmpty = computed<boolean>(() => {
+    const count = alertsList.value?.alerts?.length || 0
+    return count < 1
+  })
 
-    alertsPagination.value = {
+  const isAlertSelected = (id: number) => {
+    return alertsSelected.value.has(id)
+  }
+
+  const fetchAlerts = async () => {
+    // Api uses base 0 for page number; FE pagination uses base 1, so adjust here
+    const page = alertsPagination.value.page > 0 ? alertsPagination.value.page - 1 : 0
+
+    const pagination = {
       ...alertsPagination.value,
       page
     }
 
-    await alertsQueries.fetchAlerts(alertsFilter.value, alertsPagination.value)
+    await alertsQueries.fetchAlerts(alertsFilter.value, pagination)
 
     alertsList.value = alertsQueries.fetchAlertsData
 
-    isAlertsListEmpty.value = Boolean(alertsList.value.alerts?.length <= 0)
-
-    alertsPagination.value = {
-      ...alertsPagination.value,
-      total: alertsList.value.totalAlerts
+    if (alertsList.value.totalAlerts != alertsPagination.value.total) {
+      alertsPagination.value = {
+        ...alertsPagination.value,
+        total: alertsList.value.totalAlerts
+      }
     }
   }
 
@@ -100,7 +105,6 @@ export const useAlertsStore = defineStore('alertsStore', () => {
         page
       }
     }
-
     fetchAlerts()
   }
 
@@ -122,45 +126,60 @@ export const useAlertsStore = defineStore('alertsStore', () => {
     fetchAlerts()
   }
 
-  // all toggle (select/deselect): true/false / individual toggle: number (alert id)
-  const setAlertsSelected = (selectedAlert: number | boolean) => {
-    if (Number.isInteger(selectedAlert)) {
-      const found = alertsSelected.value?.indexOf(selectedAlert as number) as number
-      found === -1 ? alertsSelected.value?.push(selectedAlert as number) : alertsSelected.value?.splice(found, 1)
+  /** Select or deselect all current alerts. */
+  const setAllAlertsSelected = (isSelected: boolean) => {
+    if (isSelected) {
+      const ids: number[] = alertsList.value.alerts
+        ?.map((al: Alert) => Number(al.databaseId))
+        .filter((x: number) => !Number.isNaN(x) && x > 0) || []
+
+      alertsSelected.value = new Set<number>(ids)
     } else {
-      if (!selectedAlert) alertsSelected.value = []
-      else {
-        alertsSelected.value = alertsList.value.alerts.map((al: Alert) => al.databaseId)
+      alertsSelected.value.clear()
+    }
+  }
+
+  /** Select or deselect a single alert. */
+  const setAlertSelected = (id: number, isSelected: boolean) => {
+    if (alertsSelected.value.has(id)) {
+      if (!isSelected) {
+        alertsSelected.value.delete(id)
+      }
+    } else {
+      if (isSelected) {
+        alertsSelected.value.add(id)
       }
     }
   }
 
   const clearSelectedAlerts = async () => {
-    await alertsMutations.clearAlerts({ ids: alertsSelected.value })
+    await alertsMutations.clearAlerts({ ids: [...alertsSelected.value.values()] })
 
     fetchAlerts()
   }
 
   const acknowledgeSelectedAlerts = async () => {
-    await alertsMutations.acknowledgeAlerts({ ids: alertsSelected.value })
+    await alertsMutations.acknowledgeAlerts({ ids: [...alertsSelected.value.values()] })
 
     fetchAlerts()
   }
 
   return {
-    alertsList,
-    fetchAlerts,
-    resetPaginationAndFetchAlerts,
-    alertsFilter,
-    toggleSeverity,
-    selectTime,
-    alertsPagination,
-    setPage,
-    setPageSize,
-    clearAllFilters,
-    setAlertsSelected,
-    clearSelectedAlerts,
     acknowledgeSelectedAlerts,
-    isAlertsListEmpty
+    alertsFilter,
+    alertsList,
+    alertsPagination,
+    clearAllFilters,
+    clearSelectedAlerts,
+    fetchAlerts,
+    isAlertsListEmpty,
+    isAlertSelected,
+    resetPaginationAndFetchAlerts,
+    selectTime,
+    setAlertSelected,
+    setAllAlertsSelected,
+    setPageSize,
+    setPage,
+    toggleSeverity
   }
 })

--- a/ui/tests/Alerts/alerts.test.ts
+++ b/ui/tests/Alerts/alerts.test.ts
@@ -1,17 +1,18 @@
-import mount from '../mountWithPiniaVillus'
+import mountWithPiniaVillus from 'tests/mountWithPiniaVillus'
 import Alerts from '@/containers/Alerts.vue'
 import { useAlertsStore } from '@/store/Views/alertsStore'
+import { getAlert } from '../fixture/alerts'
 
 let wrapper: any
 
 describe('Alerts', () => {
   afterAll(() => {
-    wrapper.unmount()
+    wrapper?.unmount()
   })
 
   describe('Required elements', () => {
     beforeAll(() => {
-      wrapper = mount({
+      wrapper = mountWithPiniaVillus({
         component: Alerts
       })
     })
@@ -44,12 +45,20 @@ describe('Alerts', () => {
 
   describe('Alerts list not empty', () => {
     beforeAll(async () => {
-      wrapper = mount({
+      wrapper = mountWithPiniaVillus({
         component: Alerts
       })
 
+      const alertList = {
+        alerts: [getAlert()],
+        lastPage: -1,
+        nextPage: 1,
+        totalAlerts: 1
+      }
+
       const alertsStore = useAlertsStore()
-      alertsStore.isAlertsListEmpty = false
+      alertsStore.alertsList = alertList
+
       await wrapper.vm.$nextTick()
     })
 
@@ -87,7 +96,7 @@ describe('Alerts', () => {
 
   describe('Alerts list empty', () => {
     beforeAll(() => {
-      wrapper = mount({
+      wrapper = mountWithPiniaVillus({
         component: Alerts
       })
     })


### PR DESCRIPTION
## Description

Provides a more complete fix to LOK-2241. Alerts page pagination was not working correctly, this should fix pagination and also selection.

`alertsStore` contains alert data for the current page; Alerts page table data now stays in sync with this.

There is an issue where if a user pages quickly, the store and pagination display may be out of sync with what has been fetched by graphql. Added a spinner to alert the user that current data fetch is still in progress.

This PR changes selection (single select or else select/deselect all) to only work per visible items on the current page. This prevents cases where a user may click Clear or Acknowledge, not realizing there are selected items on other pages. We may revisit this behavior.

Also fixed an issue with the Spinner, the `{ isActive }` from the composable was not reactive and therefore the Spinner was never updating its visibility; added `toRefs()`.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2241
