### PR TITLE
FE: Unit tests: nodeStatusStore setNodeId, updateNodeAlias

### DIFF
--- a/ui/tests/store/Views/nodeStatusStore.test.ts
+++ b/ui/tests/store/Views/nodeStatusStore.test.ts
@@ -2,10 +2,12 @@ import { useNodeStatusStore } from '@/store/Views/nodeStatusStore'
 import { setActiveClient, useClient } from 'villus'
 import { createTestingPinia } from '@pinia/testing'
 import { useNodeStatusQueries } from '@/store/Queries/nodeStatusQueries'
+import { useNodeMutations } from '@/store/Mutations/nodeMutations'
 
 describe('Node Status Store', () => {
   beforeEach(() => {
     createTestingPinia({ stubActions: false })
+    setActiveClient(useClient({ url: 'http://test/graphql' })) // Create and set a client
   })
 
   afterEach(() => {
@@ -44,4 +46,33 @@ describe('Node Status Store', () => {
       }
     })
   })
+
+
+
+  it('calls nodeStatusQueries.setNodeId with correct parameter and sets nodeId', async () => {
+    const store = useNodeStatusStore()
+    const queries = useNodeStatusQueries()
+    const mockNodeId = 123
+    vi.spyOn(queries, 'setNodeId')
+    await store.setNodeId(mockNodeId)
+    expect(queries.setNodeId).toHaveBeenCalledWith(mockNodeId)
+    expect(store.nodeId).toBe(mockNodeId)
+  })
+
+
+
+  it('calls mutations.updateNode with correct parameters', async () => {
+    const store = useNodeStatusStore()
+    const mutations = useNodeMutations()
+    const mockNodeAlias = 'New Node Alias'
+    vi.spyOn(mutations, 'updateNode')
+    await store.updateNodeAlias(mockNodeAlias)
+    expect(mutations.updateNode).toHaveBeenCalledWith({
+      node: {
+        nodeAlias: mockNodeAlias
+      }
+    })
+  })
+
+
 })

--- a/ui/tests/store/Views/nodeStatusStore.test.ts
+++ b/ui/tests/store/Views/nodeStatusStore.test.ts
@@ -60,7 +60,6 @@ describe('Node Status Store', () => {
   })
 
 
-
   it('calls mutations.updateNode with correct parameters', async () => {
     const store = useNodeStatusStore()
     const mutations = useNodeMutations()
@@ -73,6 +72,4 @@ describe('Node Status Store', () => {
       }
     })
   })
-
-
 })

--- a/ui/tests/store/Views/nodeStatusStore.test.ts
+++ b/ui/tests/store/Views/nodeStatusStore.test.ts
@@ -46,7 +46,7 @@ describe('Node Status Store', () => {
       }
     })
   })
-  
+
 
   it('calls nodeStatusQueries.setNodeId with correct parameter and sets nodeId', async () => {
     const store = useNodeStatusStore()

--- a/ui/tests/store/Views/nodeStatusStore.test.ts
+++ b/ui/tests/store/Views/nodeStatusStore.test.ts
@@ -46,8 +46,7 @@ describe('Node Status Store', () => {
       }
     })
   })
-
-
+  
 
   it('calls nodeStatusQueries.setNodeId with correct parameter and sets nodeId', async () => {
     const store = useNodeStatusStore()


### PR DESCRIPTION
## Description
FE unit tests for nodeStatusStore setNodeIdand updateNodeAlias


When setNodeId is called, make sure nodeStatusQueries.setNodeId is called with correct parameter and that nodeId value is set correctly

When updateNodeAlias is called, make sure mutations.updateNode is called with correct parameters

## Jira link(s)
https://opennms.atlassian.net/browse/LOK-2383

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
