### PR TITLE
Implement Thread Model for Monitor Execution 

### DIFF
--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalMonitorServiceImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalMonitorServiceImpl.java
@@ -23,7 +23,6 @@ package org.opennms.horizon.minion.taskset.worker.impl;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -139,16 +138,8 @@ public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalSer
             if (monitor != null) {
                 // TBD888: populate host, or stop?
                 MonitoredService monitoredService = configureMonitoredService(taskDefinition);
-                CompletableFuture<ServiceMonitorResponse> future = CompletableFuture.supplyAsync(
-                        () -> {
-                            try {
-                                return monitor.poll(monitoredService, taskDefinition.getConfiguration())
-                                        .get();
-                            } catch (InterruptedException | ExecutionException e) {
-                                throw new RuntimeException(e);
-                            }
-                        },
-                        executor);
+                CompletableFuture<ServiceMonitorResponse> future =
+                        monitor.poll(monitoredService, taskDefinition.getConfiguration());
                 future.whenCompleteAsync(this::handleExecutionComplete, executor);
 
             } else {

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalMonitorServiceImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalMonitorServiceImpl.java
@@ -22,8 +22,12 @@
 package org.opennms.horizon.minion.taskset.worker.impl;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.opennms.horizon.minion.plugin.api.MonitoredService;
 import org.opennms.horizon.minion.plugin.api.ServiceMonitor;
 import org.opennms.horizon.minion.plugin.api.ServiceMonitorManager;
@@ -43,7 +47,7 @@ import org.slf4j.LoggerFactory;
  *  problems due to serialization/deserialization.
  */
 public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalService {
-
+    private ExecutorService executor;
     private static final Logger DEFAULT_LOGGER = LoggerFactory.getLogger(TaskExecutorLocalMonitorServiceImpl.class);
 
     private Logger log = DEFAULT_LOGGER;
@@ -66,6 +70,9 @@ public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalSer
         this.scheduler = scheduler;
         this.resultProcessor = resultProcessor;
         this.monitorRegistry = monitorRegistry;
+        this.executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+            .setNameFormat("monitor-service-response-handler")
+            .build());
     }
 
     // ========================================
@@ -132,9 +139,10 @@ public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalSer
             if (monitor != null) {
                 // TBD888: populate host, or stop?
                 MonitoredService monitoredService = configureMonitoredService(taskDefinition);
-                CompletableFuture<ServiceMonitorResponse> future =
-                        monitor.poll(monitoredService, taskDefinition.getConfiguration());
-                future.whenComplete(this::handleExecutionComplete);
+               CompletableFuture.runAsync(() -> {
+                    monitor.poll(monitoredService, taskDefinition.getConfiguration())
+                        .whenCompleteAsync(this::handleExecutionComplete, executor);
+                }, executor);
             } else {
                 log.info("Skipping service monitor execution; monitor not found: monitor="
                         + taskDefinition.getPluginName());

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalMonitorServiceImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalMonitorServiceImpl.java
@@ -21,13 +21,12 @@
  */
 package org.opennms.horizon.minion.taskset.worker.impl;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.opennms.horizon.minion.plugin.api.MonitoredService;
 import org.opennms.horizon.minion.plugin.api.ServiceMonitor;
 import org.opennms.horizon.minion.plugin.api.ServiceMonitorManager;
@@ -71,8 +70,8 @@ public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalSer
         this.resultProcessor = resultProcessor;
         this.monitorRegistry = monitorRegistry;
         this.executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
-            .setNameFormat("monitor-service-response-handler")
-            .build());
+                .setNameFormat("monitor-service-response-handler")
+                .build());
     }
 
     // ========================================
