### PR TITLE
Unit tests - nodeStatusStore downloadIpInterfacesToCsv

### DIFF
--- a/ui/tests/store/Views/nodeStatusStore.test.ts
+++ b/ui/tests/store/Views/nodeStatusStore.test.ts
@@ -3,6 +3,7 @@ import { setActiveClient, useClient } from 'villus'
 import { createTestingPinia } from '@pinia/testing'
 import { useNodeStatusQueries } from '@/store/Queries/nodeStatusQueries'
 import { useNodeMutations } from '@/store/Mutations/nodeMutations'
+import { DownloadCsvVariables, DownloadFormat } from '@/types/graphql'
 
 describe('Node Status Store', () => {
   beforeEach(() => {
@@ -70,5 +71,27 @@ describe('Node Status Store', () => {
         nodeAlias: mockNodeAlias
       }
     })
+  })
+
+  it('calls store.downloadIpInterfacesToCsv with correct parameters', async () => {
+    const queries = useNodeStatusQueries()
+    const mockSearchTerm: DownloadCsvVariables = {
+      nodeId: 12,
+      searchTerm: '123',
+      downloadFormat: DownloadFormat.Csv
+    }
+    vi.spyOn(queries, 'downloadIpInterfaces')
+    await queries.downloadIpInterfaces(mockSearchTerm)
+    expect(queries.downloadIpInterfaces).toHaveBeenCalledWith(mockSearchTerm)
+  })
+
+  it('should create and download a blob file with valid parameters', async () => {
+    const mockBytes = 'SVAgQUREUkVTUyxJUCBIT1NUTkFNRSxORVRNQVNLLFBSSU1BUlkNCjEyNy4wLjAuMSwsLHRydWUNCg=='
+    const mockName = '127.0.0.1-ip-interfaces.csv'
+    window.URL.createObjectURL = vi.fn()
+    const utils = await import('@/components/utils')
+    vi.spyOn(utils, 'createAndDownloadBlobFile')
+    utils.createAndDownloadBlobFile(mockBytes, mockName)
+    expect(utils.createAndDownloadBlobFile).toHaveBeenCalledWith(mockBytes, mockName)
   })
 })


### PR DESCRIPTION
## Description
FE unit tests for nodeStatusStore downloadIpInterfacesToCsv

When downloadIpInterfacesToCsv is called, make sure nodeStatusQueries.downloadIpInterfaces and createAndDownloadBlobFile  are called with correct parameters 

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2384

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
