### PR TITLE
NMS-2412: Upgrade to JNA 5.14.0

### DIFF
--- a/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/BSDV4NativeSocket.java
+++ b/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/BSDV4NativeSocket.java
@@ -70,7 +70,7 @@ public class BSDV4NativeSocket extends NativeDatagramSocket {
     public void setTrafficClass(final int tc) throws IOException {
         final IntByReference tc_ptr = new IntByReference(tc);
         try {
-            setsockopt(getSock(), IPPROTO_IP, IP_TOS, tc_ptr.getPointer(), Pointer.SIZE);
+            setsockopt(getSock(), IPPROTO_IP, IP_TOS, tc_ptr.getPointer(), Native.POINTER_SIZE);
         } catch (final LastErrorException e) {
             throw new IOException("setsockopt: " + strerror(e.getErrorCode()));
         }

--- a/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/BSDV6NativeSocket.java
+++ b/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/BSDV6NativeSocket.java
@@ -70,7 +70,7 @@ public class BSDV6NativeSocket extends NativeDatagramSocket {
     public void setTrafficClass(final int tc) throws LastErrorException {
         final IntByReference tc_ptr = new IntByReference(tc);
         try {
-            setsockopt(getSock(), IPPROTO_IPV6, IPV6_TCLASS, tc_ptr.getPointer(), Pointer.SIZE);
+            setsockopt(getSock(), IPPROTO_IPV6, IPV6_TCLASS, tc_ptr.getPointer(), Native.POINTER_SIZE);
         } catch (final LastErrorException e) {
             throw new RuntimeException("setsockopt: " + strerror(e.getErrorCode()));
         }

--- a/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/NativeDatagramSocket.java
+++ b/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/NativeDatagramSocket.java
@@ -22,6 +22,7 @@
 package org.opennms.horizon.minion.jicmp.jna;
 
 import com.sun.jna.LastErrorException;
+import com.sun.jna.Native;
 import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
@@ -129,7 +130,7 @@ public abstract class NativeDatagramSocket implements AutoCloseable {
         }
         final IntByReference dontfragment = new IntByReference(frag == true ? 0 : 1);
         try {
-            setsockopt(socket, level, option_name, dontfragment.getPointer(), Pointer.SIZE);
+            setsockopt(socket, level, option_name, dontfragment.getPointer(), Native.POINTER_SIZE);
         } catch (final LastErrorException e) {
             throw new IOException("setsockopt: " + strerror(e.getErrorCode()));
         }

--- a/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/SunV4NativeSocket.java
+++ b/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/SunV4NativeSocket.java
@@ -72,7 +72,7 @@ public class SunV4NativeSocket extends NativeDatagramSocket {
     public void setTrafficClass(final int tc) throws IOException {
         final IntByReference tc_ptr = new IntByReference(tc);
         try {
-            setsockopt(getSock(), IPPROTO_IP, IP_TOS, tc_ptr.getPointer(), Pointer.SIZE);
+            setsockopt(getSock(), IPPROTO_IP, IP_TOS, tc_ptr.getPointer(), Native.POINTER_SIZE);
         } catch (final LastErrorException e) {
             throw new IOException("setsockopt: " + strerror(e.getErrorCode()));
         }

--- a/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/SunV6NativeSocket.java
+++ b/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/SunV6NativeSocket.java
@@ -70,7 +70,7 @@ public class SunV6NativeSocket extends NativeDatagramSocket {
     public void setTrafficClass(final int tc) throws LastErrorException {
         final IntByReference tc_ptr = new IntByReference(tc);
         try {
-            setsockopt(getSock(), IPPROTO_IPV6, IPV6_TCLASS, tc_ptr.getPointer(), Pointer.SIZE);
+            setsockopt(getSock(), IPPROTO_IPV6, IPV6_TCLASS, tc_ptr.getPointer(), Native.POINTER_SIZE);
         } catch (final LastErrorException e) {
             throw new RuntimeException("setsockopt: " + strerror(e.getErrorCode()));
         }

--- a/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/UnixV4NativeSocket.java
+++ b/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/UnixV4NativeSocket.java
@@ -72,7 +72,7 @@ public class UnixV4NativeSocket extends NativeDatagramSocket {
     public void setTrafficClass(final int tc) throws IOException {
         final IntByReference tc_ptr = new IntByReference(tc);
         try {
-            setsockopt(getSock(), IPPROTO_IP, IP_TOS, tc_ptr.getPointer(), Pointer.SIZE);
+            setsockopt(getSock(), IPPROTO_IP, IP_TOS, tc_ptr.getPointer(), Native.POINTER_SIZE);
         } catch (final LastErrorException e) {
             throw new IOException("setsockopt: " + strerror(e.getErrorCode()));
         }

--- a/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/UnixV6NativeSocket.java
+++ b/minion/icmp/icmp-jna/src/main/java/org/opennms/horizon/minion/jicmp/jna/UnixV6NativeSocket.java
@@ -70,7 +70,7 @@ public class UnixV6NativeSocket extends NativeDatagramSocket {
     public void setTrafficClass(final int tc) throws LastErrorException {
         final IntByReference tc_ptr = new IntByReference(tc);
         try {
-            setsockopt(getSock(), IPPROTO_IPV6, IPV6_TCLASS, tc_ptr.getPointer(), Pointer.SIZE);
+            setsockopt(getSock(), IPPROTO_IPV6, IPV6_TCLASS, tc_ptr.getPointer(), Native.POINTER_SIZE);
         } catch (final LastErrorException e) {
             throw new RuntimeException("setsockopt: " + strerror(e.getErrorCode()));
         }

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -86,7 +86,7 @@
         <jexl.version>2.1.1</jexl.version>
         <jicmp.version>3.0.0</jicmp.version>
         <jicmp6.version>2.0.1</jicmp6.version>
-        <jna.version>4.4.0</jna.version>
+        <jna.version>5.14.0</jna.version>
         <joda.time.version>2.1</joda.time.version>
         <junit.version>4.13.2</junit.version>
         <jsonPatch.version>1.13</jsonPatch.version>


### PR DESCRIPTION
## Description

Java Native Access (JNA) added support for Apple Silicon (M1 etc. chips) in 5.6. Latest version is 5.14.0. We are on 4.4.0.

This appears to mostly just affect ICMP on Minion. Running with JNA 4.4.0 on an M1 chip results in no ICMP being sent, but it's fixed with 5.6.0 or higher. This also gets us up to the latest version of JNA.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2412

