### PR TITLE
LOK-2369: Rename service monitor properties to metrics

### DIFF
--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutionResultProcessorImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutionResultProcessorImpl.java
@@ -154,8 +154,9 @@ public class TaskExecutionResultProcessorImpl implements TaskExecutionResultProc
                 .setReason(Optional.of(smr)
                         .map(ServiceMonitorResponse::getReason)
                         .orElse(MonitorResponse.getDefaultInstance().getReason()))
-                .putAllMetrics(
-                        Optional.of(smr).map(ServiceMonitorResponse::getMetrics).orElse(Collections.EMPTY_MAP))
+                .putAllMetrics(Optional.of(smr)
+                        .map(ServiceMonitorResponse::getAdditionalMetrics)
+                        .orElse(Collections.EMPTY_MAP))
                 .setNodeId(smr.getNodeId())
                 .setMonitorServiceId(smr.getMonitoredServiceId())
                 .setTimestamp(smr.getTimestamp())

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutionResultProcessorImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutionResultProcessorImpl.java
@@ -154,9 +154,8 @@ public class TaskExecutionResultProcessorImpl implements TaskExecutionResultProc
                 .setReason(Optional.of(smr)
                         .map(ServiceMonitorResponse::getReason)
                         .orElse(MonitorResponse.getDefaultInstance().getReason()))
-                .putAllMetrics(Optional.of(smr)
-                        .map(ServiceMonitorResponse::getMetrics)
-                        .orElse(Collections.EMPTY_MAP))
+                .putAllMetrics(
+                        Optional.of(smr).map(ServiceMonitorResponse::getMetrics).orElse(Collections.EMPTY_MAP))
                 .setNodeId(smr.getNodeId())
                 .setMonitorServiceId(smr.getMonitoredServiceId())
                 .setTimestamp(smr.getTimestamp())

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutionResultProcessorImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutionResultProcessorImpl.java
@@ -155,7 +155,7 @@ public class TaskExecutionResultProcessorImpl implements TaskExecutionResultProc
                         .map(ServiceMonitorResponse::getReason)
                         .orElse(MonitorResponse.getDefaultInstance().getReason()))
                 .putAllMetrics(Optional.of(smr)
-                        .map(ServiceMonitorResponse::getProperties)
+                        .map(ServiceMonitorResponse::getMetrics)
                         .orElse(Collections.EMPTY_MAP))
                 .setNodeId(smr.getNodeId())
                 .setMonitorServiceId(smr.getMonitoredServiceId())

--- a/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponse.java
+++ b/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponse.java
@@ -60,7 +60,7 @@ public interface ServiceMonitorResponse {
      */
     double getResponseTime();
 
-    Map<String, Number> getProperties();
+    Map<String, Number> getMetrics();
 
     /**
      * TECHDEBT: Was originally added to the monitor interface to take advantage of poller's scheduling and

--- a/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponse.java
+++ b/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponse.java
@@ -60,7 +60,7 @@ public interface ServiceMonitorResponse {
      */
     double getResponseTime();
 
-    Map<String, Number> getMetrics();
+    Map<String, Number> getAdditionalMetrics();
 
     /**
      * TECHDEBT: Was originally added to the monitor interface to take advantage of poller's scheduling and

--- a/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponseImpl.java
+++ b/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponseImpl.java
@@ -34,7 +34,7 @@ public class ServiceMonitorResponseImpl implements ServiceMonitorResponse {
     private String ipAddress;
     private double responseTime;
     private DeviceConfig deviceConfig;
-    private Map<String, Number> properties;
+    private Map<String, Number> metrics;
     private MonitorType monitorType;
     private long nodeId;
     private long monitoredServiceId;

--- a/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponseImpl.java
+++ b/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponseImpl.java
@@ -34,7 +34,7 @@ public class ServiceMonitorResponseImpl implements ServiceMonitorResponse {
     private String ipAddress;
     private double responseTime;
     private DeviceConfig deviceConfig;
-    private Map<String, Number> metrics;
+    private Map<String, Number> additionalMetrics;
     private MonitorType monitorType;
     private long nodeId;
     private long monitoredServiceId;

--- a/minion/plugins/snmp-plugin/src/main/java/org/opennms/horizon/minion/snmp/SnmpMonitor.java
+++ b/minion/plugins/snmp-plugin/src/main/java/org/opennms/horizon/minion/snmp/SnmpMonitor.java
@@ -267,7 +267,7 @@ public class SnmpMonitor extends AbstractServiceMonitor {
             LOG.debug(reason);
         }
 
-        builder.properties(metrics);
+        builder.metrics(metrics);
         return builder.build();
     }
 

--- a/minion/plugins/snmp-plugin/src/main/java/org/opennms/horizon/minion/snmp/SnmpMonitor.java
+++ b/minion/plugins/snmp-plugin/src/main/java/org/opennms/horizon/minion/snmp/SnmpMonitor.java
@@ -267,7 +267,7 @@ public class SnmpMonitor extends AbstractServiceMonitor {
             LOG.debug(reason);
         }
 
-        builder.metrics(metrics);
+        builder.additionalMetrics(metrics);
         return builder.build();
     }
 


### PR DESCRIPTION
## Description
Service Monitor results contains a field named properties which is used to transport metrics gathered from the monitoring poll execution. Rename accordingly.
Starting point is ServiceMonitorResponseImpl. Rename the field properties to metrics. Find all usages of this field in the whole code-base and rename other usages, too. Be aware that this is named metrics in some places already. Check in modules minion, minion-gateway and metric-processor.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2369

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