@@ -139,10 +138,12 @@ public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalSer
             if (monitor != null) {
                 // TBD888: populate host, or stop?
                 MonitoredService monitoredService = configureMonitoredService(taskDefinition);
-               CompletableFuture.runAsync(() -> {
-                    monitor.poll(monitoredService, taskDefinition.getConfiguration())
-                        .whenCompleteAsync(this::handleExecutionComplete, executor);
-                }, executor);
+                CompletableFuture.runAsync(
+                        () -> {
+                            monitor.poll(monitoredService, taskDefinition.getConfiguration())
+                                    .whenCompleteAsync(this::handleExecutionComplete, executor);
+                        },
+                        executor);
             } else {
                 log.info("Skipping service monitor execution; monitor not found: monitor="
                         + taskDefinition.getPluginName());

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalMonitorServiceImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalMonitorServiceImpl.java
@@ -22,6 +22,7 @@
 package org.opennms.horizon.minion.taskset.worker.impl;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.opennms.horizon.minion.plugin.api.MonitoredService;
@@ -53,18 +54,20 @@ public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalSer
     private TaskExecutionResultProcessor resultProcessor;
     private MonitorRegistry monitorRegistry;
     private ServiceMonitor monitor = null;
-
+    private ExecutorService executor;
     private AtomicBoolean active = new AtomicBoolean(false);
 
     public TaskExecutorLocalMonitorServiceImpl(
             OpennmsScheduler scheduler,
             TaskDefinition taskDefinition,
             TaskExecutionResultProcessor resultProcessor,
-            MonitorRegistry monitorRegistry) {
+            MonitorRegistry monitorRegistry,
+            ExecutorService executor) {
         this.taskDefinition = taskDefinition;
         this.scheduler = scheduler;
         this.resultProcessor = resultProcessor;
         this.monitorRegistry = monitorRegistry;
+        this.executor = executor;
     }
 
     // ========================================
@@ -133,7 +136,7 @@ public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalSer
                 MonitoredService monitoredService = configureMonitoredService(taskDefinition);
                 CompletableFuture<ServiceMonitorResponse> future =
                         monitor.poll(monitoredService, taskDefinition.getConfiguration());
-                future.whenCompleteAsync(this::handleExecutionComplete);
+                future.whenCompleteAsync(this::handleExecutionComplete, executor);
 
             } else {
                 log.info("Skipping service monitor execution; monitor not found: monitor="

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalMonitorServiceImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalMonitorServiceImpl.java
@@ -21,10 +21,7 @@
  */
 package org.opennms.horizon.minion.taskset.worker.impl;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.opennms.horizon.minion.plugin.api.MonitoredService;
@@ -46,7 +43,6 @@ import org.slf4j.LoggerFactory;
  *  problems due to serialization/deserialization.
  */
 public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalService {
-    private ExecutorService executor;
     private static final Logger DEFAULT_LOGGER = LoggerFactory.getLogger(TaskExecutorLocalMonitorServiceImpl.class);
 
     private Logger log = DEFAULT_LOGGER;
@@ -69,9 +65,6 @@ public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalSer
         this.scheduler = scheduler;
         this.resultProcessor = resultProcessor;
         this.monitorRegistry = monitorRegistry;
-        this.executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
-                .setNameFormat("monitor-service-response-handler")
-                .build());
     }
 
     // ========================================
@@ -140,7 +133,7 @@ public class TaskExecutorLocalMonitorServiceImpl implements TaskExecutorLocalSer
                 MonitoredService monitoredService = configureMonitoredService(taskDefinition);
                 CompletableFuture<ServiceMonitorResponse> future =
                         monitor.poll(monitoredService, taskDefinition.getConfiguration());
-                future.whenCompleteAsync(this::handleExecutionComplete, executor);
+                future.whenCompleteAsync(this::handleExecutionComplete);
 
             } else {
                 log.info("Skipping service monitor execution; monitor not found: monitor="

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalServiceFactoryImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalServiceFactoryImpl.java
@@ -22,8 +22,6 @@
 package org.opennms.horizon.minion.taskset.worker.impl;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.opennms.horizon.minion.plugin.api.registries.CollectorRegistry;
@@ -93,7 +91,7 @@ public class TaskExecutorLocalServiceFactoryImpl implements TaskExecutorLocalSer
 
             case MONITOR:
                 return new TaskExecutorLocalMonitorServiceImpl(
-                scheduler, taskDefinition, resultProcessor, monitorRegistry,executor);
+                        scheduler, taskDefinition, resultProcessor, monitorRegistry, executor);
 
             case LISTENER:
                 TaskListenerRetryable listenerService =
@@ -112,7 +110,6 @@ public class TaskExecutorLocalServiceFactoryImpl implements TaskExecutorLocalSer
                 throw new RuntimeException("unrecognized taskDefinition type " + taskDefinition.getType());
         }
     }
