### PR TITLE
Node Details: SNMP Interfaces search

### DIFF
--- a/ui/src/components/NodeStatus/SNMPInterfacesTable.vue
+++ b/ui/src/components/NodeStatus/SNMPInterfacesTable.vue
@@ -154,7 +154,7 @@ const pageObjects = ref([] as any[])
 const clonedInterfaces = ref([] as any[])
 const searchLabel = ref('Search SNMP Interfaces')
 const searchVal = ref('')
-const searchableAttributes = ['ifName', 'ifDescr', 'ifAlias', "physicalAddr"];
+const searchableAttributes = ['ifName', 'ifDescr', 'ifAlias', 'physicalAddr']
 const metricsModal = ref()
 const emptyListContent = {
   msg: 'No results found.'
@@ -240,7 +240,7 @@ const updatePageSize = (v: number) => {
 }
 function onSearchChange(searchTerm: any) {
   if (searchTerm.trim().length > 0) {
-      const searchObjects = filter(snmpInterfaces.value, item => {
+    const searchObjects = filter(snmpInterfaces.value, item => {
       // Check if the searchTerm is found in any of the attributes
       return some(pick(item, searchableAttributes), value => {
         if (typeof value === 'string' && value.toLowerCase().includes(searchTerm.toLowerCase())) {
@@ -250,8 +250,8 @@ function onSearchChange(searchTerm: any) {
         } else {
           return false
         }
-      });
-    });
+      })
+    })
 
     page.value = 1
     total.value = searchObjects.length

--- a/ui/src/components/NodeStatus/SNMPInterfacesTable.vue
+++ b/ui/src/components/NodeStatus/SNMPInterfacesTable.vue
@@ -134,14 +134,13 @@
 import { useFlowsStore } from '@/store/Views/flowsStore'
 import { useNodeStatusStore } from '@/store/Views/nodeStatusStore'
 import { DeepPartial } from '@/types'
-import { Exporter } from '@/types/graphql'
+import { Exporter, SnmpInterface } from '@/types/graphql'
 import DownloadFile from '@featherds/icon/action/DownloadFile'
 import Search from '@featherds/icon/action/Search'
 import Flows from '@featherds/icon/action/SendWorkflow'
 import Traffic from '@featherds/icon/action/Workflow'
 import Refresh from '@featherds/icon/navigation/Refresh'
 import { SORT } from '@featherds/table'
-import { filter, pick, some } from 'lodash'
 
 const router = useRouter()
 const flowsStore = useFlowsStore()
@@ -238,20 +237,17 @@ const updatePageSize = (v: number) => {
     pageObjects.value = getPageObjects(clonedInterfaces.value, page.value, v)
   }
 }
-function onSearchChange(searchTerm: any) {
-  if (searchTerm.trim().length > 0) {
-    const searchObjects = filter(snmpInterfaces.value, item => {
-      // Check if the searchTerm is found in any of the attributes
-      return some(pick(item, searchableAttributes), value => {
-        if (typeof value === 'string' && value.toLowerCase().includes(searchTerm.toLowerCase())) {
-          return true
-        } else if (`${value}`.toLowerCase().includes(searchTerm.toLowerCase())) {
-          return true
-        } else {
-          return false
-        }
-      })
+const searchPageObjects = (searchTerm: any) => {
+  return snmpInterfaces.value.filter((item: SnmpInterface) => {
+    return searchableAttributes.some((attr) => {
+      const value = item[attr as unknown as keyof SnmpInterface]
+      return value.toLowerCase().includes(searchTerm.toLowerCase())
     })
+  })
+}
+const onSearchChange = (searchTerm: any) => {
+  if (searchTerm.trim().length > 0) {
+    const searchObjects = searchPageObjects(searchTerm)
 
     page.value = 1
     total.value = searchObjects.length


### PR DESCRIPTION
## Description
Enable Search on the SNMP Interfaces component in the Node Status screen.

Should be a case-insensitive search which includes partial matches on any of:

ifName

ifDescr

ifAlias

physicalAddr

The search will be implemented client-side and not call the back end; it will use data already stored in nodeStatusStore.node.snmpInterfaces.

One way to implement might be to create a search filter function, then apply it inside a computed property.

While we are not using BFF for this, a link is included below for reference on what kinds of searches we should support.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2293

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
