### PR TITLE
LOK-2378: Monitoring Policies - add table

### DIFF
--- a/ui/src/assets/circle.svg
+++ b/ui/src/assets/circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="gray" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-circle"><circle cx="12" cy="12" r="10"></circle></svg>

--- a/ui/src/components/MonitoringPolicies/MonitoringPoliciesTable.vue
+++ b/ui/src/components/MonitoringPolicies/MonitoringPoliciesTable.vue
@@ -128,16 +128,6 @@ const sort = reactive({
   affectedNodes: SORT.ASCENDING
 }) as any
 
-const policiesLength = computed(() => store.monitoringPolicies.length)
-
-watch(() => policiesLength.value, () => {
-  for (let i = 0; i < policiesLength.value; i++) {
-
-    if (!('enabled' in store.monitoringPolicies[i])) {
-      store.monitoringPolicies[i].enabled = true
-    }
-  }
-})
 const sortChanged = (sortObj: Record<string, string>) => {
   // store.setTopNNodesTableSort(sortObj)
 
@@ -150,9 +140,6 @@ const sortChanged = (sortObj: Record<string, string>) => {
 
 const onSelectPolicy = (id: string) => {
   console.log(`onSelectPolicy, id: ${id}`)
-
-  const index = store.monitoringPolicies.findIndex((item: Policy) => item.id === Number(id))
-  store.monitoringPolicies[index].enabled = !store.monitoringPolicies[index].enabled
 
   const selectedPolicy = store.monitoringPolicies.find((item: Policy) => item.id === Number(id))
 
@@ -170,11 +157,6 @@ const onRefresh = () => {
   console.log('refresh clicked')
   store.getMonitoringPolicies()
 }
-
-// onMounted(async () => await store.getTopNNodes())
-onMounted(() => {
-  console.log('In MonitoringPoliciesTable v1')
-})
 
 </script>
 

--- a/ui/src/containers/MonitoringPolicies.vue
+++ b/ui/src/containers/MonitoringPolicies.vue
@@ -54,7 +54,7 @@ onMounted(() => store.getMonitoringPolicies())
 }
 
 .content {
-  width: vars.$max-width-constrained;
+  width: 88%;
   margin-right: var(variables.$spacing-l);
   margin-left: var(variables.$spacing-l);
 }

--- a/ui/src/store/Views/monitoringPoliciesStore.ts
+++ b/ui/src/store/Views/monitoringPoliciesStore.ts
@@ -94,6 +94,16 @@ export const useMonitoringPoliciesStore = defineStore('monitoringPoliciesStore',
       const queries = useMonitoringPoliciesQueries()
       await queries.listMonitoringPolicies()
       this.monitoringPolicies = queries.monitoringPolicies
+
+      // we are setting this to true until the back end supports enable/disable.
+      //  Then this component can just display the status.
+      //  Once back end adds ability to enable/disable, then we will add another issue to implement it here and elsewhere.
+
+      for (let i = 0; i < this.monitoringPolicies.length; i++) {
+        if (!('enabled' in  this.monitoringPolicies[i])) {
+          this.monitoringPolicies[i].enabled = true
+        }
+      }
     },
     displayPolicyForm(policy?: Policy) {
       this.selectedPolicy = policy ? cloneDeep(policy) : cloneDeep(defaultPolicy)

--- a/ui/src/types/graphql.ts
+++ b/ui/src/types/graphql.ts
@@ -311,6 +311,7 @@ export type MonitorPolicy = {
   notifyInstruction?: Maybe<Scalars['String']>;
   rules?: Maybe<Array<Maybe<PolicyRule>>>;
   tags?: Maybe<Array<Maybe<Scalars['String']>>>;
+  enabled?: Maybe<Scalars['Boolean']>;
 }
 
 export type MonitorPolicyInput = {

--- a/ui/tests/store/Views/nodeStatusStore.test.ts
+++ b/ui/tests/store/Views/nodeStatusStore.test.ts
@@ -11,12 +11,12 @@ describe('Node Status Store', () => {
   let store: any
   beforeEach(() => {
     createTestingPinia({ stubActions: false })
-    setActiveClient(useClient({ url: 'http://test/graphql' })) 
+    setActiveClient(useClient({ url: 'http://test/graphql' }))
 
     store = useNodeStatusStore()
     store.fetchAlertsByNodeData.value = {
-      totalAlerts: 20, 
-      alerts: [] 
+      totalAlerts: 20,
+      alerts: []
     }
   })
 


### PR DESCRIPTION
## Description
Monitoring Policies - add table
Implement Monitoring Policies table on new page. Link: monitoring-policies-new.

get actual data

highlight row with mouse over

active vs inactive icon

Can have separate tickets for pagination and sorting.

There isn’t actually an active/inactive status yet, so just use the active icon (see CheckCircle in Feather, success color).

## Jira link(s)
https://opennms.atlassian.net/browse/LOK-2378

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Lōkahi's [development guidelines.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS-Cloud/lokahi/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts.
* [ ] Notify documentation team of any changes to names of screens or features (affects URLs).
