### PR TITLE
LOK-2352: Events search

### DIFF
--- a/ui/src/components/NodeStatus/EventsTable.vue
+++ b/ui/src/components/NodeStatus/EventsTable.vue
@@ -83,7 +83,7 @@ import { useNodeStatusStore } from '@/store/Views/nodeStatusStore'
 import { format as fnsFormat } from 'date-fns'
 import { SORT } from '@featherds/table'
 import Search from '@featherds/icon/action/Search'
-import { sortBy } from 'lodash'
+import { isEmpty, sortBy } from 'lodash'
 
 const nodeStatusStore = useNodeStatusStore()
 
@@ -91,7 +91,7 @@ const searchEvents = ref('')
 
 const searchableAttributes = ['uei', 'ipAddress', 'producedTime']
 
-const eventSearchedData = ref([])
+const eventSearchedData = ref([] as any[])
 
 const paginatedEvents = ref([] as any[])
 
@@ -136,7 +136,7 @@ const hasEvents = computed(() => eventData.value.events.length > 0)
 
 const updateEvents = () => {
   if (hasEvents.value) {
-    eventSearchedData.value = [...eventData.value.events] as any
+    eventSearchedData.value = [...eventData.value.events] as any[]
     pageInfo.total = eventData.value.events.length || 0
     updatePaginatedEvents(eventSearchedData.value, pageInfo.page, pageInfo.pageSize)
   }
@@ -191,15 +191,22 @@ const sortChanged = (sortObj: Record<string, string>) => {
   sort[sortObj.property] = sortObj.value
 }
 
-function onSearchChanged(searchTerm: any) {
+const onSearchChanged = (searchTerm: any) => {
+  let searchObjects
 
-  const searchObjects = eventSearchedData.value.filter((item: any) => {
-    return searchableAttributes.some((attribute) => {
-      const value = String(item[attribute]).toLowerCase()
-      return value.includes(searchTerm.toLowerCase())
+  if (isEmpty(searchTerm)) {
+    searchObjects = [...eventSearchedData.value]
+  } else {
+    const searchItem = searchTerm.toLowerCase()
+    searchObjects = eventSearchedData.value.filter((item: any) => {
+      return searchableAttributes.some((attribute) => {
+        const value = String(item[attribute]).toLowerCase()
+        return value.includes(searchItem)
+      })
     })
-  })
+  }
 
+  eventData.value.events = [...searchObjects]
   pageInfo.page = 1
   pageInfo.total = searchObjects?.length
 

--- a/ui/src/components/NodeStatus/EventsTable.vue
+++ b/ui/src/components/NodeStatus/EventsTable.vue
@@ -10,6 +10,7 @@
             v-model.trim="searchEvents"
             type="search"
             data-test="search-input"
+            @update:model-value="onSearchChanged"
           >
             <template #pre>
               <FeatherIcon :icon="icons.Search" />
@@ -47,7 +48,7 @@
               </FeatherSortHeader>
           </tr>
         </thead>
-        <TransitionGroup name="data-table" tag="tbody" v-if="hasEvents">
+        <TransitionGroup name="data-table" tag="tbody" v-if="hasEvents && pageInfo.total">
           <tr v-for="event in paginatedEvents" :key="event.id as number" data-test="data-item">
             <td>{{ fnsFormat(event.producedTime, 'M/dd/yyyy HH:mm:ssxxx') }}</td>
             <td>{{ event.uei }}</td>
@@ -55,7 +56,7 @@
           </tr>
         </TransitionGroup>
       </table>
-      <div v-if="!hasEvents">
+      <div v-if="!hasEvents || pageInfo.total === 0">
         <EmptyList
           :content="emptyListContent"
           data-test="empty-list"
@@ -69,7 +70,7 @@
           @update:modelValue="onPageChanged"
           @update:pageSize="onPageSizeChanged"
           data-test="pagination"
-          v-if="hasEvents"
+          v-if="hasEvents && pageInfo.total"
         />
   </div>
   </TableCard>
@@ -87,6 +88,10 @@ import { sortBy } from 'lodash'
 const nodeStatusStore = useNodeStatusStore()
 
 const searchEvents = ref('')
+
+const searchableAttributes = ['uei', 'ipAddress', 'producedTime']
+
+const eventSearchedData = ref([])
 
 const paginatedEvents = ref([] as any[])
 
@@ -131,8 +136,9 @@ const hasEvents = computed(() => eventData.value.events.length > 0)
 
 const updateEvents = () => {
   if (hasEvents.value) {
+    eventSearchedData.value = [...eventData.value.events] as any
     pageInfo.total = eventData.value.events.length || 0
-    updatePaginatedEvents([...eventData.value.events], pageInfo.page, pageInfo.pageSize)
+    updatePaginatedEvents(eventSearchedData.value, pageInfo.page, pageInfo.pageSize)
   }
 }
 
@@ -184,6 +190,22 @@ const sortChanged = (sortObj: Record<string, string>) => {
   }
   sort[sortObj.property] = sortObj.value
 }
+
+function onSearchChanged(searchTerm: any) {
+
+  const searchObjects = eventSearchedData.value.filter((item: any) => {
+    return searchableAttributes.some((attribute) => {
+      const value = String(item[attribute]).toLowerCase()
+      return value.includes(searchTerm.toLowerCase())
+    })
+  })
+
+  pageInfo.page = 1
+  pageInfo.total = searchObjects?.length
+
+  updatePaginatedEvents(searchObjects, pageInfo.page, pageInfo.pageSize)
+}
+
 </script>
 
 <style lang="scss" scoped>

--- a/ui/src/components/NodeStatus/EventsTable.vue
+++ b/ui/src/components/NodeStatus/EventsTable.vue
@@ -83,7 +83,7 @@ import { useNodeStatusStore } from '@/store/Views/nodeStatusStore'
 import { format as fnsFormat } from 'date-fns'
 import { SORT } from '@featherds/table'
 import Search from '@featherds/icon/action/Search'
-import { isEmpty, sortBy } from 'lodash'
+import { sortBy } from 'lodash'
 
 const nodeStatusStore = useNodeStatusStore()
 
@@ -194,7 +194,7 @@ const sortChanged = (sortObj: Record<string, string>) => {
 const onSearchChanged = (searchTerm: any) => {
   let searchObjects
 
-  if (isEmpty(searchTerm)) {
+  if (searchTerm === '') {
     searchObjects = [...eventSearchedData.value]
   } else {
     const searchItem = searchTerm.toLowerCase()

--- a/ui/src/components/NodeStatus/EventsTable.vue
+++ b/ui/src/components/NodeStatus/EventsTable.vue
@@ -83,7 +83,7 @@ import { useNodeStatusStore } from '@/store/Views/nodeStatusStore'
 import { format as fnsFormat } from 'date-fns'
 import { SORT } from '@featherds/table'
 import Search from '@featherds/icon/action/Search'
-import { sortBy } from 'lodash'
+import { isEmpty, sortBy } from 'lodash'
 
 const nodeStatusStore = useNodeStatusStore()
 
@@ -194,7 +194,7 @@ const sortChanged = (sortObj: Record<string, string>) => {
 const onSearchChanged = (searchTerm: any) => {
   let searchObjects
 
-  if (searchTerm === '') {
+  if (isEmpty(searchTerm)) {
     searchObjects = [...eventSearchedData.value]
   } else {
     const searchItem = searchTerm.toLowerCase()


### PR DESCRIPTION
## Description
Enable Search on the Events component in the Node Status screen.

User can enter search term to search by. Should be a case-insensitive search which includes partial matches. The search will be implemented client-side and not call the back end; it will use data already stored in nodeStatusStore.node.events.

Can search by:

uei

ip_address

While we are not using BFF for this, a link is included below for reference on what kinds of searches we should support.

## Jira link(s)
https://opennms.atlassian.net/browse/LOK-2352

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
