### PR TITLE
FE: Node Status: Add initial unit tests

### DIFF
--- a/ui/src/containers/NodeStatus.vue
+++ b/ui/src/containers/NodeStatus.vue
@@ -8,7 +8,7 @@
     />
     <div class="header-wrapper">
       <div class="header">
-        <div class="pre-title">Node Status</div>
+        <div class="pre-title" data-test="title">Node Status</div>
         <div class="page-headline">
           {{ nodeStatusStore.node.nodeAlias || nodeStatusStore.node.nodeLabel }}
           <FeatherButton

--- a/ui/tests/NodeStatus/nodeStatus.test.ts
+++ b/ui/tests/NodeStatus/nodeStatus.test.ts
@@ -1,0 +1,37 @@
+import NodeStatus from '@/containers/NodeStatus.vue'
+import mountWithPiniaVillus from 'tests/mountWithPiniaVillus'
+import { createRouter, createWebHistory } from 'vue-router'
+import { RouterLinkStub } from '@vue/test-utils'
+
+let wrapper: any
+const mockRouter = createRouter({ history: createWebHistory(), routes: [ 
+{  path: '/:pathMatch(.*)*',
+  name: 'NotFoundPage',
+  component: NodeStatus,
+},         ] })
+mockRouter.currentRoute.value.params = { id: '1' }
+await mockRouter.isReady()
+describe('Inventory page', () => {
+  afterAll(() => {
+    wrapper.unmount()
+  })
+
+  it('should have the required components', () => {
+    wrapper = mountWithPiniaVillus({
+      component: NodeStatus,
+      global: {
+        plugins: [mockRouter],
+        stubs: {
+          RouterLink: RouterLinkStub
+        }
+      },
+      shallow: true
+    })
+
+    const pageHeader = wrapper.get('[data-test="title"]')
+    expect(pageHeader.exists()).toBe(true)
+
+    // const featherTabContainer = wrapper.getComponent('[data-test="tab-container"]')
+    // expect(featherTabContainer.exists()).toBe(true)
+  })
+})

--- a/ui/tests/NodeStatus/nodeStatus.test.ts
+++ b/ui/tests/NodeStatus/nodeStatus.test.ts
@@ -1,37 +1,26 @@
 import NodeStatus from '@/containers/NodeStatus.vue'
 import mountWithPiniaVillus from 'tests/mountWithPiniaVillus'
-import { createRouter, createWebHistory } from 'vue-router'
-import { RouterLinkStub } from '@vue/test-utils'
+import router from '@/router'
 
 let wrapper: any
-const mockRouter = createRouter({ history: createWebHistory(), routes: [ 
-{  path: '/:pathMatch(.*)*',
-  name: 'NotFoundPage',
-  component: NodeStatus,
-},         ] })
-mockRouter.currentRoute.value.params = { id: '1' }
-await mockRouter.isReady()
-describe('Inventory page', () => {
+
+describe('Node Status page', () => {
   afterAll(() => {
     wrapper.unmount()
   })
-
-  it('should have the required components', () => {
+  beforeAll(() => {
     wrapper = mountWithPiniaVillus({
       component: NodeStatus,
       global: {
-        plugins: [mockRouter],
-        stubs: {
-          RouterLink: RouterLinkStub
-        }
+        plugins: [router]
+
       },
       shallow: true
     })
-
+  })
+  it('should have the required components', () => {
     const pageHeader = wrapper.get('[data-test="title"]')
     expect(pageHeader.exists()).toBe(true)
 
-    // const featherTabContainer = wrapper.getComponent('[data-test="tab-container"]')
-    // expect(featherTabContainer.exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Description
Add some initial unit tests for the Node Status page.

Add tests/NodeStatus/nodeStatus.test.ts and use inventory.test.ts as an example.

Ensure the main title and System Information title are present.

We will add more tests in the future, this is just to add the first one.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2347

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
