### PR TITLE
Unit tests: locationStore part 3

### DIFF
--- a/ui/tests/store/Views/locationStore.test.ts
+++ b/ui/tests/store/Views/locationStore.test.ts
@@ -110,4 +110,32 @@ describe('Locations Store', () => {
     locationStore.selectedLocationId = 2
     expect(locationStore.selectedLocation).toStrictEqual(mockLocationList[0])
   })
+
+  it('calls store.getMinionsForLocationId with correct parameters', async () => {
+    vi.spyOn(locationStore, 'getMinionsForLocationId')
+    const mockLocationId = 200
+    await locationStore.getMinionsForLocationId(mockLocationId)
+    expect(locationStore.getMinionsForLocationId).toHaveBeenCalledWith(mockLocationId)
+    expect(locationStore.displayType).toBe(DisplayType.LIST)
+    expect(locationStore.selectedLocationId).toBe(mockLocationId)
+  })
+
+  it('calls store.getMinionCertificate with correct parameters', async () => {
+    vi.spyOn(locationStore, 'getMinionCertificate')
+    await locationStore.getMinionCertificate()
+    expect(locationStore.getMinionCertificate).toHaveBeenCalledOnce()
+  })
+
+  it('calls store.revokeMinionCertificate with correct parameters', async () => {
+    vi.spyOn(locationStore, 'revokeMinionCertificate')
+    await locationStore.revokeMinionCertificate()
+    expect(locationStore.revokeMinionCertificate).toHaveBeenCalledOnce()
+  })
+
+  it('calls store.setCertificatePassword with correct parameters', async () => {
+    vi.spyOn(locationStore, 'setCertificatePassword')
+    const mockPassword = 'test'
+    await locationStore.setCertificatePassword(mockPassword)
+    expect(locationStore.certificatePassword).toBe(mockPassword)
+  })
 })


### PR DESCRIPTION
## Description
Add tests to tests/store/Views/locationStore.test.ts:

getMinionsForLocationId
getMinionCertificate
revokeMinionCertificaste
setCertificatePassword

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2398

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
