### PR TITLE
LOK-1927: Update button labels on screens

### DIFF
--- a/ui/src/components/Locations/LocationsAddForm.vue
+++ b/ui/src/components/Locations/LocationsAddForm.vue
@@ -58,7 +58,7 @@
             type="submit"
             primary
             data-test="save-button"
-            >save location</ButtonWithSpinner
+            >Save Location</ButtonWithSpinner
           >
         </template>
       </FooterSection>

--- a/ui/src/components/Locations/LocationsAddForm.vue
+++ b/ui/src/components/Locations/LocationsAddForm.vue
@@ -58,7 +58,7 @@
             type="submit"
             primary
             data-test="save-button"
-            >save</ButtonWithSpinner
+            >save location</ButtonWithSpinner
           >
         </template>
       </FooterSection>

--- a/ui/src/components/Locations/LocationsEditForm.vue
+++ b/ui/src/components/Locations/LocationsEditForm.vue
@@ -76,7 +76,7 @@
             type="submit"
             primary
             data-test="save-button"
-            >save Location</ButtonWithSpinner
+            >Save Location</ButtonWithSpinner
           >
         </template>
       </FooterSection>

--- a/ui/src/components/Locations/LocationsEditForm.vue
+++ b/ui/src/components/Locations/LocationsEditForm.vue
@@ -76,7 +76,7 @@
             type="submit"
             primary
             data-test="save-button"
-            >save</ButtonWithSpinner
+            >save Location</ButtonWithSpinner
           >
         </template>
       </FooterSection>


### PR DESCRIPTION
## Description
For better tracking (and consistency with the rest of the UI), the “Save” labels on the locations screen should be updated:

Save Location (when user is saving a location)

Save Minion or Add Minion (when user is adding a Minion).

Right now, Pendo cannot distinguish these buttons, so we are unable to identify core events like saving a Minion or saving a location. 

## Jira link(s)
https://opennms.atlassian.net/browse/LOK-1927
## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
