### PR TITLE
LOK-2355: Events table refresh

### DIFF
--- a/ui/src/components/NodeStatus/EventsTable.vue
+++ b/ui/src/components/NodeStatus/EventsTable.vue
@@ -26,6 +26,7 @@
             <FeatherButton
               primary
               icon="Refresh"
+              @click="nodeStatusQueries.fetchNodeStatus"
             >
               <FeatherIcon :icon="icons.Refresh"/>
             </FeatherButton>
@@ -80,10 +81,13 @@
 import DownloadFile from '@featherds/icon/action/DownloadFile'
 import Refresh from '@featherds/icon/navigation/Refresh'
 import { useNodeStatusStore } from '@/store/Views/nodeStatusStore'
+import { useNodeStatusQueries } from '@/store/Queries/nodeStatusQueries'
 import { format as fnsFormat } from 'date-fns'
 import { SORT } from '@featherds/table'
 import Search from '@featherds/icon/action/Search'
 import { sortBy } from 'lodash'
+
+const nodeStatusQueries = useNodeStatusQueries()
 
 const nodeStatusStore = useNodeStatusStore()
 


### PR DESCRIPTION
## Description
Implement the Refresh button on the Events table in the Node Status page. It should just make another call to the back end for data.
## Jira link(s)
https://opennms.atlassian.net/browse/LOK-2355

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
