### PR TITLE
LOK-2333: Suppress calling flows API until back end is implemented

### DIFF
--- a/ui/src/constants/index.ts
+++ b/ui/src/constants/index.ts
@@ -1,0 +1,3 @@
+// For now, setting this to false until flows are more fully implemented
+// Use this as a feature switch
+export const FLOWS_ENABLED = false

--- a/ui/src/store/Views/nodeStatusStore.ts
+++ b/ui/src/store/Views/nodeStatusStore.ts
@@ -1,8 +1,9 @@
 import { defineStore } from 'pinia'
+import { FLOWS_ENABLED } from '@/constants'
 import { useNodeStatusQueries } from '@/store/Queries/nodeStatusQueries'
-import { useNodeMutations } from '../Mutations/nodeMutations'
 import { AZURE_SCAN, DeepPartial } from '@/types'
 import { Exporter, NodeUpdateInput, RequestCriteriaInput } from '@/types/graphql'
+import { useNodeMutations } from '../Mutations/nodeMutations'
 
 export const useNodeStatusStore = defineStore('nodeStatusStore', () => {
   const nodeStatusQueries = useNodeStatusQueries()
@@ -10,6 +11,7 @@ export const useNodeStatusStore = defineStore('nodeStatusStore', () => {
   const fetchedData = computed(() => nodeStatusQueries.fetchedData)
   const exporters = ref<DeepPartial<Exporter>[]>([])
   const nodeId = ref()
+
   const setNodeId = (id: number) => {
     nodeStatusQueries.setNodeId(id)
     nodeId.value = id
@@ -30,8 +32,13 @@ export const useNodeStatusStore = defineStore('nodeStatusStore', () => {
         endTime
       }
     }
-    const data = await nodeStatusQueries.fetchExporters(payload)
-    exporters.value = data.value?.findExporters || []
+
+    if (FLOWS_ENABLED) {
+      const data = await nodeStatusQueries.fetchExporters(payload)
+      exporters.value = data.value?.findExporters || []
+    } else {
+      exporters.value = []
+    }
   }
 
   // add the exporter object to the matching node snmp interface (match on ifIndex)

--- a/ui/tests/store/Views/nodeStatusStore.test.ts
+++ b/ui/tests/store/Views/nodeStatusStore.test.ts
@@ -12,7 +12,8 @@ describe('Node Status Store', () => {
     vi.restoreAllMocks()
   })
 
-  it('Correctly calls the fetch exports query', async () => {
+  // Skipping this test until flows are fully enabled
+  it.skip('Correctly calls the fetch exports query', async () => {
     setActiveClient(useClient({ url: 'http://test/graphql' }))
 
     const store = useNodeStatusStore()


### PR DESCRIPTION
## Description

Flows is not yet fully implemented. The Node Status / Node Details pages were calling `findExporters` API, causing a snackbar error message to pop up all the time.

This disables that call for now.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2333
