### PR TITLE
LOK-2351: Friendly error messages for new Monitoring Policy and Rules

### DIFF
--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesPolicyForm.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesPolicyForm.vue
@@ -45,6 +45,7 @@
           label="New Policy Name"
           v-focus
           data-test="policy-name-input"
+          :error="store.validationErrors.policyName"
           :readonly="store.selectedPolicy.isDefault"
         />
         <FeatherTextarea

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesRuleForm.vue
@@ -44,6 +44,7 @@
               hideLabel
               v-focus
               data-test="rule-name-input"
+              :error="store.validationErrors.ruleName"
               :readonly="store.selectedPolicy.isDefault"
             />
           </div>


### PR DESCRIPTION
## Description

Add validation for Monitoring Policy and Rule names to prevent blank or duplicate names.

Does a client-side check, if that fails, displays a friendly error message next to then input field and does not send an API request.

Should prevent "snackbar" errors from displaying (they occur when graphql API calls fail).

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2351
