### PR TITLE
Node Details: IP Interfaces search

### DIFF
--- a/ui/src/components/NodeStatus/IPInterfacesTable.vue
+++ b/ui/src/components/NodeStatus/IPInterfacesTable.vue
@@ -120,6 +120,7 @@ import Traffic from '@featherds/icon/action/Workflow'
 import Refresh from '@featherds/icon/navigation/Refresh'
 import { FeatherPagination } from '@featherds/pagination'
 import { SORT } from '@featherds/table'
+import { sortBy } from 'lodash'
 const nodeStatusStore = useNodeStatusStore()
 const nodeStatusQueries = useNodeStatusQueries()
 const metricsModal = ref()
@@ -211,33 +212,19 @@ const getPageObjects = (array: Array<any>, pageNumber: number, pageSize: number)
   const endIndex = startIndex + pageSize
   return array.slice(startIndex, endIndex)
 }
-const sortByattributeAscending = (data: any[], attribute: string) => {
-  return data.sort((a, b) => {
-    if (a[attribute] < b[attribute]) return -1
-    if (a[attribute] > b[attribute]) return 1
-    return 0
-  })
-}
-const sortByAttributeDescending = (data: any[], attribute: string) => {
-  return data.sort((a, b) => {
-    if (a[attribute] < b[attribute]) return 1
-    if (a[attribute] > b[attribute]) return -1
-    return 0
-  })
-}
 const sortChanged = (sortObj: Record<string, string>) => {
-  let sorted = ipInterfaces.value
   if (sortObj.value === 'asc') {
-    sorted = sortByattributeAscending(ipInterfaces.value, sortObj.property)
+    clonedInterfaces.value = sortBy(ipInterfaces.value, sortObj.property)
   }
   if (sortObj.value === 'desc') {
-    sorted = sortByAttributeDescending(ipInterfaces.value, sortObj.property)
+    clonedInterfaces.value = sortBy(ipInterfaces.value, sortObj.property).reverse()
   }
-  clonedInterfaces.value = sorted
+  if (sortObj.value === 'none') {
+    clonedInterfaces.value = sortBy(ipInterfaces.value, 'id')
+  }
 
   page.value = 1
-
-  pageObjects.value = getPageObjects(sorted, page.value, pageSize.value)
+  pageObjects.value = getPageObjects(clonedInterfaces.value, page.value, pageSize.value)
   for (const prop in sort) {
     sort[prop] = SORT.NONE
   }

--- a/ui/src/components/NodeStatus/IPInterfacesTable.vue
+++ b/ui/src/components/NodeStatus/IPInterfacesTable.vue
@@ -149,7 +149,7 @@ const pageObjects = ref([] as any[])
 const clonedInterfaces = ref([] as any[])
 const searchLabel = ref('Search IP Interfaces')
 const searchVal = ref('')
-const searchableAttributes = ['ipAddress', 'hostname'];
+const searchableAttributes = ['ipAddress', 'hostname']
 const emptyListContent = {
   msg: 'No results found.'
 }
@@ -248,7 +248,7 @@ const refresh = () => {
 
 function onSearchChange(searchTerm: any) {
   if (searchTerm.trim().length > 0) {
-      const searchObjects = filter(ipInterfaces.value, item => {
+    const searchObjects = filter(ipInterfaces.value, item => {
       // Check if the searchTerm is found in any of the attributes
       return some(pick(item, searchableAttributes), value => {
         if (typeof value === 'string' && value.toLowerCase().includes(searchTerm.toLowerCase())) {
@@ -258,8 +258,8 @@ function onSearchChange(searchTerm: any) {
         } else {
           return false
         }
-      });
-    });
+      })
+    })
 
     page.value = 1
     total.value = searchObjects.length

--- a/ui/src/components/NodeStatus/IPInterfacesTable.vue
+++ b/ui/src/components/NodeStatus/IPInterfacesTable.vue
@@ -113,6 +113,7 @@
 <script lang="ts" setup>
 import { useNodeStatusQueries } from '@/store/Queries/nodeStatusQueries'
 import { useNodeStatusStore } from '@/store/Views/nodeStatusStore'
+import { IpInterface } from '@/types/graphql'
 import DownloadFile from '@featherds/icon/action/DownloadFile'
 import Search from '@featherds/icon/action/Search'
 import Traffic from '@featherds/icon/action/Workflow'
@@ -258,9 +259,9 @@ const refresh = () => {
   nodeStatusQueries.fetchNodeStatus()
 }
 const searchPageObjects = (searchTerm: any) => {
-  return ipInterfaces.value.filter((item) => {
+  return ipInterfaces.value.filter((item: IpInterface) => {
     return searchableAttributes.some((attr) => {
-      const value = item[attr]
+      const value = item[attr as unknown as keyof IpInterface]
       return value.toLowerCase().includes(searchTerm.toLowerCase())
     })
   })

--- a/ui/src/components/NodeStatus/IPInterfacesTable.vue
+++ b/ui/src/components/NodeStatus/IPInterfacesTable.vue
@@ -119,7 +119,6 @@ import Traffic from '@featherds/icon/action/Workflow'
 import Refresh from '@featherds/icon/navigation/Refresh'
 import { FeatherPagination } from '@featherds/pagination'
 import { SORT } from '@featherds/table'
-import { sortBy, filter, some, pick } from 'lodash'
 const nodeStatusStore = useNodeStatusStore()
 const nodeStatusQueries = useNodeStatusQueries()
 const metricsModal = ref()
@@ -211,13 +210,27 @@ const getPageObjects = (array: Array<any>, pageNumber: number, pageSize: number)
   const endIndex = startIndex + pageSize
   return array.slice(startIndex, endIndex)
 }
+const sortByattributeAscending = (data: any[], attribute: string) => {
+  return data.sort((a, b) => {
+    if (a[attribute] < b[attribute]) return -1
+    if (a[attribute] > b[attribute]) return 1
+    return 0
+  })
+}
+const sortByAttributeDescending = (data: any[], attribute: string) => {
+  return data.sort((a, b) => {
+    if (a[attribute] < b[attribute]) return 1
+    if (a[attribute] > b[attribute]) return -1
+    return 0
+  })
+}
 const sortChanged = (sortObj: Record<string, string>) => {
   let sorted = ipInterfaces.value
   if (sortObj.value === 'asc') {
-    sorted = sortBy(ipInterfaces.value, sortObj.property)
+    sorted = sortByattributeAscending(ipInterfaces.value, sortObj.property)
   }
   if (sortObj.value === 'desc') {
-    sorted = sortBy(ipInterfaces.value, sortObj.property).reverse()
+    sorted = sortByAttributeDescending(ipInterfaces.value, sortObj.property)
   }
   clonedInterfaces.value = sorted
 
@@ -241,25 +254,20 @@ const updatePageSize = (v: number) => {
     pageObjects.value = getPageObjects(clonedInterfaces.value, page.value, v)
   }
 }
-
 const refresh = () => {
   nodeStatusQueries.fetchNodeStatus()
 }
-
-function onSearchChange(searchTerm: any) {
-  if (searchTerm.trim().length > 0) {
-    const searchObjects = filter(ipInterfaces.value, item => {
-      // Check if the searchTerm is found in any of the attributes
-      return some(pick(item, searchableAttributes), value => {
-        if (typeof value === 'string' && value.toLowerCase().includes(searchTerm.toLowerCase())) {
-          return true
-        } else if (`${value}`.toLowerCase().includes(searchTerm.toLowerCase())) {
-          return true
-        } else {
-          return false
-        }
-      })
+const searchPageObjects = (searchTerm: any) => {
+  return ipInterfaces.value.filter((item) => {
+    return searchableAttributes.some((attr) => {
+      const value = item[attr]
+      return value.toLowerCase().includes(searchTerm.toLowerCase())
     })
+  })
+}
+const onSearchChange = (searchTerm: any) => {
+  if (searchTerm.trim().length > 0) {
+    const searchObjects = searchPageObjects(searchTerm)
 
     page.value = 1
     total.value = searchObjects.length


### PR DESCRIPTION
## Description
Enable Search on the IP Interfaces component in the Node Status screen.

User can enter IP address or hostname to search by. Should be a case-insensitive search which includes partial matches. The search will be implemented client-side and not call the back end; it will use data already stored in nodeStatusStore.node.ipInterfaces.

One way to implement might be to create a search filter function, then apply it inside the ipInterfaces computed property.

While we are not using BFF for this, a link is included below for reference on what kinds of searches we should support.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2297

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
