### PR TITLE
LOK-2375: Don't add duplicate tags

### DIFF
--- a/ui/src/store/Components/tagStore.ts
+++ b/ui/src/store/Components/tagStore.ts
@@ -37,10 +37,17 @@ export const useTagStore = defineStore('tagStore', () => {
   }
 
   const addFilteredTag = (tag: Tag) => {
-    if (!filteredTags.value.find((t) => t.name === tag.name)) {
+    const snackbar = useSnackbar()
+    const isDuplicate = filteredTags.value.some(
+      (t) => t.name?.toLocaleLowerCase().trim() === tag.name?.toLocaleLowerCase().trim()
+    )
+    if (!isDuplicate) {
       filteredTags.value = [...filteredTags.value].concat([tag])
+    } else {
+      snackbar.showSnackbar({msg: 'Don\'t add duplicate tags !', error: true})
     }
   }
+
   const updateAllNodeTypes = async () => {
     const inventoryQueries = useInventoryQueries()
     inventoryQueries.buildNetworkInventory()

--- a/ui/src/store/Components/tagStore.ts
+++ b/ui/src/store/Components/tagStore.ts
@@ -44,7 +44,7 @@ export const useTagStore = defineStore('tagStore', () => {
     if (!isDuplicate) {
       filteredTags.value = [...filteredTags.value].concat([tag])
     } else {
-      snackbar.showSnackbar({msg: 'Don\'t add duplicate tags !', error: true})
+      snackbar.showSnackbar({msg: 'Cannot add duplicate tags.', error: true})
     }
   }
 


### PR DESCRIPTION
## Description
When managing tags on the Node Status page, you can add duplicate tags, which should not be allowed.

LOK-2345: Duplicate tag name for the same tenant Id exception - Muhammad Junaid
TO DO
 is to fix this on the back end, but we should also do a check in the front end to not allow user to add a duplicate tag, if we already have that tag in our tagStore.

## Jira link(s)
https://opennms.atlassian.net/browse/LOK-2375

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