-
 
     public void close() {
         executor.shutdown();

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalServiceFactoryImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalServiceFactoryImpl.java
@@ -92,7 +92,8 @@ public class TaskExecutorLocalServiceFactoryImpl implements TaskExecutorLocalSer
                 return new TaskExecutorLocalScannerServiceImpl(taskDefinition, scannerRegistry, resultProcessor);
 
             case MONITOR:
-                return createAndGetMonitorServiceInThreadPool(taskDefinition);
+                return new TaskExecutorLocalMonitorServiceImpl(
+                scheduler, taskDefinition, resultProcessor, monitorRegistry,executor);
 
             case LISTENER:
                 TaskListenerRetryable listenerService =
@@ -112,33 +113,6 @@ public class TaskExecutorLocalServiceFactoryImpl implements TaskExecutorLocalSer
         }
     }
 
-    private TaskExecutorLocalService createAndGetMonitorServiceInThreadPool(TaskDefinition taskDefinition) {
-        // Create CompletableFuture for asynchronous task creation
-        TaskExecutorLocalService taskExecutorLocalService = null;
-        CompletableFuture<TaskExecutorLocalService> future = CompletableFuture.supplyAsync(
-                () -> {
-                    try {
-                        // Create the service instance
-                        return new TaskExecutorLocalMonitorServiceImpl(
-                                scheduler, taskDefinition, resultProcessor, monitorRegistry);
-                    } catch (Exception e) {
-                        throw new RuntimeException(
-                                "Failed to get the TaskExecutorLocalMonitorService instance of  taskDefinition type "
-                                        + taskDefinition.getType());
-                    }
-                },
-                executor);
-
-        try {
-            // Wait for the future to complete and return the result
-            taskExecutorLocalService = future.get();
-        } catch (InterruptedException | ExecutionException e) {
-            throw new RuntimeException(
-                    "Failed to get the TaskExecutorLocalMonitorService instance of  taskDefinition type "
-                            + taskDefinition.getType());
-        }
-        return taskExecutorLocalService;
-    }
 
     public void close() {
         executor.shutdown();

--- a/minion/minion-taskset/taskset-worker/src/main/resources/OSGI-INF/blueprint/horizon-ignite.xml
+++ b/minion/minion-taskset/taskset-worker/src/main/resources/OSGI-INF/blueprint/horizon-ignite.xml
@@ -63,7 +63,7 @@
   <reference id="collectorRegistry" interface="org.opennms.horizon.minion.plugin.api.registries.CollectorRegistry" />
   <reference id="scannerRegistry" interface="org.opennms.horizon.minion.plugin.api.registries.ScannerRegistry" />
 
-  <bean id="workflowExecutorLocalServiceFactory" class="org.opennms.horizon.minion.taskset.worker.impl.TaskExecutorLocalServiceFactoryImpl">
+  <bean id="workflowExecutorLocalServiceFactory" class="org.opennms.horizon.minion.taskset.worker.impl.TaskExecutorLocalServiceFactoryImpl" destroy-method="close">
     <argument ref="opennmsScheduler"/>
     <argument ref="workflowExecutionResultProcessor"/>
     <argument ref="listenerFactoryRegistry"/>

--- a/minion/plugins/icmp-plugin/src/test/java/org/opennms/horizon/minion/icmp/IcmpMonitorTest.java
+++ b/minion/plugins/icmp-plugin/src/test/java/org/opennms/horizon/minion/icmp/IcmpMonitorTest.java
@@ -89,7 +89,6 @@ public class IcmpMonitorTest {
         assertTrue(serviceMonitorResponse.getResponseTime() > 0.0);
     }
 
-
     @Test
     public void testTimeout() throws Exception {
         icmpMonitor = getIcmpMonitor(false, true);
@@ -103,7 +102,6 @@ public class IcmpMonitorTest {
         assertEquals(0.0d, serviceMonitorResponse.getResponseTime(), 0);
     }
 
-
     @Test
     public void testError() throws Exception {
         icmpMonitor = getIcmpMonitor(true, false);
@@ -116,5 +114,4 @@ public class IcmpMonitorTest {
         assertEquals("Failed to ping", serviceMonitorResponse.getReason());
         assertEquals(0.0d, serviceMonitorResponse.getResponseTime(), 0);
     }
-
 }

--- a/minion/plugins/icmp-plugin/src/test/java/org/opennms/horizon/minion/icmp/IcmpMonitorTest.java
+++ b/minion/plugins/icmp-plugin/src/test/java/org/opennms/horizon/minion/icmp/IcmpMonitorTest.java
@@ -89,17 +89,6 @@ public class IcmpMonitorTest {
         assertTrue(serviceMonitorResponse.getResponseTime() > 0.0);
     }
 
-    @Test
-    public void testPollThroughThreadPoll() {
-        icmpMonitor = getIcmpMonitor(false, false);
-        CompletableFuture<ServiceMonitorResponse> future = icmpMonitor.poll(monitoredService, testConfig);
-        future.whenCompleteAsync(
-                (response, throwable) -> {
-                    assertEquals(Status.Up, response.getStatus());
-                    assertTrue(response.getResponseTime() > 0.0);
-                },
-                executor);
-    }
 
     @Test
     public void testTimeout() throws Exception {
@@ -114,20 +103,6 @@ public class IcmpMonitorTest {
         assertEquals(0.0d, serviceMonitorResponse.getResponseTime(), 0);
     }
 
-    @Test
-    public void testTimeOutThroughThreadPoll() {
-        icmpMonitor = getIcmpMonitor(false, true);
-
-        CompletableFuture<ServiceMonitorResponse> future = icmpMonitor.poll(monitoredService, testConfig);
-        future.whenCompleteAsync(
-                (response, throwable) -> {
-                    assertNotNull(response); // Ensure the response is not null
-                    assertEquals(Status.Unknown, response.getStatus());
-                    assertEquals("timeout", response.getReason());
-                    assertEquals(0.0d, response.getResponseTime(), 0);
-                },
-                executor);
-    }
 
     @Test
     public void testError() throws Exception {
@@ -142,17 +117,4 @@ public class IcmpMonitorTest {
         assertEquals(0.0d, serviceMonitorResponse.getResponseTime(), 0);
     }
 
-    @Test
-    public void testErrorThroughThreadPoll() {
-        icmpMonitor = getIcmpMonitor(true, false);
-        CompletableFuture<ServiceMonitorResponse> future = icmpMonitor.poll(monitoredService, testConfig);
-        future.whenCompleteAsync(
-                (response, throwable) -> {
-                    assertNotNull(response); // Ensure the response is not null
-                    assertEquals(Status.Down, response.getStatus());
-                    assertEquals("Failed to ping", response.getReason());
-                    assertEquals(0.0d, response.getResponseTime(), 0);
-                },
-                executor);
-    }
 }

--- a/minion/plugins/icmp-plugin/src/test/java/org/opennms/horizon/minion/icmp/IcmpMonitorTest.java
+++ b/minion/plugins/icmp-plugin/src/test/java/org/opennms/horizon/minion/icmp/IcmpMonitorTest.java
@@ -26,11 +26,8 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.Any;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -51,10 +48,6 @@ public class IcmpMonitorTest {
     IcmpMonitorRequest testEchoRequest;
     Any testConfig;
     IcmpMonitor icmpMonitor;
-    private ExecutorService executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
-            .setNameFormat("monitor-service-response-handler")
-            .build());
-    ;
 
     @Before
     public void setUp() throws Exception {

--- a/minion/plugins/icmp-plugin/src/test/java/org/opennms/horizon/minion/icmp/IcmpMonitorTest.java
+++ b/minion/plugins/icmp-plugin/src/test/java/org/opennms/horizon/minion/icmp/IcmpMonitorTest.java
@@ -92,16 +92,11 @@ public class IcmpMonitorTest {
     @Test
     public void testPollThroughThreadPoll() {
         icmpMonitor = getIcmpMonitor(false, false);
-        CompletableFuture.runAsync(
-                () -> {
-                    icmpMonitor
-                            .poll(monitoredService, testConfig)
-                            .whenCompleteAsync(
-                                    (response, throwable) -> {
-                                        assertEquals(Status.Up, response.getStatus());
-                                        assertTrue(response.getResponseTime() > 0.0);
-                                    },
-                                    executor);
+        CompletableFuture<ServiceMonitorResponse> future = icmpMonitor.poll(monitoredService, testConfig);
+        future.whenCompleteAsync(
+                (response, throwable) -> {
+                    assertEquals(Status.Up, response.getStatus());
+                    assertTrue(response.getResponseTime() > 0.0);
                 },
                 executor);
     }
@@ -122,18 +117,14 @@ public class IcmpMonitorTest {
     @Test
     public void testTimeOutThroughThreadPoll() {
         icmpMonitor = getIcmpMonitor(false, true);
-        CompletableFuture.runAsync(
-                () -> {
-                    icmpMonitor
-                            .poll(monitoredService, testConfig)
-                            .whenCompleteAsync(
-                                    (response, throwable) -> {
-                                        assertNotNull(response); // Ensure the response is not null
-                                        assertEquals(Status.Unknown, response.getStatus());
-                                        assertEquals("timeout", response.getReason());
-                                        assertEquals(0.0d, response.getResponseTime(), 0);
-                                    },
-                                    executor);
+
+        CompletableFuture<ServiceMonitorResponse> future = icmpMonitor.poll(monitoredService, testConfig);
+        future.whenCompleteAsync(
+                (response, throwable) -> {
+                    assertNotNull(response); // Ensure the response is not null
+                    assertEquals(Status.Unknown, response.getStatus());
+                    assertEquals("timeout", response.getReason());
+                    assertEquals(0.0d, response.getResponseTime(), 0);
                 },
                 executor);
     }
@@ -154,18 +145,13 @@ public class IcmpMonitorTest {
     @Test
     public void testErrorThroughThreadPoll() {
         icmpMonitor = getIcmpMonitor(true, false);
-        CompletableFuture.runAsync(
-                () -> {
-                    icmpMonitor
-                            .poll(monitoredService, testConfig)
-                            .whenCompleteAsync(
-                                    (response, throwable) -> {
-                                        assertNotNull(response); // Ensure the response is not null
-                                        assertEquals(Status.Down, response.getStatus());
-                                        assertEquals("Failed to ping", response.getReason());
-                                        assertEquals(0.0d, response.getResponseTime(), 0);
-                                    },
-                                    executor);
+        CompletableFuture<ServiceMonitorResponse> future = icmpMonitor.poll(monitoredService, testConfig);
+        future.whenCompleteAsync(
+                (response, throwable) -> {
+                    assertNotNull(response); // Ensure the response is not null
+                    assertEquals(Status.Down, response.getStatus());
+                    assertEquals("Failed to ping", response.getReason());
+                    assertEquals(0.0d, response.getResponseTime(), 0);
                 },
                 executor);
     }


### PR DESCRIPTION
## Description
Current monitor execution is undefined and current implementation is unclear. Current API uses futures to delegate problem to implementation.

Implement a thread pool to be shared by all monitors and use this threadpool to execute the monitoring. Therefore alter the monitor interface to not return a future.

Implement a separate thread pool used to process and hand-off monitor results from minion to gateway.

## Jira link(s)
- https://opennms.atlassian.net/browse/LOK-2360