### PR TITLE
Node Details: IP Interfaces Refresh

### DIFF
--- a/ui/src/components/NodeStatus/IPInterfacesTable.vue
+++ b/ui/src/components/NodeStatus/IPInterfacesTable.vue
@@ -31,6 +31,7 @@
           <FeatherButton
               primary
               icon="Refresh"
+              @click.prevent="refresh"
             >
               <FeatherIcon :icon="fsIcons.Refresh"> </FeatherIcon>
             </FeatherButton>
@@ -111,7 +112,9 @@ import Refresh from '@featherds/icon/navigation/Refresh'
 import Search from '@featherds/icon/action/Search'
 import { SORT } from '@featherds/table'
 import { sortBy } from 'lodash'
+import { useNodeStatusQueries } from '@/store/Queries/nodeStatusQueries'
 const nodeStatusStore = useNodeStatusStore()
+const nodeStatusQueries = useNodeStatusQueries()
 const metricsModal = ref()
 
 const fsIcons = markRaw({
@@ -233,6 +236,10 @@ const updatePageSize = (v: number) => {
 onBeforeUnmount(() => {
   isMounted.value = false
 })
+
+const refresh = () => {
+  nodeStatusQueries.fetchNodeStatus()
+}
 const icons = markRaw({
   Traffic
 })


### PR DESCRIPTION
## Description
Implement the Refresh button for the IP Interfaces table on the Node Status page.

Not sure there is any way to just refresh IP Interface info, so need to just re-fetch the node status data, something equivalent to:

const queries = useNodeStatusQueries()
queries.fetchNodeStatus()
(may or may not need await, don’t need it if this will fire in the background)

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2296

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
