### PR TITLE
FE: Unit tests - getAlertsByNode

### DIFF
--- a/ui/tests/store/Views/nodeStatusStore.test.ts
+++ b/ui/tests/store/Views/nodeStatusStore.test.ts
@@ -3,15 +3,29 @@ import { setActiveClient, useClient } from 'villus'
 import { createTestingPinia } from '@pinia/testing'
 import { useNodeStatusQueries } from '@/store/Queries/nodeStatusQueries'
 import { useNodeMutations } from '@/store/Mutations/nodeMutations'
+import { AlertsFilters, Pagination } from '@/types/alerts'
+import { TimeRange } from '@/types/graphql'
 
 describe('Node Status Store', () => {
+  let store: any
   beforeEach(() => {
     createTestingPinia({ stubActions: false })
     setActiveClient(useClient({ url: 'http://test/graphql' })) // Create and set a client
+
+    store = useNodeStatusStore()
+    store.fetchAlertsByNodeData.value = {
+      totalAlerts: 20, // Set some initial total alerts for testing pagination
+      alerts: [] // You can add some dummy data for testing if needed
+    }
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
+    store.alertsPagination.value = {
+      page: 0,
+      pageSize: 10,
+      total: 0
+    }
   })
 
   // Skipping this test until flows are fully enabled
@@ -70,5 +84,51 @@ describe('Node Status Store', () => {
         nodeAlias: mockNodeAlias
       }
     })
+  })
+
+
+  it('calls getAlertsByNodeQuery with correct parameters and updates fetchAlertsByNodeData and alertsPagination', async () => {
+    const queries = useNodeStatusQueries()
+    const sortFilter: AlertsFilters = {
+      timeRange: TimeRange.All,
+      nodeLabel: '',
+      severities: [],
+      sortAscending: true,
+      sortBy: 'id',
+      nodeId: 1
+    }
+
+    const paginationFilter: Pagination = {
+      page: 0, // FE pagination component has base 1 (first page)
+      pageSize: 10,
+      total: 0
+    }
+
+    store.alertsFilter = sortFilter
+    store.alertsPagination = paginationFilter
+    await store.getAlertsByNode()
+    vi.spyOn(queries, 'getAlertsByNodeQuery')
+    queries.getAlertsByNodeQuery(sortFilter, paginationFilter)
+    expect(queries.getAlertsByNodeQuery).toHaveBeenCalledWith(sortFilter, paginationFilter)
+    expect(store.fetchAlertsByNodeData.totalAlerts).toBe(0)
+    expect(store.alertsPagination.total).toBe(0)
+  })
+
+
+  it('calls getAlertsByNode when setAlertsByNodePage is called and updates alertsPagination', async () => {
+    const getAlertsByNodeMock = vi.spyOn(store, 'getAlertsByNode')
+    await store.setAlertsByNodePage(2)
+    await store.getAlertsByNode()
+    expect(store.alertsPagination.page).toBe(2)
+    expect(getAlertsByNodeMock).toHaveBeenCalled()
+  })
+
+
+  it('calls getAlertsByNode when setAlertsByNodePageSize is called and updates alertsPagination', async () => {
+    const getAlertsByNodeMock = vi.spyOn(store, 'getAlertsByNode')
+    await store.setAlertsByNodePageSize(20)
+    await store.getAlertsByNode()
+    expect(store.alertsPagination.pageSize).toBe(20)
+    expect(getAlertsByNodeMock).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Description
E unit tests for getAlertsByNode

When getAlertsByNode is called, make sure nodeStatusQueries.getAlertsByNodeQuery is called with correct parameters, and that fetchAlertsByNodeData and alertsPagination are set correctly.

When setPage is called, make sure alertsPagination is set to correct value and that getAlertsByNode is called.

When setPageSize is called, make sure alertsPagination is set to correct value and that getAlertsByNode is called.

Also, rename setPage -> setAlertsByNodePage, setPageSize -> setAlertsByNodePageSize (both here and in all code that calls this).

## Jira link(s)
https://opennms.atlassian.net/browse/LOK-2385

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
